### PR TITLE
docs: add client setup guidance and local deploy helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ STNAME:"California"
 # Numeric range (assets in $thousands)
 ASSET:[1000000 TO *]
 
-# Date range
+# Date range (hyphenated format for failures/history datasets)
 FAILDATE:[2008-01-01 TO 2010-12-31]
+
+# Date range (compact YYYYMMDD format for financials/demographics/summary datasets)
+REPDTE:[20230101 TO 20231231]
 
 # Combine with AND / OR
 STNAME:"Texas" AND ACTIVE:1 AND ASSET:[500000 TO *]
@@ -71,6 +74,23 @@ Field names vary by dataset. For example:
 Use the tool description or `fields` parameter to tailor queries to the dataset you are calling.
 
 ## Installation
+
+### From npm
+
+Run directly without a global install:
+
+```bash
+npx fdic-mcp-server
+```
+
+Or install globally:
+
+```bash
+npm install -g fdic-mcp-server
+fdic-mcp-server
+```
+
+### From source
 
 ```bash
 npm install
@@ -103,6 +123,8 @@ Publishing from GitHub Actions is intended to use npm trusted publishing via Git
 
 ## Usage
 
+Client-specific setup notes for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI are in [docs/clients.md](./docs/clients.md).
+
 ### CLI bundle
 
 The build produces two outputs:
@@ -116,6 +138,19 @@ node dist/index.js
 ```
 
 **Claude Desktop config** (`~/Library/Application\ Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "command": "npx",
+      "args": ["-y", "fdic-mcp-server"]
+    }
+  }
+}
+```
+
+If running from a local clone instead of the npm package:
 
 ```json
 {
@@ -178,7 +213,7 @@ sort_order: DESC
 (fdic_search_demographics)
 ```
 
-**Rank banks by growth across two dates without orchestrating many separate queries:**
+**Rank banks by growth across two snapshots (default `analysis_mode: snapshot`):**
 ```
 state: North Carolina
 start_repdte: 20211231
@@ -188,7 +223,7 @@ sort_order: DESC
 (fdic_compare_bank_snapshots)
 ```
 
-**Analyze quarterly trends with streaks and derived metrics:**
+**Analyze quarterly trends with streaks and derived metrics (`analysis_mode: timeseries`):**
 ```
 state: North Carolina
 start_repdte: 20211231
@@ -218,8 +253,22 @@ The tool can take either:
 Notable outputs from `fdic_compare_bank_snapshots`:
 - point-to-point changes for assets, deposits, net income, ROA, ROE, and office counts
 - derived metrics such as `assets_per_office_change`, `deposits_per_office_change`, and `deposits_to_assets_change`
-- insight tags such as `growth_with_better_profitability`, `growth_with_branch_expansion`, `balance_sheet_growth_without_profitability`, and `growth_with_branch_consolidation`
-- in `timeseries` mode, quarterly series plus streak metrics like sustained asset growth and multi-quarter ROA decline
+- insight tags (see [Insight Tags](#insight-tags) below)
+- in `timeseries` mode, quarterly series plus streak metrics
+
+### Insight Tags
+
+The analysis tool assigns insight tags to individual comparisons and aggregates them in a top-level `insights` summary. All possible tags:
+
+| Tag | Meaning |
+|-----|---------|
+| `growth_with_better_profitability` | Asset growth >= 25%, deposit growth >= 15%, and ROA improved |
+| `growth_with_branch_expansion` | Asset growth >= 25%, deposit growth >= 15%, and office count increased |
+| `balance_sheet_growth_without_profitability` | Asset growth >= 20% but ROA and ROE both flat or declining |
+| `growth_with_branch_consolidation` | Positive asset growth while office count decreased |
+| `deposit_mix_softening` | Deposits declined both in absolute terms and as a share of total assets |
+| `sustained_asset_growth` | (timeseries only) Three or more consecutive quarters of rising assets |
+| `multi_quarter_roa_decline` | (timeseries only) Two or more consecutive quarters of falling ROA |
 
 ## Response Shape
 
@@ -253,6 +302,50 @@ Typical lookup miss response shape:
   "message": "No institution found with CERT number 999999999."
 }
 ```
+
+Typical analysis response shape (`fdic_compare_bank_snapshots`):
+
+```json
+{
+  "total_candidates": 150,
+  "analyzed_count": 142,
+  "start_repdte": "20211231",
+  "end_repdte": "20250630",
+  "analysis_mode": "snapshot",
+  "sort_by": "asset_growth",
+  "sort_order": "DESC",
+  "warnings": [],
+  "insights": {
+    "growth_with_better_profitability": ["Bank A", "Bank B"],
+    "growth_with_branch_expansion": ["Bank A"],
+    "balance_sheet_growth_without_profitability": [],
+    "growth_with_branch_consolidation": ["Bank C"],
+    "deposit_mix_softening": [],
+    "sustained_asset_growth": [],
+    "multi_quarter_roa_decline": []
+  },
+  "total": 142,
+  "offset": 0,
+  "count": 10,
+  "has_more": true,
+  "next_offset": 10,
+  "comparisons": [
+    {
+      "cert": 12345,
+      "name": "Bank A",
+      "asset_growth": 50000,
+      "asset_growth_pct": 45.2,
+      "insights": ["growth_with_better_profitability", "growth_with_branch_expansion"]
+    }
+  ]
+}
+```
+
+The `warnings` array is populated when the server detects a data issue, such as the institution roster being truncated because it exceeded the FDIC API's per-request limit.
+
+In most successful analyses, `warnings` will be empty.
+
+The `sustained_asset_growth` and `multi_quarter_roa_decline` insight summaries are only populated for `analysis_mode: "timeseries"`.
 
 ## Data Notes
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,165 @@
+# Client Setup
+
+This page collects minimal setup notes for common MCP clients.
+
+The examples below assume you already installed the published package:
+
+```bash
+npm install -g fdic-mcp-server
+```
+
+On this machine, that installs the binary at:
+
+```bash
+/opt/homebrew/bin/fdic-mcp-server
+```
+
+If your global npm prefix differs, adjust the path accordingly.
+
+Client support changes quickly. Treat the linked official docs as the source of truth.
+
+Last verified: March 15, 2026.
+
+## Claude Desktop
+
+Config file:
+
+```text
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "command": "/opt/homebrew/bin/fdic-mcp-server"
+    }
+  }
+}
+```
+
+After editing the file, restart Claude Desktop.
+
+## ChatGPT
+
+ChatGPT Developer Mode supports MCP apps/connectors, but it expects a remote MCP server over streaming HTTP or SSE, not a local stdio process. This means you cannot point ChatGPT directly at `/opt/homebrew/bin/fdic-mcp-server` unless you expose it through the server's HTTP transport.
+
+Run the server over HTTP:
+
+```bash
+TRANSPORT=http PORT=3000 /opt/homebrew/bin/fdic-mcp-server
+```
+
+Then expose it at a reachable HTTPS URL, for example through a tunnel or your own deployment.
+
+In ChatGPT:
+
+1. Go to `Settings -> Apps -> Advanced settings -> Developer mode` and enable Developer mode.
+2. Open the Apps settings page and create an app for your MCP server.
+3. Use your remote MCP URL.
+4. Refresh tools from the app details page if needed.
+
+Notes:
+- ChatGPT supports streaming HTTP and SSE for MCP apps.
+- ChatGPT Developer Mode availability depends on plan and workspace settings.
+- For Business and Enterprise/Edu workspaces, admins may need to allow custom apps first.
+
+Official docs:
+- OpenAI Developer Mode: https://developers.openai.com/api/docs/guides/developer-mode
+- OpenAI Apps in ChatGPT help: https://help.openai.com/en/articles/11487775
+
+## Gemini CLI
+
+Gemini CLI supports MCP servers through `~/.gemini/settings.json` for user scope or `.gemini/settings.json` for project scope.
+
+Config example:
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "command": "/opt/homebrew/bin/fdic-mcp-server",
+      "trust": true
+    }
+  }
+}
+```
+
+CLI-based setup:
+
+```bash
+gemini mcp add -s user --trust fdic /opt/homebrew/bin/fdic-mcp-server
+```
+
+Verification:
+
+```bash
+gemini mcp list
+```
+
+Notes:
+- Gemini CLI uses stdio for local MCP servers by default.
+- If the current folder is untrusted, local stdio MCP servers may appear disconnected until you trust the folder.
+
+Official docs:
+- Gemini CLI MCP guide: https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md
+
+## GitHub Copilot CLI
+
+GitHub Copilot CLI supports local MCP servers through `~/.copilot/mcp-config.json`.
+
+Config example:
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "type": "local",
+      "command": "/opt/homebrew/bin/fdic-mcp-server",
+      "env": {},
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+CLI-based setup:
+
+```bash
+/mcp add
+```
+
+Or edit the config file directly, then check:
+
+```bash
+/mcp show
+```
+
+Notes:
+- The built-in GitHub MCP server is separate; these instructions are only for adding this FDIC server.
+- Copilot CLI makes newly added MCP servers available immediately without a restart.
+
+Official docs:
+- GitHub Copilot CLI MCP setup: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+
+## Other MCP Hosts
+
+Many other MCP hosts accept the same basic stdio pattern:
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "command": "/opt/homebrew/bin/fdic-mcp-server"
+    }
+  }
+}
+```
+
+Before documenting a specific host in this repo, verify:
+- that it currently supports MCP
+- whether it expects local stdio, remote HTTP, or both
+- where its config file lives
+- whether it requires a restart or explicit enable step

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "pack:check": "npm pack --dry-run",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "deploy:local": "bash scripts/deploy-local.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+failures=()
+
+steps=("typecheck" "test" "build")
+
+for step in "${steps[@]}"; do
+  echo ""
+  echo "=== Running: npm run $step ==="
+  echo ""
+  if npm run "$step"; then
+    echo ""
+    echo "  ✓ $step passed"
+  else
+    echo ""
+    echo "  ✗ $step failed"
+    failures+=("$step")
+  fi
+done
+
+echo ""
+echo "==============================="
+echo "  Summary"
+echo "==============================="
+
+for step in "${steps[@]}"; do
+  if printf '%s\n' "${failures[@]}" | grep -qx "$step" 2>/dev/null; then
+    echo "  ✗ $step"
+  else
+    echo "  ✓ $step"
+  fi
+done
+
+echo ""
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo "Skipping install — ${#failures[@]} step(s) failed: ${failures[*]}"
+  exit 1
+fi
+
+echo "All checks passed. Installing globally..."
+echo ""
+npm install -g .
+echo ""
+echo "Done. $(node -e "console.log(require('./package.json').name + '@' + require('./package.json').version)") installed globally."


### PR DESCRIPTION
## Summary
This PR adds a dedicated client setup guide for common MCP hosts and improves the README's installation and analysis-response documentation. It also adds a `deploy:local` helper that runs the repo checks before installing the package globally, making local validation and deployment a single command.

## Root Cause
The repo documented source usage well, but it did not provide a stable place for client-specific MCP setup instructions for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI. Separately, there was no one-step local deployment workflow, so validating and reinstalling the package required running multiple commands manually.

## Fix Strategy
I kept the volatile client-specific setup guidance out of the main README by moving it into `docs/clients.md` and linking to it from the usage section. For local deployment, I added a small shell script and npm script that preserve the current validation steps and only install globally if all checks pass.

## Changes
| File | Change |
|------|--------|
| `README.md` | Clarify npm usage, link to the client setup guide, expand analysis/response docs, and improve the Claude Desktop example. |
| `docs/clients.md` | Add a separate client setup guide for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI. |
| `scripts/deploy-local.sh` | Add a local deploy helper that runs typecheck, test, and build before `npm install -g .`. |
| `package.json` | Add the `deploy:local` npm script. |

## Validation
- Verified the README and client guide changes are internally consistent with the published package install path and current MCP client patterns.
- Ran `npm run typecheck`, `npm test`, and `npm run build`.
- Ran `npm run deploy:local` and confirmed it completed the checks and global install successfully.

## Screenshots / Output (if applicable)
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run deploy:local`