### PR TITLE
fix(#4): enforce an analysis timeout budget

### DIFF
--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -19,6 +19,10 @@ interface QueryParams {
   sort_order?: string;
 }
 
+interface QueryOptions {
+  signal?: AbortSignal;
+}
+
 interface FdicResponse {
   data: Array<{ data: Record<string, unknown> }>;
   meta: { total: number };
@@ -59,12 +63,18 @@ export function clearQueryCache(): void {
 export async function queryEndpoint(
   endpoint: string,
   params: QueryParams,
+  options: QueryOptions = {},
 ): Promise<FdicResponse> {
+  if (options.signal?.aborted) {
+    throw new Error("FDIC API request was canceled before it started.");
+  }
+
+  const shouldUseCache = !options.signal;
   const now = Date.now();
   pruneExpiredQueryCache(now);
 
   const cacheKey = getCacheKey(endpoint, params);
-  const cached = queryCache.get(cacheKey);
+  const cached = shouldUseCache ? queryCache.get(cacheKey) : undefined;
 
   if (cached && cached.expiresAt > now) {
     return cached.value;
@@ -84,9 +94,21 @@ export async function queryEndpoint(
 
       const response = await apiClient.get(`/${endpoint}`, {
         params: queryParams,
+        signal: options.signal,
       });
       return response.data;
     } catch (err) {
+      if (
+        options.signal?.aborted ||
+        (typeof err === "object" &&
+          err !== null &&
+          "code" in err &&
+          (err as { code?: string }).code === "ERR_CANCELED") ||
+        (err instanceof DOMException && err.name === "AbortError")
+      ) {
+        throw new Error("FDIC API request was canceled.");
+      }
+
       if (err instanceof AxiosError) {
         const status = err.response?.status;
         const detail =
@@ -111,15 +133,19 @@ export async function queryEndpoint(
     }
   })();
 
-  queryCache.set(cacheKey, {
-    expiresAt: now + QUERY_CACHE_TTL_MS,
-    value: requestPromise,
-  });
+  if (shouldUseCache) {
+    queryCache.set(cacheKey, {
+      expiresAt: now + QUERY_CACHE_TTL_MS,
+      value: requestPromise,
+    });
+  }
 
   try {
     return await requestPromise;
   } catch (error) {
-    queryCache.delete(cacheKey);
+    if (shouldUseCache) {
+      queryCache.delete(cacheKey);
+    }
     throw error;
   }
 }

--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -14,6 +14,7 @@ type ComparisonRecord = Record<string, unknown>;
 
 const CHUNK_SIZE = 25;
 const MAX_CONCURRENCY = 4;
+const ANALYSIS_TIMEOUT_MS = 90_000;
 
 const SortFieldSchema = z.enum([
   "asset_growth",
@@ -528,6 +529,7 @@ async function fetchInstitutionRoster(
   state: string | undefined,
   institutionFilters: string | undefined,
   activeOnly: boolean,
+  signal?: AbortSignal,
 ): Promise<InstitutionRecord[]> {
   const filterParts: string[] = [];
   if (state) filterParts.push(`STNAME:"${state}"`);
@@ -541,7 +543,7 @@ async function fetchInstitutionRoster(
     offset: 0,
     sort_by: "CERT",
     sort_order: "ASC",
-  });
+  }, { signal });
 
   return extractRecords(response);
 }
@@ -551,6 +553,7 @@ async function fetchBatchedRecordsForDates(
   certs: number[],
   repdteFilters: string[],
   fields: string,
+  signal?: AbortSignal,
 ): Promise<Map<string, Map<number, InstitutionRecord>>> {
   const certFilters = buildCertFilters(certs);
   const tasks = repdteFilters.flatMap((repdteFilter) =>
@@ -568,7 +571,7 @@ async function fetchBatchedRecordsForDates(
       offset: 0,
       sort_by: "CERT",
       sort_order: "ASC",
-    });
+    }, { signal });
 
     return { repdteFilter: task.repdteFilter, response };
   });
@@ -594,6 +597,7 @@ async function fetchSeriesRecords(
   startRepdte: string,
   endRepdte: string,
   fields: string,
+  signal?: AbortSignal,
 ): Promise<Map<number, InstitutionRecord[]>> {
   const certFilters = buildCertFilters(certs);
   const responses = await mapWithConcurrency(
@@ -607,7 +611,7 @@ async function fetchSeriesRecords(
         offset: 0,
         sort_by: "REPDTE",
         sort_order: "ASC",
-      }),
+      }, { signal }),
   );
 
   const grouped = new Map<number, InstitutionRecord[]>();
@@ -752,6 +756,9 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
       sort_by,
       sort_order,
     }) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
+
       try {
         const roster =
           certs && certs.length > 0
@@ -760,6 +767,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
                 state,
                 institution_filters,
                 active_only,
+                controller.signal,
               );
 
         const candidateCerts = roster
@@ -805,6 +813,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
               start_repdte,
               end_repdte,
               "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+              controller.signal,
             ),
             include_demographics
               ? fetchSeriesRecords(
@@ -813,6 +822,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
                   start_repdte,
                   end_repdte,
                   "CERT,REPDTE,OFFTOT,OFFSTATE,CBSANAME",
+                  controller.signal,
                 )
               : Promise.resolve(new Map<number, InstitutionRecord[]>()),
           ]);
@@ -838,6 +848,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
               candidateCerts,
               [`REPDTE:${start_repdte}`, `REPDTE:${end_repdte}`],
               "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+              controller.signal,
             ),
             include_demographics
               ? fetchBatchedRecordsForDates(
@@ -845,6 +856,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
                   candidateCerts,
                   [`REPDTE:${start_repdte}`, `REPDTE:${end_repdte}`],
                   "CERT,REPDTE,OFFTOT,OFFSTATE,CBSANAME",
+                  controller.signal,
                 )
               : Promise.resolve(new Map<string, Map<number, InstitutionRecord>>()),
           ]);
@@ -911,7 +923,16 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
           structuredContent: output,
         };
       } catch (err) {
+        if (controller.signal.aborted) {
+          return formatToolError(
+            new Error(
+              `Analysis timed out after ${Math.floor(ANALYSIS_TIMEOUT_MS / 1000)} seconds. Narrow the comparison set with certs or institution_filters and try again.`,
+            ),
+          );
+        }
         return formatToolError(err);
+      } finally {
+        clearTimeout(timeoutId);
       }
     },
   );

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -342,28 +342,36 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toContain(
       "Compared 2 institutions from 20211231 to 20250630",
     );
-    expect(getMock).toHaveBeenNthCalledWith(1, "/institutions", {
-      params: {
-        fields: "CERT,NAME,CITY,STALP,ACTIVE",
-        filters: 'STNAME:"North Carolina" AND ACTIVE:1',
-        limit: 10000,
-        offset: 0,
-        output: "json",
-        sort_by: "CERT",
-        sort_order: "ASC",
-      },
-    });
-    expect(getMock).toHaveBeenNthCalledWith(2, "/financials", {
-      params: {
-        fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
-        filters: "(CERT:3510 OR CERT:9846) AND REPDTE:20211231",
-        limit: 10000,
-        offset: 0,
-        output: "json",
-        sort_by: "CERT",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenNthCalledWith(
+      1,
+      "/institutions",
+      expect.objectContaining({
+        params: {
+          fields: "CERT,NAME,CITY,STALP,ACTIVE",
+          filters: 'STNAME:"North Carolina" AND ACTIVE:1',
+          limit: 10000,
+          offset: 0,
+          output: "json",
+          sort_by: "CERT",
+          sort_order: "ASC",
+        },
+      }),
+    );
+    expect(getMock).toHaveBeenNthCalledWith(
+      2,
+      "/financials",
+      expect.objectContaining({
+        params: {
+          fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+          filters: "(CERT:3510 OR CERT:9846) AND REPDTE:20211231",
+          limit: 10000,
+          offset: 0,
+          output: "json",
+          sort_by: "CERT",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("returns time-series analysis with derived metrics and insights", async () => {
@@ -435,17 +443,66 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toContain(
       "using timeseries analysis",
     );
-    expect(getMock).toHaveBeenNthCalledWith(2, "/financials", {
+    expect(getMock).toHaveBeenNthCalledWith(
+      2,
+      "/financials",
+      expect.objectContaining({
+        params: {
+          fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
+          filters: "(CERT:3510) AND REPDTE:[20211231 TO 20250630]",
+          limit: 10000,
+          offset: 0,
+          output: "json",
+          sort_by: "REPDTE",
+          sort_order: "ASC",
+        },
+      }),
+    );
+  });
+
+  it("fails analysis requests that exceed the overall timeout budget", async () => {
+    const setTimeoutSpy = vi
+      .spyOn(global, "setTimeout")
+      .mockImplementation(((callback: TimerHandler) => {
+        queueMicrotask(() => {
+          if (typeof callback === "function") {
+            callback();
+          }
+        });
+        return 0 as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+
+    getMock.mockImplementation(
+      (_url: string, config?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          config?.signal?.addEventListener("abort", () => {
+            reject(new Error("canceled"));
+          });
+        }),
+    );
+
+    const responsePromise = mcpPost({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
       params: {
-        fields: "CERT,NAME,REPDTE,ASSET,DEP,NETINC,ROA,ROE",
-        filters: "(CERT:3510) AND REPDTE:[20211231 TO 20250630]",
-        limit: 10000,
-        offset: 0,
-        output: "json",
-        sort_by: "REPDTE",
-        sort_order: "ASC",
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+        },
       },
     });
+
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.isError).toBe(true);
+    expect(response.body.result.content[0].text).toContain(
+      "Analysis timed out after 90 seconds.",
+    );
+    setTimeoutSpy.mockRestore();
   });
 
   it("orders top-level insight summaries by the ranked comparisons", async () => {


### PR DESCRIPTION
Closes #4

## Summary
This PR adds a wall-clock timeout budget to `fdic_compare_bank_snapshots` so long multi-call analyses fail fast instead of running until each individual FDIC request times out on its own. The analysis tool now returns a clear narrowing hint when the overall budget is exhausted.

## Root Cause
The analysis workflow in `src/tools/analysis.ts` fans out into multiple FDIC requests, but only the underlying axios client in `src/services/fdicClient.ts` had a per-request timeout. A sequence of individually successful requests could therefore run for an arbitrarily long total time with no overall cap.

## Fix Strategy
I introduced a shared `AbortController` for the analysis request and threaded its signal through the FDIC client. Signals bypass the normal response cache so cancellation stays request-scoped, and the tool converts budget expiry into a user-facing analysis timeout error.

## Changes
| File | Change |
|------|--------|
| `src/services/fdicClient.ts` | Accept optional abort signals, bypass cache for signal-bound calls, and map canceled requests to a stable error. |
| `src/tools/analysis.ts` | Add a 90-second analysis timeout budget and propagate cancellation through roster, snapshot, and series fetches. |
| `tests/mcp-http.test.ts` | Add timeout-path coverage and update existing analysis assertions for the new cancellable request shape. |

## Validation
- Verified analysis requests abort with a clear timeout message after the shared budget expires.
- Verified existing snapshot and timeseries flows still pass with the new request signal.
- Ran `npm test`, `npm run typecheck`, and `npm run build`.

## Screenshots / Output (if applicable)
- `npm test`
- `npm run typecheck`
- `npm run build`