### PR TITLE
Add server-side bank snapshot analysis tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ An MCP (Model Context Protocol) server that provides access to the [FDIC BankFin
 ## Features
 
 - **No API key required** — The FDIC BankFind API is publicly available
-- **10 tools** covering all BankFind dataset endpoints
+- **11 tools** covering BankFind datasets plus a built-in comparative analysis tool
 - **Flexible ElasticSearch-style filtering** on all endpoints
 - **Pagination support** for large result sets
 - **Dual transport**: stdio (local) or HTTP (remote)
 - **Structured tool output** via `structuredContent` for MCP clients
+- **Built-in analytical batching** for multi-bank comparisons
+- **Short-lived response caching** for repeated analytical prompts
 
 ## Available Tools
 
@@ -25,10 +27,16 @@ An MCP (Model Context Protocol) server that provides access to the [FDIC BankFin
 | `fdic_search_summary` | Search annual financial summary data |
 | `fdic_search_sod` | Search Summary of Deposits (branch-level deposit data) |
 | `fdic_search_demographics` | Search quarterly demographics and market-structure data |
+| `fdic_compare_bank_snapshots` | Compare two reporting snapshots across banks and rank growth/profitability changes |
 
 Two tools are convenience lookups rather than separate BankFind datasets:
 - `fdic_get_institution` wraps the `institutions` dataset
 - `fdic_get_institution_failure` wraps the `failures` dataset
+
+One tool is a server-side analysis helper:
+- `fdic_compare_bank_snapshots` batches roster lookup, financial snapshots, and optional demographics snapshots inside the MCP server so complex trend prompts do not require many separate tool calls
+- It supports both `snapshot` comparisons and `timeseries` analysis across a quarterly range
+- It computes derived efficiency and balance-sheet metrics and assigns insight tags for notable growth patterns
 
 ## Filter Syntax
 
@@ -169,6 +177,49 @@ sort_by: REPDTE
 sort_order: DESC
 (fdic_search_demographics)
 ```
+
+**Rank banks by growth across two dates without orchestrating many separate queries:**
+```
+state: North Carolina
+start_repdte: 20211231
+end_repdte: 20250630
+sort_by: asset_growth
+sort_order: DESC
+(fdic_compare_bank_snapshots)
+```
+
+**Analyze quarterly trends with streaks and derived metrics:**
+```
+state: North Carolina
+start_repdte: 20211231
+end_repdte: 20250630
+analysis_mode: timeseries
+sort_by: asset_growth_pct
+sort_order: DESC
+(fdic_compare_bank_snapshots)
+```
+
+## Complex Prompts
+
+The built-in `fdic_compare_bank_snapshots` tool is meant to make analysis-heavy prompts performant by batching FDIC calls inside the MCP server. The server also caches repeated state/date lookups for a short period, which helps iterative analysis. Good examples:
+
+- Identify North Carolina banks with the strongest asset growth from 2021 to 2025, then compare whether that growth came with higher deposits, more branches, or better profitability
+- Rank a set of banks by deposit growth percentage between two report dates and check which ones also improved ROA or ROE
+- Compare current active banks in a state between two snapshots to see which institutions grew while reducing office counts
+- Analyze whether rapid asset growth was accompanied by stronger profitability or just balance-sheet expansion
+- Analyze quarterly trends from 2021 through 2025 and call out inflection points, sustained asset-growth streaks, or multi-quarter ROA declines
+- Identify banks whose deposits-per-office and assets-per-office improved even while total branch counts fell
+- Separate banks with branch-supported growth from banks that mainly expanded their balance sheets
+
+The tool can take either:
+- `state` plus optional `institution_filters` to build a roster
+- `certs` to compare a specific list of institutions directly
+
+Notable outputs from `fdic_compare_bank_snapshots`:
+- point-to-point changes for assets, deposits, net income, ROA, ROE, and office counts
+- derived metrics such as `assets_per_office_change`, `deposits_per_office_change`, and `deposits_to_assets_change`
+- insight tags such as `growth_with_better_profitability`, `growth_with_branch_expansion`, `balance_sheet_growth_without_profitability`, and `growth_with_branch_consolidation`
+- in `timeseries` mode, quarterly series plus streak metrics like sustained asset growth and multi-quarter ROA decline
 
 ## Response Shape
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { registerHistoryTools } from "./tools/history.js";
 import { registerFinancialTools } from "./tools/financials.js";
 import { registerSodTools } from "./tools/sod.js";
 import { registerDemographicsTools } from "./tools/demographics.js";
+import { registerAnalysisTools } from "./tools/analysis.js";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -26,6 +27,7 @@ export function createServer(): McpServer {
   registerFinancialTools(server);
   registerSodTools(server);
   registerDemographicsTools(server);
+  registerAnalysisTools(server);
 
   return server;
 }

--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -24,10 +24,43 @@ interface FdicResponse {
   meta: { total: number };
 }
 
+interface CacheEntry {
+  expiresAt: number;
+  value: Promise<FdicResponse>;
+}
+
+const QUERY_CACHE_TTL_MS = 60_000;
+const queryCache = new Map<string, CacheEntry>();
+
+function getCacheKey(endpoint: string, params: QueryParams): string {
+  return JSON.stringify([
+    endpoint,
+    params.filters ?? null,
+    params.fields ?? null,
+    params.limit ?? null,
+    params.offset ?? null,
+    params.sort_by ?? null,
+    params.sort_order ?? null,
+  ]);
+}
+
+export function clearQueryCache(): void {
+  queryCache.clear();
+}
+
 export async function queryEndpoint(
   endpoint: string,
   params: QueryParams,
 ): Promise<FdicResponse> {
+  const cacheKey = getCacheKey(endpoint, params);
+  const now = Date.now();
+  const cached = queryCache.get(cacheKey);
+
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  const requestPromise = (async () => {
   try {
     const queryParams: Record<string, unknown> = {
       limit: params.limit ?? 20,
@@ -65,6 +98,19 @@ export async function queryEndpoint(
       }
     }
     throw new Error(`Unexpected error calling FDIC API: ${String(err)}`);
+  }
+  })();
+
+  queryCache.set(cacheKey, {
+    expiresAt: now + QUERY_CACHE_TTL_MS,
+    value: requestPromise,
+  });
+
+  try {
+    return await requestPromise;
+  } catch (error) {
+    queryCache.delete(cacheKey);
+    throw error;
   }
 }
 

--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -1,0 +1,893 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CHARACTER_LIMIT, ENDPOINTS } from "../constants.js";
+import {
+  buildPaginationInfo,
+  extractRecords,
+  formatToolError,
+  queryEndpoint,
+  truncateIfNeeded,
+} from "../services/fdicClient.js";
+
+type InstitutionRecord = Record<string, unknown>;
+type ComparisonRecord = Record<string, unknown>;
+
+const CHUNK_SIZE = 25;
+const MAX_CONCURRENCY = 4;
+
+const SortFieldSchema = z.enum([
+  "asset_growth",
+  "asset_growth_pct",
+  "dep_growth",
+  "dep_growth_pct",
+  "netinc_change",
+  "netinc_change_pct",
+  "roa_change",
+  "roe_change",
+  "offices_change",
+  "assets_per_office_change",
+  "deposits_per_office_change",
+  "deposits_to_assets_change",
+]);
+
+const AnalysisModeSchema = z.enum(["snapshot", "timeseries"]);
+
+const SnapshotAnalysisSchema = z
+  .object({
+    state: z
+      .string()
+      .optional()
+      .describe(
+        'State name for the institution roster filter. Example: "North Carolina"',
+      ),
+    certs: z
+      .array(z.number().int().positive())
+      .max(100)
+      .optional()
+      .describe(
+        "Optional list of FDIC certificate numbers to compare directly. Max 100.",
+      ),
+    institution_filters: z
+      .string()
+      .optional()
+      .describe(
+        'Additional institution-level filter used when building the comparison set. Example: BKCLASS:N or CITY:"Charlotte"',
+      ),
+    active_only: z
+      .boolean()
+      .default(true)
+      .describe("Limit the comparison set to currently active institutions."),
+    start_repdte: z
+      .string()
+      .regex(/^\d{8}$/)
+      .describe("Starting report date in YYYYMMDD format."),
+    end_repdte: z
+      .string()
+      .regex(/^\d{8}$/)
+      .describe("Ending report date in YYYYMMDD format."),
+    analysis_mode: AnalysisModeSchema.default("snapshot").describe(
+      "Use snapshot for two-point comparison or timeseries for quarterly trend analysis across the date range.",
+    ),
+    include_demographics: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Include office-count changes from the demographics dataset when available.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(10)
+      .describe("Maximum number of ranked comparisons to return."),
+    sort_by: SortFieldSchema.default("asset_growth").describe(
+      "Comparison field used to rank institutions.",
+    ),
+    sort_order: z
+      .enum(["ASC", "DESC"])
+      .default("DESC")
+      .describe("Sort direction for the ranked comparisons."),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.state && (!value.certs || value.certs.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide either state or certs.",
+        path: ["state"],
+      });
+    }
+  });
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function buildCertFilters(certs: number[]): string[] {
+  const filters: string[] = [];
+
+  for (let i = 0; i < certs.length; i += CHUNK_SIZE) {
+    const chunk = certs.slice(i, i + CHUNK_SIZE);
+    filters.push(chunk.map((cert) => `CERT:${cert}`).join(" OR "));
+  }
+
+  return filters;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  limit: number,
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= values.length) return;
+      results[currentIndex] = await mapper(values[currentIndex], currentIndex);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, () => worker()),
+  );
+
+  return results;
+}
+
+function ratio(numerator: number | null, denominator: number | null): number | null {
+  if (
+    numerator === null ||
+    denominator === null ||
+    denominator === 0
+  ) {
+    return null;
+  }
+
+  return numerator / denominator;
+}
+
+function pctChange(start: number | null, end: number | null): number | null {
+  if (start === null || end === null || start === 0) return null;
+  return ((end - start) / start) * 100;
+}
+
+function change(start: number | null, end: number | null): number | null {
+  if (start === null || end === null) return null;
+  return end - start;
+}
+
+function yearsBetween(startRepdte: string, endRepdte: string): number {
+  const start = new Date(
+    `${startRepdte.slice(0, 4)}-${startRepdte.slice(4, 6)}-${startRepdte.slice(6, 8)}`,
+  );
+  const end = new Date(
+    `${endRepdte.slice(0, 4)}-${endRepdte.slice(4, 6)}-${endRepdte.slice(6, 8)}`,
+  );
+  return Math.max((end.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000), 0);
+}
+
+function cagr(start: number | null, end: number | null, years: number): number | null {
+  if (start === null || end === null || start <= 0 || end <= 0 || years <= 0) {
+    return null;
+  }
+  return (Math.pow(end / start, 1 / years) - 1) * 100;
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? "n/a" : `${value.toFixed(1)}%`;
+}
+
+function formatChange(value: number | null, digits = 4): string {
+  if (value === null) return "n/a";
+  return value.toFixed(digits);
+}
+
+function formatInteger(value: number | null): string {
+  return value === null ? "n/a" : `${Math.round(value).toLocaleString()}`;
+}
+
+function sortComparisons(
+  comparisons: ComparisonRecord[],
+  sortBy: z.infer<typeof SortFieldSchema>,
+  sortOrder: "ASC" | "DESC",
+): ComparisonRecord[] {
+  const direction = sortOrder === "ASC" ? 1 : -1;
+
+  return [...comparisons].sort((left, right) => {
+    const leftValue = asNumber(left[sortBy]) ?? Number.NEGATIVE_INFINITY;
+    const rightValue = asNumber(right[sortBy]) ?? Number.NEGATIVE_INFINITY;
+    return (leftValue - rightValue) * direction;
+  });
+}
+
+function classifyInsights(comparison: ComparisonRecord): string[] {
+  const insights: string[] = [];
+  const assetGrowthPct = asNumber(comparison.asset_growth_pct);
+  const depGrowthPct = asNumber(comparison.dep_growth_pct);
+  const roaChange = asNumber(comparison.roa_change);
+  const roeChange = asNumber(comparison.roe_change);
+  const officesChange = asNumber(comparison.offices_change);
+  const depositsToAssetsChange = asNumber(comparison.deposits_to_assets_change);
+
+  if (
+    assetGrowthPct !== null &&
+    assetGrowthPct >= 25 &&
+    depGrowthPct !== null &&
+    depGrowthPct >= 15 &&
+    roaChange !== null &&
+    roaChange > 0
+  ) {
+    insights.push("growth_with_better_profitability");
+  }
+
+  if (
+    assetGrowthPct !== null &&
+    assetGrowthPct >= 25 &&
+    depGrowthPct !== null &&
+    depGrowthPct >= 15 &&
+    officesChange !== null &&
+    officesChange > 0
+  ) {
+    insights.push("growth_with_branch_expansion");
+  }
+
+  if (
+    assetGrowthPct !== null &&
+    assetGrowthPct >= 20 &&
+    (roaChange === null || roaChange <= 0) &&
+    (roeChange === null || roeChange <= 0)
+  ) {
+    insights.push("balance_sheet_growth_without_profitability");
+  }
+
+  if (
+    assetGrowthPct !== null &&
+    assetGrowthPct > 0 &&
+    officesChange !== null &&
+    officesChange < 0
+  ) {
+    insights.push("growth_with_branch_consolidation");
+  }
+
+  if (
+    depositsToAssetsChange !== null &&
+    depositsToAssetsChange < 0 &&
+    depGrowthPct !== null &&
+    depGrowthPct < 0
+  ) {
+    insights.push("deposit_mix_softening");
+  }
+
+  return insights;
+}
+
+function buildTopLevelInsights(comparisons: ComparisonRecord[]): Record<string, string[]> {
+  return {
+    growth_with_better_profitability: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "growth_with_better_profitability",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+    growth_with_branch_expansion: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "growth_with_branch_expansion",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+    balance_sheet_growth_without_profitability: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "balance_sheet_growth_without_profitability",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+    growth_with_branch_consolidation: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "growth_with_branch_consolidation",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+  };
+}
+
+function longestMonotonicStreak(
+  values: Array<number | null>,
+  direction: "up" | "down",
+): number {
+  let longest = 0;
+  let current = 0;
+
+  for (let i = 1; i < values.length; i += 1) {
+    const previous = values[i - 1];
+    const next = values[i];
+    if (previous === null || next === null) {
+      current = 0;
+      continue;
+    }
+
+    const matches = direction === "up" ? next > previous : next < previous;
+    if (matches) {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+
+  return longest;
+}
+
+function summarizeTimeSeries(
+  records: InstitutionRecord[],
+  demographicsByDate: Map<string, InstitutionRecord>,
+  institution: InstitutionRecord,
+): ComparisonRecord | null {
+  if (records.length < 2) return null;
+
+  const sorted = [...records].sort((left, right) =>
+    String(left.REPDTE).localeCompare(String(right.REPDTE)),
+  );
+  const start = sorted[0];
+  const end = sorted[sorted.length - 1];
+  const startRepdte = String(start.REPDTE);
+  const endRepdte = String(end.REPDTE);
+  const years = yearsBetween(startRepdte, endRepdte);
+  const assetSeries = sorted.map((record) => asNumber(record.ASSET));
+  const roaSeries = sorted.map((record) => asNumber(record.ROA));
+  const roeSeries = sorted.map((record) => asNumber(record.ROE));
+  const officesSeries = sorted.map(
+    (record) => asNumber(demographicsByDate.get(String(record.REPDTE))?.OFFTOT),
+  );
+  const assetStart = asNumber(start.ASSET);
+  const assetEnd = asNumber(end.ASSET);
+  const depStart = asNumber(start.DEP);
+  const depEnd = asNumber(end.DEP);
+  const roaStart = asNumber(start.ROA);
+  const roaEnd = asNumber(end.ROA);
+  const roeStart = asNumber(start.ROE);
+  const roeEnd = asNumber(end.ROE);
+  const netIncStart = asNumber(start.NETINC);
+  const netIncEnd = asNumber(end.NETINC);
+  const officesStart = officesSeries[0] ?? null;
+  const officesEnd = officesSeries[officesSeries.length - 1] ?? null;
+  const assetsPerOfficeStart = ratio(assetStart, officesStart);
+  const assetsPerOfficeEnd = ratio(assetEnd, officesEnd);
+  const depositsPerOfficeStart = ratio(depStart, officesStart);
+  const depositsPerOfficeEnd = ratio(depEnd, officesEnd);
+  const depositsToAssetsStart = ratio(depStart, assetStart);
+  const depositsToAssetsEnd = ratio(depEnd, assetEnd);
+  const peakAsset = Math.max(...assetSeries.filter((value): value is number => value !== null));
+  const troughRoaValues = roaSeries.filter((value): value is number => value !== null);
+  const troughRoa = troughRoaValues.length > 0 ? Math.min(...troughRoaValues) : null;
+  const comparison: ComparisonRecord = {
+    cert: asNumber(start.CERT),
+    name: end.NAME ?? start.NAME ?? institution.NAME,
+    city: institution.CITY,
+    stalp: institution.STALP,
+    analysis_mode: "timeseries",
+    start_repdte: startRepdte,
+    end_repdte: endRepdte,
+    periods_analyzed: sorted.length,
+    asset_start: assetStart,
+    asset_end: assetEnd,
+    asset_growth: change(assetStart, assetEnd),
+    asset_growth_pct: pctChange(assetStart, assetEnd),
+    asset_cagr: cagr(assetStart, assetEnd, years),
+    dep_start: depStart,
+    dep_end: depEnd,
+    dep_growth: change(depStart, depEnd),
+    dep_growth_pct: pctChange(depStart, depEnd),
+    netinc_start: netIncStart,
+    netinc_end: netIncEnd,
+    netinc_change: change(netIncStart, netIncEnd),
+    netinc_change_pct: pctChange(netIncStart, netIncEnd),
+    roa_start: roaStart,
+    roa_end: roaEnd,
+    roa_change: change(roaStart, roaEnd),
+    roe_start: roeStart,
+    roe_end: roeEnd,
+    roe_change: change(roeStart, roeEnd),
+    offices_start: officesStart,
+    offices_end: officesEnd,
+    offices_change: change(officesStart, officesEnd),
+    assets_per_office_start: assetsPerOfficeStart,
+    assets_per_office_end: assetsPerOfficeEnd,
+    assets_per_office_change: change(assetsPerOfficeStart, assetsPerOfficeEnd),
+    deposits_per_office_start: depositsPerOfficeStart,
+    deposits_per_office_end: depositsPerOfficeEnd,
+    deposits_per_office_change: change(
+      depositsPerOfficeStart,
+      depositsPerOfficeEnd,
+    ),
+    deposits_to_assets_start: depositsToAssetsStart,
+    deposits_to_assets_end: depositsToAssetsEnd,
+    deposits_to_assets_change: change(
+      depositsToAssetsStart,
+      depositsToAssetsEnd,
+    ),
+    asset_peak: peakAsset,
+    roa_trough: troughRoa,
+    asset_growth_streak: longestMonotonicStreak(assetSeries, "up"),
+    roa_decline_streak: longestMonotonicStreak(roaSeries, "down"),
+    roe_decline_streak: longestMonotonicStreak(roeSeries, "down"),
+    time_series: sorted.map((record) => {
+      const repdte = String(record.REPDTE);
+      const demo = demographicsByDate.get(repdte);
+      return {
+        repdte,
+        asset: asNumber(record.ASSET),
+        dep: asNumber(record.DEP),
+        netinc: asNumber(record.NETINC),
+        roa: asNumber(record.ROA),
+        roe: asNumber(record.ROE),
+        offices: asNumber(demo?.OFFTOT),
+      };
+    }),
+  };
+
+  comparison.insights = classifyInsights(comparison);
+  if ((comparison.asset_growth_streak as number) >= 3) {
+    (comparison.insights as string[]).push("sustained_asset_growth");
+  }
+  if ((comparison.roa_decline_streak as number) >= 2) {
+    (comparison.insights as string[]).push("multi_quarter_roa_decline");
+  }
+
+  return comparison;
+}
+
+function formatComparisonText(output: {
+  analyzed_count: number;
+  total_candidates: number;
+  start_repdte: string;
+  end_repdte: string;
+  sort_by: string;
+  analysis_mode: "snapshot" | "timeseries";
+  comparisons: ComparisonRecord[];
+  insights?: Record<string, string[]>;
+}): string {
+  const header =
+    `Compared ${output.analyzed_count} institutions from ${output.start_repdte} ` +
+    `to ${output.end_repdte} (from ${output.total_candidates} candidates), ` +
+    `ranked by ${output.sort_by} using ${output.analysis_mode} analysis.`;
+
+  if (output.comparisons.length === 0) {
+    return header;
+  }
+
+  const rows = output.comparisons.map((comparison, index) => {
+    const name = String(comparison.name ?? comparison.cert);
+    const city = comparison.city ? `, ${comparison.city}` : "";
+    const base =
+      `${index + 1}. ${name}${city} | ` +
+      `Asset growth: ${formatInteger(asNumber(comparison.asset_growth))} ` +
+      `(${formatPercent(asNumber(comparison.asset_growth_pct))}) | ` +
+      `Deposit growth: ${formatPercent(asNumber(comparison.dep_growth_pct))} | ` +
+      `Offices: ${formatInteger(asNumber(comparison.offices_change))} | ` +
+      `ROA: ${formatChange(asNumber(comparison.roa_change))} | ` +
+      `ROE: ${formatChange(asNumber(comparison.roe_change))}`;
+
+    if (output.analysis_mode === "timeseries") {
+      return (
+        `${base} | ` +
+        `Asset CAGR: ${formatPercent(asNumber(comparison.asset_cagr))} | ` +
+        `Streaks: asset ${formatInteger(asNumber(comparison.asset_growth_streak))}, ` +
+        `ROA decline ${formatInteger(asNumber(comparison.roa_decline_streak))}`
+      );
+    }
+
+    return base;
+  });
+
+  const insights = output.insights
+    ? Object.entries(output.insights)
+        .filter(([, names]) => names.length > 0)
+        .map(([label, names]) => `${label}: ${names.join(", ")}`)
+        .join("\n")
+    : "";
+
+  return insights ? `${header}\n${rows.join("\n")}\nInsights\n${insights}` : `${header}\n${rows.join("\n")}`;
+}
+
+async function fetchInstitutionRoster(
+  state: string | undefined,
+  institutionFilters: string | undefined,
+  activeOnly: boolean,
+): Promise<InstitutionRecord[]> {
+  const filterParts: string[] = [];
+  if (state) filterParts.push(`STNAME:"${state}"`);
+  if (activeOnly) filterParts.push("ACTIVE:1");
+  if (institutionFilters) filterParts.push(`(${institutionFilters})`);
+
+  const response = await queryEndpoint(ENDPOINTS.INSTITUTIONS, {
+    filters: filterParts.join(" AND "),
+    fields: "CERT,NAME,CITY,STALP,ACTIVE",
+    limit: 10_000,
+    offset: 0,
+    sort_by: "CERT",
+    sort_order: "ASC",
+  });
+
+  return extractRecords(response);
+}
+
+async function fetchBatchedRecordsForDates(
+  endpoint: string,
+  certs: number[],
+  repdteFilters: string[],
+  fields: string,
+): Promise<Map<string, Map<number, InstitutionRecord>>> {
+  const certFilters = buildCertFilters(certs);
+  const tasks = repdteFilters.flatMap((repdteFilter) =>
+    certFilters.map((certFilter) => ({
+      repdteFilter,
+      certFilter,
+    })),
+  );
+
+  const responses = await mapWithConcurrency(tasks, MAX_CONCURRENCY, async (task) => {
+    const response = await queryEndpoint(endpoint, {
+      filters: `(${task.certFilter}) AND ${task.repdteFilter}`,
+      fields,
+      limit: 10_000,
+      offset: 0,
+      sort_by: "CERT",
+      sort_order: "ASC",
+    });
+
+    return { repdteFilter: task.repdteFilter, response };
+  });
+
+  const byDate = new Map<string, Map<number, InstitutionRecord>>();
+  for (const { repdteFilter, response } of responses) {
+    if (!byDate.has(repdteFilter)) {
+      byDate.set(repdteFilter, new Map<number, InstitutionRecord>());
+    }
+    const target = byDate.get(repdteFilter)!;
+    for (const record of extractRecords(response)) {
+      const cert = asNumber(record.CERT);
+      if (cert !== null) target.set(cert, record);
+    }
+  }
+
+  return byDate;
+}
+
+async function fetchSeriesRecords(
+  endpoint: string,
+  certs: number[],
+  startRepdte: string,
+  endRepdte: string,
+  fields: string,
+): Promise<Map<number, InstitutionRecord[]>> {
+  const certFilters = buildCertFilters(certs);
+  const responses = await mapWithConcurrency(
+    certFilters,
+    MAX_CONCURRENCY,
+    async (certFilter) =>
+      queryEndpoint(endpoint, {
+        filters: `(${certFilter}) AND REPDTE:[${startRepdte} TO ${endRepdte}]`,
+        fields,
+        limit: 10_000,
+        offset: 0,
+        sort_by: "REPDTE",
+        sort_order: "ASC",
+      }),
+  );
+
+  const grouped = new Map<number, InstitutionRecord[]>();
+  for (const response of responses) {
+    for (const record of extractRecords(response)) {
+      const cert = asNumber(record.CERT);
+      if (cert === null) continue;
+      if (!grouped.has(cert)) grouped.set(cert, []);
+      grouped.get(cert)!.push(record);
+    }
+  }
+
+  return grouped;
+}
+
+function buildSnapshotComparison(
+  cert: number,
+  institution: InstitutionRecord,
+  startFinancial: InstitutionRecord,
+  endFinancial: InstitutionRecord,
+  startDemo: InstitutionRecord | undefined,
+  endDemo: InstitutionRecord | undefined,
+  startRepdte: string,
+  endRepdte: string,
+): ComparisonRecord {
+  const assetStart = asNumber(startFinancial.ASSET);
+  const assetEnd = asNumber(endFinancial.ASSET);
+  const depStart = asNumber(startFinancial.DEP);
+  const depEnd = asNumber(endFinancial.DEP);
+  const netIncStart = asNumber(startFinancial.NETINC);
+  const netIncEnd = asNumber(endFinancial.NETINC);
+  const roaStart = asNumber(startFinancial.ROA);
+  const roaEnd = asNumber(endFinancial.ROA);
+  const roeStart = asNumber(startFinancial.ROE);
+  const roeEnd = asNumber(endFinancial.ROE);
+  const officesStart = asNumber(startDemo?.OFFTOT);
+  const officesEnd = asNumber(endDemo?.OFFTOT);
+  const assetsPerOfficeStart = ratio(assetStart, officesStart);
+  const assetsPerOfficeEnd = ratio(assetEnd, officesEnd);
+  const depositsPerOfficeStart = ratio(depStart, officesStart);
+  const depositsPerOfficeEnd = ratio(depEnd, officesEnd);
+  const depositsToAssetsStart = ratio(depStart, assetStart);
+  const depositsToAssetsEnd = ratio(depEnd, assetEnd);
+
+  const comparison: ComparisonRecord = {
+    cert,
+    name: endFinancial.NAME ?? startFinancial.NAME ?? institution.NAME,
+    city: institution.CITY,
+    stalp: institution.STALP,
+    analysis_mode: "snapshot",
+    start_repdte: startRepdte,
+    end_repdte: endRepdte,
+    asset_start: assetStart,
+    asset_end: assetEnd,
+    asset_growth: change(assetStart, assetEnd),
+    asset_growth_pct: pctChange(assetStart, assetEnd),
+    dep_start: depStart,
+    dep_end: depEnd,
+    dep_growth: change(depStart, depEnd),
+    dep_growth_pct: pctChange(depStart, depEnd),
+    netinc_start: netIncStart,
+    netinc_end: netIncEnd,
+    netinc_change: change(netIncStart, netIncEnd),
+    netinc_change_pct: pctChange(netIncStart, netIncEnd),
+    roa_start: roaStart,
+    roa_end: roaEnd,
+    roa_change: change(roaStart, roaEnd),
+    roe_start: roeStart,
+    roe_end: roeEnd,
+    roe_change: change(roeStart, roeEnd),
+    offices_start: officesStart,
+    offices_end: officesEnd,
+    offices_change: change(officesStart, officesEnd),
+    assets_per_office_start: assetsPerOfficeStart,
+    assets_per_office_end: assetsPerOfficeEnd,
+    assets_per_office_change: change(assetsPerOfficeStart, assetsPerOfficeEnd),
+    deposits_per_office_start: depositsPerOfficeStart,
+    deposits_per_office_end: depositsPerOfficeEnd,
+    deposits_per_office_change: change(
+      depositsPerOfficeStart,
+      depositsPerOfficeEnd,
+    ),
+    deposits_to_assets_start: depositsToAssetsStart,
+    deposits_to_assets_end: depositsToAssetsEnd,
+    deposits_to_assets_change: change(
+      depositsToAssetsStart,
+      depositsToAssetsEnd,
+    ),
+    cbsa_start: startDemo?.CBSANAME,
+    cbsa_end: endDemo?.CBSANAME,
+  };
+
+  comparison.insights = classifyInsights(comparison);
+  return comparison;
+}
+
+export function registerAnalysisTools(server: McpServer): void {
+  server.registerTool(
+    "fdic_compare_bank_snapshots",
+    {
+      title: "Compare Bank Snapshot Trends",
+      description: `Compare FDIC reporting snapshots across a set of institutions and rank the results by growth, profitability, or efficiency changes.
+
+This tool is designed for heavier analytical prompts that would otherwise require many separate MCP calls. It batches institution roster lookup, financial snapshots, optional office-count snapshots, and can also fetch a quarterly time series inside the server.
+
+Good uses:
+  - Identify North Carolina banks with the strongest asset growth from 2021 to 2025
+  - Compare whether deposit growth came with branch expansion or profitability improvement
+  - Rank a specific cert list by ROA, ROE, asset-per-office, or deposit-to-asset changes
+  - Pull a quarterly trend series and highlight inflection points, streaks, and structural shifts
+
+Inputs:
+  - state or certs: choose a geographic roster or provide a direct comparison set
+  - start_repdte, end_repdte: report dates in YYYYMMDD format
+  - analysis_mode: snapshot or timeseries
+  - institution_filters: optional extra institution filter when building the roster
+  - active_only: default true
+  - include_demographics: default true, adds office-count comparisons when available
+  - sort_by: ranking field such as asset_growth, dep_growth_pct, roa_change, assets_per_office_change
+  - sort_order: ASC or DESC
+  - limit: maximum ranked results to return
+
+Returns concise comparison text plus structured deltas, derived metrics, and insight tags for each institution.`,
+      inputSchema: SnapshotAnalysisSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({
+      state,
+      certs,
+      institution_filters,
+      active_only,
+      start_repdte,
+      end_repdte,
+      analysis_mode,
+      include_demographics,
+      limit,
+      sort_by,
+      sort_order,
+    }) => {
+      try {
+        const roster =
+          certs && certs.length > 0
+            ? certs.map((cert) => ({ CERT: cert }))
+            : await fetchInstitutionRoster(
+                state,
+                institution_filters,
+                active_only,
+              );
+
+        const candidateCerts = roster
+          .map((record) => asNumber(record.CERT))
+          .filter((cert): cert is number => cert !== null);
+
+        if (candidateCerts.length === 0) {
+          const output = {
+            total_candidates: 0,
+            analyzed_count: 0,
+            start_repdte,
+            end_repdte,
+            analysis_mode,
+            sort_by,
+            sort_order,
+            comparisons: [],
+          };
+
+          return {
+            content: [
+              { type: "text", text: "No institutions matched the comparison set." },
+            ],
+            structuredContent: output,
+          };
+        }
+
+        const rosterByCert = new Map(
+          roster
+            .map((record) => [asNumber(record.CERT), record] as const)
+            .filter(
+              (entry): entry is readonly [number, InstitutionRecord] =>
+                entry[0] !== null,
+            ),
+        );
+
+        let comparisons: ComparisonRecord[] = [];
+
+        if (analysis_mode === "timeseries") {
+          const [financialSeries, demographicsSeries] = await Promise.all([
+            fetchSeriesRecords(
+              ENDPOINTS.FINANCIALS,
+              candidateCerts,
+              start_repdte,
+              end_repdte,
+              "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+            ),
+            include_demographics
+              ? fetchSeriesRecords(
+                  ENDPOINTS.DEMOGRAPHICS,
+                  candidateCerts,
+                  start_repdte,
+                  end_repdte,
+                  "CERT,REPDTE,OFFTOT,OFFSTATE,CBSANAME",
+                )
+              : Promise.resolve(new Map<number, InstitutionRecord[]>()),
+          ]);
+
+          comparisons = candidateCerts
+            .map((cert) =>
+              summarizeTimeSeries(
+                financialSeries.get(cert) ?? [],
+                new Map(
+                  (demographicsSeries.get(cert) ?? []).map((record) => [
+                    String(record.REPDTE),
+                    record,
+                  ]),
+                ),
+                rosterByCert.get(cert) ?? {},
+              ),
+            )
+            .filter((comparison): comparison is ComparisonRecord => comparison !== null);
+        } else {
+          const [financialSnapshots, demographicSnapshots] = await Promise.all([
+            fetchBatchedRecordsForDates(
+              ENDPOINTS.FINANCIALS,
+              candidateCerts,
+              [`REPDTE:${start_repdte}`, `REPDTE:${end_repdte}`],
+              "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+            ),
+            include_demographics
+              ? fetchBatchedRecordsForDates(
+                  ENDPOINTS.DEMOGRAPHICS,
+                  candidateCerts,
+                  [`REPDTE:${start_repdte}`, `REPDTE:${end_repdte}`],
+                  "CERT,REPDTE,OFFTOT,OFFSTATE,CBSANAME",
+                )
+              : Promise.resolve(new Map<string, Map<number, InstitutionRecord>>()),
+          ]);
+
+          const startFinancials =
+            financialSnapshots.get(`REPDTE:${start_repdte}`) ??
+            new Map<number, InstitutionRecord>();
+          const endFinancials =
+            financialSnapshots.get(`REPDTE:${end_repdte}`) ??
+            new Map<number, InstitutionRecord>();
+          const startDemographics =
+            demographicSnapshots.get(`REPDTE:${start_repdte}`) ??
+            new Map<number, InstitutionRecord>();
+          const endDemographics =
+            demographicSnapshots.get(`REPDTE:${end_repdte}`) ??
+            new Map<number, InstitutionRecord>();
+
+          comparisons = candidateCerts
+            .map((cert) => {
+              const startFinancial = startFinancials.get(cert);
+              const endFinancial = endFinancials.get(cert);
+              if (!startFinancial || !endFinancial) return null;
+              return buildSnapshotComparison(
+                cert,
+                rosterByCert.get(cert) ?? {},
+                startFinancial,
+                endFinancial,
+                startDemographics.get(cert),
+                endDemographics.get(cert),
+                start_repdte,
+                end_repdte,
+              );
+            })
+            .filter((comparison): comparison is ComparisonRecord => comparison !== null);
+        }
+
+        const ranked = sortComparisons(comparisons, sort_by, sort_order).slice(
+          0,
+          limit,
+        );
+        const pagination = buildPaginationInfo(comparisons.length, 0, ranked.length);
+        const output = {
+          total_candidates: candidateCerts.length,
+          analyzed_count: comparisons.length,
+          start_repdte,
+          end_repdte,
+          analysis_mode,
+          sort_by,
+          sort_order,
+          insights: buildTopLevelInsights(comparisons),
+          ...pagination,
+          comparisons: ranked,
+        };
+
+        const text = truncateIfNeeded(
+          formatComparisonText(output),
+          CHARACTER_LIMIT,
+        );
+
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: output,
+        };
+      } catch (err) {
+        return formatToolError(err);
+      }
+    },
+  );
+}

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -29,6 +29,7 @@ vi.mock("axios", () => {
 import { AxiosError } from "axios";
 import {
   buildPaginationInfo,
+  clearQueryCache,
   extractRecords,
   formatToolError,
   queryEndpoint,
@@ -41,6 +42,7 @@ const expectedVersion = packageJson.version;
 describe("fdicClient", () => {
   beforeEach(() => {
     getMock.mockReset();
+    clearQueryCache();
   });
 
   it("configures the axios client with the expected base settings", () => {
@@ -98,6 +100,19 @@ describe("fdicClient", () => {
         sort_order: "DESC",
       },
     });
+  });
+
+  it("reuses cached results for identical queries within the cache window", async () => {
+    getMock.mockResolvedValue({
+      data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
+    });
+
+    const first = await queryEndpoint("institutions", { filters: "CERT:3511" });
+    const second = await queryEndpoint("institutions", { filters: "CERT:3511" });
+
+    expect(first.meta.total).toBe(1);
+    expect(second.meta.total).toBe(1);
+    expect(getMock).toHaveBeenCalledTimes(1);
   });
 
   it("maps 400 responses to a filter syntax error", async () => {

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -28,6 +28,7 @@ vi.mock("axios", () => {
 });
 
 import { createApp } from "../src/index.js";
+import { clearQueryCache } from "../src/services/fdicClient.js";
 import packageJson from "../package.json";
 
 const expectedVersion = packageJson.version;
@@ -43,6 +44,7 @@ function mcpPost(body: Record<string, unknown>) {
 describe("HTTP MCP server", () => {
   beforeEach(() => {
     getMock.mockReset();
+    clearQueryCache();
   });
 
   it("serves the health endpoint", async () => {
@@ -65,10 +67,13 @@ describe("HTTP MCP server", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.body.result.tools).toHaveLength(10);
+    expect(response.body.result.tools).toHaveLength(11);
     expect(
       response.body.result.tools.map((tool: { name: string }) => tool.name),
     ).toContain("fdic_search_demographics");
+    expect(
+      response.body.result.tools.map((tool: { name: string }) => tool.name),
+    ).toContain("fdic_compare_bank_snapshots");
 
     const financialsTool = response.body.result.tools.find(
       (tool: { name: string }) => tool.name === "fdic_search_financials",
@@ -76,6 +81,10 @@ describe("HTTP MCP server", () => {
     expect(financialsTool.inputSchema.properties.sort_order.default).toBe(
       "DESC",
     );
+    const analysisTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "fdic_compare_bank_snapshots",
+    );
+    expect(analysisTool.title).toBe("Compare Bank Snapshot Trends");
   });
 
   it("handles repeated MCP requests without reusing a connected server", async () => {
@@ -256,5 +265,180 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toBe(
       "Error: Unexpected error calling FDIC API: Error: backend unavailable",
     );
+  });
+
+  it("batches snapshot comparisons into financial and demographic date queries", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, NAME: "Bank A", CITY: "Charlotte", STALP: "NC" } },
+            { data: { CERT: 9846, NAME: "Bank B", CITY: "Raleigh", STALP: "NC" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, NAME: "Bank A", ASSET: 100, DEP: 50, NETINC: 10, ROA: 1, ROE: 8 } },
+            { data: { CERT: 9846, NAME: "Bank B", ASSET: 200, DEP: 100, NETINC: 20, ROA: 2, ROE: 9 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, NAME: "Bank A", ASSET: 150, DEP: 90, NETINC: 12, ROA: 1.2, ROE: 8.5 } },
+            { data: { CERT: 9846, NAME: "Bank B", ASSET: 260, DEP: 140, NETINC: 30, ROA: 2.5, ROE: 10 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, OFFTOT: 5, CBSANAME: "Charlotte" } },
+            { data: { CERT: 9846, OFFTOT: 7, CBSANAME: "Raleigh" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, OFFTOT: 4, CBSANAME: "Charlotte" } },
+            { data: { CERT: 9846, OFFTOT: 8, CBSANAME: "Raleigh" } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          limit: 2,
+          sort_by: "asset_growth",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.analyzed_count).toBe(2);
+    expect(response.body.result.structuredContent.comparisons[0]).toMatchObject({
+      cert: 9846,
+      asset_growth: 60,
+      dep_growth: 40,
+      offices_change: 1,
+    });
+    expect(response.body.result.content[0].text).toContain(
+      "Compared 2 institutions from 20211231 to 20250630",
+    );
+    expect(getMock).toHaveBeenNthCalledWith(1, "/institutions", {
+      params: {
+        fields: "CERT,NAME,CITY,STALP,ACTIVE",
+        filters: 'STNAME:"North Carolina" AND ACTIVE:1',
+        limit: 10000,
+        offset: 0,
+        output: "json",
+        sort_by: "CERT",
+        sort_order: "ASC",
+      },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, "/financials", {
+      params: {
+        fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+        filters: "(CERT:3510 OR CERT:9846) AND REPDTE:20211231",
+        limit: 10000,
+        offset: 0,
+        output: "json",
+        sort_by: "CERT",
+        sort_order: "ASC",
+      },
+    });
+  });
+
+  it("returns time-series analysis with derived metrics and insights", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 3510, NAME: "Bank A", CITY: "Charlotte", STALP: "NC" } }],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, NAME: "Bank A", REPDTE: "20211231", ASSET: 100, DEP: 50, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+            { data: { CERT: 3510, NAME: "Bank A", REPDTE: "20220331", ASSET: 120, DEP: 60, NETINC: 11, ROA: 1.1, ROE: 8.2 } },
+            { data: { CERT: 3510, NAME: "Bank A", REPDTE: "20250630", ASSET: 180, DEP: 90, NETINC: 16, ROA: 1.4, ROE: 9.5 } },
+          ],
+          meta: { total: 3 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 3510, REPDTE: "20211231", OFFTOT: 5, CBSANAME: "Charlotte" } },
+            { data: { CERT: 3510, REPDTE: "20220331", OFFTOT: 5, CBSANAME: "Charlotte" } },
+            { data: { CERT: 3510, REPDTE: "20250630", OFFTOT: 6, CBSANAME: "Charlotte" } },
+          ],
+          meta: { total: 3 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          analysis_mode: "timeseries",
+          limit: 1,
+          sort_by: "asset_growth_pct",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.analysis_mode).toBe(
+      "timeseries",
+    );
+    expect(response.body.result.structuredContent.comparisons[0]).toMatchObject({
+      cert: 3510,
+      asset_growth: 80,
+      deposits_per_office_change: 5,
+      deposits_to_assets_change: 0,
+      asset_growth_streak: 2,
+    });
+    expect(
+      response.body.result.structuredContent.comparisons[0].insights,
+    ).toContain("growth_with_branch_expansion");
+    expect(response.body.result.content[0].text).toContain(
+      "using timeseries analysis",
+    );
+    expect(getMock).toHaveBeenNthCalledWith(2, "/financials", {
+      params: {
+        fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+        filters: "(CERT:3510) AND REPDTE:[20211231 TO 20250630]",
+        limit: 10000,
+        offset: 0,
+        output: "json",
+        sort_by: "REPDTE",
+        sort_order: "ASC",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a first-class server-side analysis path for complex BankFind prompts so the model no longer has to orchestrate many low-level MCP calls to compare banks across dates.

## What Changed

- Added `fdic_compare_bank_snapshots` in `src/tools/analysis.ts`
  - Supports `snapshot` mode for point-to-point comparisons
  - Supports `timeseries` mode for quarterly trend analysis across a date range
  - Accepts either a `state` roster or explicit `certs`
  - Computes deltas and rankings server-side
  - Returns insight tags for notable patterns

- Wired the new tool into `createServer()` in `src/index.ts`

- Improved analytical performance in `src/services/fdicClient.ts`
  - Added short-lived in-memory caching for FDIC API responses
  - Reuses identical in-flight requests

- Improved batched upstream fetching inside the analysis tool
  - Chunks large cert sets into OR filters
  - Fetches those chunks with bounded concurrency instead of serial loops

## Derived Metrics And Insights

The analysis tool now computes additional fields beyond the raw FDIC values, including:

- `asset_growth`, `asset_growth_pct`, `asset_cagr`
- `dep_growth`, `dep_growth_pct`
- `netinc_change`, `netinc_change_pct`
- `roa_change`, `roe_change`
- `offices_change`
- `assets_per_office_change`
- `deposits_per_office_change`
- `deposits_to_assets_change`
- streak metrics such as `asset_growth_streak`, `roa_decline_streak`, and `roe_decline_streak`

It also classifies banks into higher-level insight groups such as:

- `growth_with_better_profitability`
- `growth_with_branch_expansion`
- `balance_sheet_growth_without_profitability`
- `growth_with_branch_consolidation`
- `deposit_mix_softening`

## README Updates

The README now documents:

- the new comparison tool in the tool list
- example snapshot and time-series queries
- the kinds of analytical prompts this tool makes performant
- the new derived metrics and insight outputs
- the built-in caching and batching behavior for analytical workflows

## Tests

Updated and expanded tests cover:

- FDIC client cache reuse
- tool registration and discoverability
- batched snapshot comparison behavior
- time-series analysis behavior and derived metrics

## Validation

Ran locally:

- `npm test`
- `npm run typecheck`
- `npm run build`

Also smoke-tested the new tool against live data on the feature branch, including `timeseries` mode over North Carolina banks from `20211231` to `20250630`.

## Why This Matters

This should materially improve performance and reliability for prompts like:

- identify banks with the strongest growth across two dates
- compare whether deposit growth came with branch expansion or better profitability
- analyze quarterly trend series and call out inflection points or multi-quarter declines
- separate branch-supported growth from balance-sheet-only growth
