### PR TITLE
fix(#5): sort analysis insight summaries with results

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -858,10 +858,12 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             .filter((comparison): comparison is ComparisonRecord => comparison !== null);
         }
 
-        const ranked = sortComparisons(comparisons, sort_by, sort_order).slice(
-          0,
-          limit,
+        const sortedComparisons = sortComparisons(
+          comparisons,
+          sort_by,
+          sort_order,
         );
+        const ranked = sortedComparisons.slice(0, limit);
         const pagination = buildPaginationInfo(comparisons.length, 0, ranked.length);
         const output = {
           total_candidates: candidateCerts.length,
@@ -871,7 +873,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
           analysis_mode,
           sort_by,
           sort_order,
-          insights: buildTopLevelInsights(comparisons),
+          insights: buildTopLevelInsights(sortedComparisons),
           ...pagination,
           comparisons: ranked,
         };

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -441,4 +441,74 @@ describe("HTTP MCP server", () => {
       },
     });
   });
+
+  it("orders top-level insight summaries by the ranked comparisons", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank Slow", CITY: "Raleigh", STALP: "NC" } },
+            { data: { CERT: 2222, NAME: "Bank Fast", CITY: "Durham", STALP: "NC" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank Slow", REPDTE: "20211231", ASSET: 100, DEP: 100, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+            { data: { CERT: 2222, NAME: "Bank Fast", REPDTE: "20211231", ASSET: 100, DEP: 100, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank Slow", REPDTE: "20250630", ASSET: 130, DEP: 120, NETINC: 12, ROA: 1.1, ROE: 8.5 } },
+            { data: { CERT: 2222, NAME: "Bank Fast", REPDTE: "20250630", ASSET: 180, DEP: 160, NETINC: 15, ROA: 1.3, ROE: 9.0 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, REPDTE: "20211231", OFFTOT: 4, CBSANAME: "Raleigh" } },
+            { data: { CERT: 2222, REPDTE: "20211231", OFFTOT: 4, CBSANAME: "Durham" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, REPDTE: "20250630", OFFTOT: 5, CBSANAME: "Raleigh" } },
+            { data: { CERT: 2222, REPDTE: "20250630", OFFTOT: 6, CBSANAME: "Durham" } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          limit: 2,
+          sort_by: "asset_growth",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.structuredContent.insights.growth_with_branch_expansion,
+    ).toEqual(["Bank Fast", "Bank Slow"]);
+  });
 });


### PR DESCRIPTION
Closes #5

## Summary
This PR makes the top-level analysis insight buckets follow the same ranking order as the comparison results. The summary now reflects the sorted output the user sees instead of the original roster order.

## Root Cause
`fdic_compare_bank_snapshots` sorted `comparisons` for the returned result rows, but `buildTopLevelInsights` still received the unsorted array in `src/tools/analysis.ts`. Because each insight bucket sliced the first five matching names from that unsorted list, summary ordering could disagree with the ranked comparison table.

## Fix Strategy
I reused the already ranked comparison list as the source for insight summarization. That keeps the behavior simple and aligns the summary with the chosen `sort_by` and `sort_order` inputs without changing the underlying insight classification rules.

## Changes
| File | Change |
|------|--------|
| `src/tools/analysis.ts` | Build top-level insight buckets from the sorted comparison list before applying the result limit. |
| `tests/mcp-http.test.ts` | Add a regression case where roster order differs from ranking order. |

## Validation
- Verified the insight summary order now matches the ranked comparison order.
- Verified the main timeseries and snapshot analysis tests still pass.
- Ran `npm test` and `npm run build`.

## Screenshots / Output (if applicable)
- `npm test`
- `npm run build`