### PR TITLE
fix(#5): add the missing top-level insight categories

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -323,6 +323,30 @@ function buildTopLevelInsights(comparisons: ComparisonRecord[]): Record<string, 
       )
       .slice(0, 5)
       .map((comparison) => String(comparison.name)),
+    deposit_mix_softening: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "deposit_mix_softening",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+    sustained_asset_growth: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "sustained_asset_growth",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
+    multi_quarter_roa_decline: comparisons
+      .filter((comparison) =>
+        (comparison.insights as string[] | undefined)?.includes(
+          "multi_quarter_roa_decline",
+        ),
+      )
+      .slice(0, 5)
+      .map((comparison) => String(comparison.name)),
   };
 }
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -575,6 +575,49 @@ describe("HTTP MCP server", () => {
     ).toEqual(["Bank Fast", "Bank Slow"]);
   });
 
+  it("includes all generated insight categories in the top-level summary", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          { data: { CERT: 1111, NAME: "Trend Bank", REPDTE: "20210331", ASSET: 100, DEP: 90, NETINC: 10, ROA: 1.4, ROE: 9.0 } },
+          { data: { CERT: 1111, NAME: "Trend Bank", REPDTE: "20210630", ASSET: 110, DEP: 85, NETINC: 9, ROA: 1.2, ROE: 8.8 } },
+          { data: { CERT: 1111, NAME: "Trend Bank", REPDTE: "20210930", ASSET: 120, DEP: 80, NETINC: 8, ROA: 1.0, ROE: 8.5 } },
+          { data: { CERT: 1111, NAME: "Trend Bank", REPDTE: "20211231", ASSET: 130, DEP: 75, NETINC: 7, ROA: 0.8, ROE: 8.2 } },
+          { data: { CERT: 2222, NAME: "Funding Bank", REPDTE: "20210331", ASSET: 200, DEP: 190, NETINC: 12, ROA: 0.9, ROE: 7.5 } },
+          { data: { CERT: 2222, NAME: "Funding Bank", REPDTE: "20210630", ASSET: 205, DEP: 170, NETINC: 11, ROA: 0.9, ROE: 7.4 } },
+          { data: { CERT: 2222, NAME: "Funding Bank", REPDTE: "20210930", ASSET: 210, DEP: 160, NETINC: 10, ROA: 0.8, ROE: 7.2 } },
+          { data: { CERT: 2222, NAME: "Funding Bank", REPDTE: "20211231", ASSET: 220, DEP: 150, NETINC: 9, ROA: 0.8, ROE: 7.0 } },
+        ],
+        meta: { total: 8 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 12,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          certs: [1111, 2222],
+          start_repdte: "20210331",
+          end_repdte: "20211231",
+          analysis_mode: "timeseries",
+          include_demographics: false,
+          limit: 2,
+          sort_by: "asset_growth",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.insights).toMatchObject({
+      deposit_mix_softening: ["Trend Bank", "Funding Bank"],
+      sustained_asset_growth: ["Trend Bank", "Funding Bank"],
+      multi_quarter_roa_decline: ["Trend Bank"],
+    });
+  });
+
   it("warns when the analysis roster is truncated by the FDIC API limit", async () => {
     getMock.mockImplementation(async (url: string) => {
       if (url === "/institutions") {


### PR DESCRIPTION
Closes #5

## Summary
This PR finishes the reopened `#5` scope by surfacing the remaining insight categories that were already being generated per comparison but never exposed in the top-level analysis summary. The analysis response now includes `deposit_mix_softening`, `sustained_asset_growth`, and `multi_quarter_roa_decline` alongside the previously returned summary buckets.

## Root Cause
`buildTopLevelInsights` in `src/tools/analysis.ts` only aggregated four insight labels even though `classifyInsights` and the timeseries summarizer could emit seven distinct categories. As a result, callers could see those tags on individual comparison rows without ever seeing them summarized in `structuredContent.insights`.

## Fix Strategy
I kept the existing summary shape and ordering behavior from the earlier fix, and extended the helper with the three missing categories using the same filter/slice/map pattern as the existing entries. This is the smallest change that closes the gap without changing how insights are classified.

## Changes
| File | Change |
|------|--------|
| `src/tools/analysis.ts` | Add `deposit_mix_softening`, `sustained_asset_growth`, and `multi_quarter_roa_decline` to `buildTopLevelInsights`. |
| `tests/mcp-http.test.ts` | Add a timeseries regression test proving the missing categories appear in the top-level insights summary. |

## Validation
- Verified the top-level insights summary now includes all three previously omitted categories.
- Verified the new coverage exercises both timeseries-added and classifier-added insight labels.
- Ran `npm test`, `npm run typecheck`, and `npm run build`.

## Screenshots / Output (if applicable)
- `npm test`
- `npm run typecheck`
- `npm run build`