### PR TITLE
fix(#3): warn on truncated analysis rosters

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -530,7 +530,10 @@ async function fetchInstitutionRoster(
   institutionFilters: string | undefined,
   activeOnly: boolean,
   signal?: AbortSignal,
-): Promise<InstitutionRecord[]> {
+): Promise<{
+  records: InstitutionRecord[];
+  warning?: string;
+}> {
   const filterParts: string[] = [];
   if (state) filterParts.push(`STNAME:"${state}"`);
   if (activeOnly) filterParts.push("ACTIVE:1");
@@ -545,7 +548,13 @@ async function fetchInstitutionRoster(
     sort_order: "ASC",
   }, { signal });
 
-  return extractRecords(response);
+  const records = extractRecords(response);
+  const warning =
+    response.meta.total > records.length
+      ? `Institution roster truncated to ${records.length.toLocaleString()} records out of ${response.meta.total.toLocaleString()} matched institutions. Narrow the comparison set with institution_filters or certs for complete analysis.`
+      : undefined;
+
+  return { records, warning };
 }
 
 async function fetchBatchedRecordsForDates(
@@ -760,15 +769,19 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
       const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
 
       try {
-        const roster =
+        const rosterResult =
           certs && certs.length > 0
-            ? certs.map((cert) => ({ CERT: cert }))
+            ? {
+                records: certs.map((cert) => ({ CERT: cert })),
+                warning: undefined,
+              }
             : await fetchInstitutionRoster(
                 state,
                 institution_filters,
                 active_only,
                 controller.signal,
               );
+        const roster = rosterResult.records;
 
         const candidateCerts = roster
           .map((record) => asNumber(record.CERT))
@@ -908,13 +921,19 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
           analysis_mode,
           sort_by,
           sort_order,
+          warnings: rosterResult.warning ? [rosterResult.warning] : [],
           insights: buildTopLevelInsights(sortedComparisons),
           ...pagination,
           comparisons: ranked,
         };
 
         const text = truncateIfNeeded(
-          formatComparisonText(output),
+          [
+            rosterResult.warning ? `Warning: ${rosterResult.warning}` : null,
+            formatComparisonText(output),
+          ]
+            .filter((value): value is string => value !== null)
+            .join("\n\n"),
           CHARACTER_LIMIT,
         );
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -574,4 +574,49 @@ describe("HTTP MCP server", () => {
       response.body.result.structuredContent.insights.growth_with_branch_expansion,
     ).toEqual(["Bank Fast", "Bank Slow"]);
   });
+
+  it("warns when the analysis roster is truncated by the FDIC API limit", async () => {
+    getMock.mockImplementation(async (url: string) => {
+      if (url === "/institutions") {
+        return {
+          data: {
+            data: Array.from({ length: 10_000 }, (_, index) => ({
+              data: { CERT: index + 1, NAME: `Bank ${index + 1}` },
+            })),
+            meta: { total: 10_500 },
+          },
+        };
+      }
+
+      return {
+        data: {
+          data: [],
+          meta: { total: 0 },
+        },
+      };
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          limit: 1,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.warnings).toEqual([
+      "Institution roster truncated to 10,000 records out of 10,500 matched institutions. Narrow the comparison set with institution_filters or certs for complete analysis.",
+    ]);
+    expect(response.body.result.content[0].text).toContain(
+      "Warning: Institution roster truncated to 10,000 records out of 10,500 matched institutions.",
+    );
+  });
 });


### PR DESCRIPTION
Closes #3

## Summary
This PR makes the analysis tool explicit when the institution roster is clipped by the FDIC API's 10,000-record limit. Instead of silently analyzing a partial comparison set, the tool now returns a warning in both text output and structured content.

## Root Cause
`fetchInstitutionRoster` in `src/tools/analysis.ts` always requested `limit: 10000` and returned only the extracted records. When the FDIC API reported a larger `meta.total`, that signal was discarded, so the caller had no way to know the analysis omitted matching institutions.

## Fix Strategy
I kept the single-request roster fetch and surfaced truncation metadata instead of introducing full pagination in this change. That resolves the silent-data-loss problem while keeping the tool behavior and request volume stable.

## Changes
| File | Change |
|------|--------|
| `src/tools/analysis.ts` | Return roster truncation metadata and include warnings in analysis output. |
| `tests/mcp-http.test.ts` | Add a regression test covering the truncated-roster warning path. |

## Validation
- Verified truncated rosters emit a warning in `content` and `structuredContent.warnings`.
- Verified the analysis tool still returns successful output when downstream snapshot queries are empty.
- Ran `npm test`, `npm run typecheck`, and `npm run build`.

## Screenshots / Output (if applicable)
- `npm test`
- `npm run typecheck`
- `npm run build`