### PR TITLE
fix(#6): use exact quarter spans for analysis CAGR

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -160,14 +160,37 @@ function change(start: number | null, end: number | null): number | null {
   return end - start;
 }
 
-function yearsBetween(startRepdte: string, endRepdte: string): number {
+function getQuarterIndex(repdte: string): number | null {
+  const year = Number.parseInt(repdte.slice(0, 4), 10);
+  const month = Number.parseInt(repdte.slice(4, 6), 10);
+  const quarter = month / 3;
+
+  if (!Number.isInteger(quarter) || quarter < 1 || quarter > 4) {
+    return null;
+  }
+
+  return year * 4 + quarter;
+}
+
+export function yearsBetween(startRepdte: string, endRepdte: string): number {
+  const startQuarterIndex = getQuarterIndex(startRepdte);
+  const endQuarterIndex = getQuarterIndex(endRepdte);
+
+  if (startQuarterIndex !== null && endQuarterIndex !== null) {
+    return Math.max((endQuarterIndex - startQuarterIndex) / 4, 0);
+  }
+
   const start = new Date(
-    `${startRepdte.slice(0, 4)}-${startRepdte.slice(4, 6)}-${startRepdte.slice(6, 8)}`,
+    `${startRepdte.slice(0, 4)}-${startRepdte.slice(4, 6)}-${startRepdte.slice(6, 8)}T00:00:00Z`,
   );
   const end = new Date(
-    `${endRepdte.slice(0, 4)}-${endRepdte.slice(4, 6)}-${endRepdte.slice(6, 8)}`,
+    `${endRepdte.slice(0, 4)}-${endRepdte.slice(4, 6)}-${endRepdte.slice(6, 8)}T00:00:00Z`,
   );
-  return Math.max((end.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000), 0);
+
+  return Math.max(
+    (end.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000),
+    0,
+  );
 }
 
 function cagr(start: number | null, end: number | null, years: number): number | null {

--- a/tests/analysis.test.ts
+++ b/tests/analysis.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { yearsBetween } from "../src/tools/analysis.js";
+
+describe("yearsBetween", () => {
+  it("returns exact quarter-based year spans for FDIC reporting dates", () => {
+    expect(yearsBetween("20211231", "20250630")).toBe(3.5);
+    expect(yearsBetween("20240331", "20240630")).toBe(0.25);
+  });
+
+  it("clamps reversed ranges to zero", () => {
+    expect(yearsBetween("20250630", "20211231")).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #6

## Summary
This PR replaces the analysis tool's approximate year-span calculation with exact quarter-based spans for FDIC reporting dates. CAGR and related timeseries metrics now line up with quarter boundaries instead of depending on a 365.25-day approximation.

## Root Cause
`yearsBetween` in `src/tools/analysis.ts` converted report dates to `Date` objects and divided the day difference by `365.25`. FDIC analysis dates are quarter-end snapshots, so that approximation introduces small but avoidable errors in multi-quarter spans such as 0.25, 0.5, and 3.5 years.

## Fix Strategy
I changed the function to index quarter-end dates directly and compute elapsed years as exact quarter differences divided by four. For non-quarter dates, the existing calendar-based fallback remains in place so the helper stays resilient.

## Changes
| File | Change |
|------|--------|
| `src/tools/analysis.ts` | Add exact quarter indexing for `yearsBetween` with calendar fallback for non-quarter dates. |
| `tests/analysis.test.ts` | Add focused unit tests for exact quarterly spans and reversed ranges. |

## Validation
- Verified `20211231 -> 20250630` returns exactly `3.5` years.
- Verified `20240331 -> 20240630` returns exactly `0.25` years.
- Verified reversed ranges clamp to zero.
- Ran `npm test`, `npm run typecheck`, and `npm run build`.

## Screenshots / Output (if applicable)
- `npm test`
- `npm run typecheck`
- `npm run build`