### PR TITLE
Add fdic_peer_group_analysis tool for peer group ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An MCP (Model Context Protocol) server that provides access to the [FDIC BankFin
 ## Features
 
 - **No API key required** — The FDIC BankFind API is publicly available
-- **11 tools** covering BankFind datasets plus a built-in comparative analysis tool
+- **12 tools** covering BankFind datasets plus built-in analytical tools
 - **Flexible ElasticSearch-style filtering** on all endpoints
 - **Pagination support** for large result sets
 - **Dual transport**: stdio (local) or HTTP (remote)
@@ -28,15 +28,17 @@ An MCP (Model Context Protocol) server that provides access to the [FDIC BankFin
 | `fdic_search_sod` | Search Summary of Deposits (branch-level deposit data) |
 | `fdic_search_demographics` | Search quarterly demographics and market-structure data |
 | `fdic_compare_bank_snapshots` | Compare two reporting snapshots across banks and rank growth/profitability changes |
+| `fdic_peer_group_analysis` | Build a peer group and rank an institution against peers on financial metrics |
+
+Two tools are server-side analysis helpers:
+- `fdic_compare_bank_snapshots` batches roster lookup, financial snapshots, and optional demographics snapshots inside the MCP server so complex trend prompts do not require many separate tool calls
+- `fdic_peer_group_analysis` builds a peer group from asset size, charter class, and geography criteria, then ranks an institution against peers on financial and efficiency metrics
 
 Two tools are convenience lookups rather than separate BankFind datasets:
 - `fdic_get_institution` wraps the `institutions` dataset
 - `fdic_get_institution_failure` wraps the `failures` dataset
 
-One tool is a server-side analysis helper:
-- `fdic_compare_bank_snapshots` batches roster lookup, financial snapshots, and optional demographics snapshots inside the MCP server so complex trend prompts do not require many separate tool calls
-- It supports both `snapshot` comparisons and `timeseries` analysis across a quarterly range
-- It computes derived efficiency and balance-sheet metrics and assigns insight tags for notable growth patterns
+`fdic_compare_bank_snapshots` supports both `snapshot` comparisons and `timeseries` analysis across a quarterly range. It computes derived efficiency and balance-sheet metrics and assigns insight tags for notable growth patterns
 
 ## Filter Syntax
 
@@ -233,6 +235,45 @@ sort_by: asset_growth_pct
 sort_order: DESC
 (fdic_compare_bank_snapshots)
 ```
+
+**Find peers for a specific bank (auto-derived criteria):**
+```
+cert: 29846
+repdte: 20241231
+(fdic_peer_group_analysis)
+```
+
+**Define a peer group with explicit criteria:**
+```
+repdte: 20241231
+asset_min: 5000000
+asset_max: 20000000
+charter_classes: ["N"]
+state: NC
+(fdic_peer_group_analysis)
+```
+
+**Override auto-derived defaults:**
+```
+cert: 29846
+repdte: 20241231
+asset_min: 3000000
+state: NC
+(fdic_peer_group_analysis)
+```
+
+## Peer Group Analysis
+
+The `fdic_peer_group_analysis` tool builds a peer group for a bank and ranks it against peers on financial and efficiency metrics at a single report date.
+
+The tool returns rankings (competition rank + percentile) and peer group medians for:
+- Total Assets, Total Deposits, ROA, ROE, Net Interest Margin
+- Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
+- Deposits-to-Assets Ratio, Non-Interest Income Share
+
+The subject bank is excluded from the peer set and ranking denominators. Ranking denominators are metric-specific — if some peers lack data for a metric, the denominator reflects only peers with valid values.
+
+Peer CERTs from the response can be passed to `fdic_compare_bank_snapshots` for trend analysis across the peer group.
 
 ## Complex Prompts
 

--- a/docs/plans/2026-03-15-peer-group-analysis-design.md
+++ b/docs/plans/2026-03-15-peer-group-analysis-design.md
@@ -1,0 +1,301 @@
+# Peer Group Analysis Tool Design
+
+## Overview
+
+A new `fdic_peer_group_analysis` tool that builds a peer group for an FDIC-insured institution and ranks it against peers on key financial and efficiency metrics at a single report date. The tool is stateless — peer group CERTs are returned in the response and can be passed to `fdic_compare_bank_snapshots` for trend analysis.
+
+## Input Schema
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cert` | number, optional | — | Subject institution CERT. Auto-derives peer criteria; ranks this bank against peers. |
+| `repdte` | string, required | — | Report date in YYYYMMDD format. |
+| `asset_min` | number, optional | 50% of subject's report-date assets | Minimum total assets ($thousands). |
+| `asset_max` | number, optional | 200% of subject's report-date assets | Maximum total assets ($thousands). |
+| `charter_classes` | string[], optional | [subject's BKCLASS] | Charter class codes to include (e.g., ["N", "SM"]). |
+| `state` | string, optional | — | Two-letter state code (e.g., "NC", "TX"). |
+| `raw_filter` | string, optional | — | Advanced: raw ElasticSearch query string for peer selection. Appended to other criteria with AND. Not validated beyond what the FDIC API accepts. |
+| `active_only` | boolean | true | Limit to institutions where ACTIVE:1 (currently operating, FDIC-insured). |
+| `extra_fields` | string[], optional | — | Additional FDIC field names to include as raw values in the response payload. Does not affect peer selection. |
+| `limit` | number | 50 | Max peer records returned in the response. All matched peers are used for percentile/rank computation regardless of this limit. |
+
+### Three Usage Modes
+
+**Subject-driven (auto-build):**
+```json
+{ "cert": 29846, "repdte": "20241231" }
+```
+
+**Explicit criteria:**
+```json
+{ "repdte": "20241231", "asset_min": 5000000, "asset_max": 20000000, "charter_classes": ["N"], "state": "NC" }
+```
+
+**Subject with overrides:**
+```json
+{ "cert": 29846, "repdte": "20241231", "asset_min": 3000000, "state": "NC" }
+```
+
+### Override Precedence
+
+When `cert` is provided, the tool looks up the subject institution's profile and report-date financials, then derives defaults for `asset_min`, `asset_max`, and `charter_classes`. Any explicitly provided parameter overrides the derived default. Explicit parameters without `cert` are used as-is with no derivation.
+
+### Validation Rules
+
+- `repdte` is always required.
+- At least one peer-group constructor is required: `cert`, `asset_min`, `asset_max`, `charter_classes`, `state`, or `raw_filter`.
+- If both `asset_min` and `asset_max` are provided, `asset_min` must be <= `asset_max`.
+- If `cert` is provided and no institution is found for that CERT, return an error.
+- If `cert` is provided but the subject has no financial data for `repdte`, return an error explaining that auto-derivation requires asset data at the specified report date.
+- `state` must be exactly 2 uppercase letters when provided.
+
+## Output Shape
+
+### Structural Rules
+
+- **Subject is excluded from peers.** The subject bank does not appear in the `peers` array and is not counted in ranking denominators. Rankings answer "how does the subject compare against its peers."
+- **Medians exclude the subject.** `peer_group.medians` is computed from the peer set only.
+- **Null metric handling:** Percentile/rank denominators are metric-specific. If 27 peers exist but only 24 have valid ROE, then `"of": 24` for ROE. Medians are computed from non-null values only. If the subject's value for a metric is null, that metric's ranking entry is `null`.
+- **Consistent field placement:** Balance-sheet fields (`asset`, `dep`) and derived ratios all live inside `metrics` for both subject and peers. Identification fields (`cert`, `name`, `city`, `stalp`) are top-level.
+
+### Response Structure
+
+```json
+{
+  "subject": {
+    "cert": 29846,
+    "name": "Live Oak Banking Company",
+    "city": "Wilmington",
+    "stalp": "NC",
+    "bkclass": "NM",
+    "metrics": {
+      "asset": 11200000,
+      "dep": 9800000,
+      "roa": 1.25,
+      "roe": 12.8,
+      "netnim": 3.45,
+      "equity_ratio": 9.8,
+      "efficiency_ratio": 58.2,
+      "loan_to_deposit": 0.87,
+      "deposits_to_assets": 0.875,
+      "noninterest_income_share": 0.12
+    },
+    "rankings": {
+      "asset": { "rank": 2, "of": 27, "percentile": 93 },
+      "roa": { "rank": 3, "of": 27, "percentile": 89 },
+      "roe": { "rank": 5, "of": 24, "percentile": 79 },
+      "netnim": { "rank": 8, "of": 27, "percentile": 70 },
+      "equity_ratio": { "rank": 12, "of": 27, "percentile": 56 },
+      "efficiency_ratio": { "rank": 6, "of": 27, "percentile": 78 },
+      "loan_to_deposit": { "rank": 15, "of": 27, "percentile": 44 },
+      "deposits_to_assets": { "rank": 10, "of": 27, "percentile": 63 },
+      "noninterest_income_share": { "rank": 4, "of": 25, "percentile": 84 }
+    }
+  },
+  "peer_group": {
+    "repdte": "20241231",
+    "criteria_used": {
+      "asset_min": 5600000,
+      "asset_max": 22400000,
+      "charter_classes": ["NM"],
+      "state": null,
+      "active_only": true,
+      "raw_filter": null
+    },
+    "medians": {
+      "asset": 9500000,
+      "dep": 7800000,
+      "roa": 0.95,
+      "roe": 9.2,
+      "netnim": 3.1,
+      "equity_ratio": 10.1,
+      "efficiency_ratio": 65.0,
+      "loan_to_deposit": 0.82,
+      "deposits_to_assets": 0.84,
+      "noninterest_income_share": 0.08
+    }
+  },
+  "metric_definitions": {
+    "asset": { "higher_is_better": true, "unit": "$thousands", "label": "Total Assets" },
+    "dep": { "higher_is_better": true, "unit": "$thousands", "label": "Total Deposits" },
+    "roa": { "higher_is_better": true, "unit": "%", "label": "Return on Assets" },
+    "roe": { "higher_is_better": true, "unit": "%", "label": "Return on Equity" },
+    "netnim": { "higher_is_better": true, "unit": "%", "label": "Net Interest Margin" },
+    "equity_ratio": { "higher_is_better": true, "unit": "%", "label": "Equity Capital Ratio" },
+    "efficiency_ratio": { "higher_is_better": false, "unit": "%", "label": "Efficiency Ratio" },
+    "loan_to_deposit": { "higher_is_better": null, "unit": "ratio", "label": "Loan-to-Deposit Ratio", "ranking_note": "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent." },
+    "deposits_to_assets": { "higher_is_better": null, "unit": "ratio", "label": "Deposits-to-Assets Ratio", "ranking_note": "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent." },
+    "noninterest_income_share": { "higher_is_better": true, "unit": "ratio", "label": "Non-Interest Income Share" }
+  },
+  "peers": [
+    {
+      "cert": 12345,
+      "name": "Some Peer Bank",
+      "city": "Raleigh",
+      "stalp": "NC",
+      "metrics": {
+        "asset": 10500000,
+        "dep": 8200000,
+        "roa": 1.1,
+        "roe": 10.5,
+        "netnim": 3.2,
+        "equity_ratio": 10.5,
+        "efficiency_ratio": 62.0,
+        "loan_to_deposit": 0.85,
+        "deposits_to_assets": 0.78,
+        "noninterest_income_share": 0.09
+      }
+    }
+  ],
+  "peer_count": 27,
+  "returned_count": 27,
+  "has_more": false,
+  "message": null,
+  "warnings": []
+}
+```
+
+### Key Notes
+
+- `subject` is present only when `cert` was provided. Omitted in explicit-criteria-only mode.
+- `peer_count` is the single source of truth for the analytical universe size (post-financial-filtering). It appears only at the top level.
+- `message` is a single human-readable informational string or null.
+- `warnings` is a string array for non-fatal issues (e.g., roster truncation).
+- `extra_fields` values appear as additional keys inside each peer's top-level object, not inside `metrics`, clearly separated from computed metrics.
+- `metric_definitions` is always present, giving downstream consumers the context to interpret rankings correctly.
+
+### Empty Peer Set
+
+Returns `peer_count: 0`, empty `medians` (all null), empty `peers`, no `rankings` on subject, `message` with a factual statement, and `metric_definitions` still included.
+
+## Computation Pipeline
+
+### Phase 1 — Resolve Subject (if `cert` provided)
+
+Two parallel queries:
+- `institutions` endpoint: `CERT:{cert}` for profile fields (`NAME`, `CITY`, `STALP`, `BKCLASS`).
+- `financials` endpoint: `CERT:{cert} AND REPDTE:{repdte}` for report-date financial data.
+
+If the institution is not found, return an error. If financials are not found for `repdte`, return an error: "No financial data for CERT {cert} at report date {repdte}. Auto-derivation of peer criteria requires asset data at the specified report date."
+
+Derive defaults from the **financials** record's `ASSET`:
+- `asset_min` default = `ASSET * 0.5`
+- `asset_max` default = `ASSET * 2.0`
+- `charter_classes` default = `[BKCLASS]` (from institutions profile)
+
+Explicit parameters override derived values.
+
+### Phase 2 — Build Peer Roster
+
+Query the `institutions` endpoint with assembled criteria:
+- `ASSET:[{asset_min} TO {asset_max}]` (when either bound is set)
+- `BKCLASS:{class}` joined with OR (when `charter_classes` is set)
+- `STALP:{state}` (when `state` is set)
+- `ACTIVE:1` (when `active_only` is true)
+- Any `raw_filter` appended with AND
+
+Use `limit: 10_000`. If `response.meta.total > records.length`, the roster is truncated — add a warning to the `warnings` array. Remove the subject CERT from results if present.
+
+### Phase 3 — Fetch Peer Financials
+
+Query the `financials` endpoint for `REPDTE:{repdte}` across all peer CERTs using the same batched-chunking pattern as `fdic_compare_bank_snapshots` (chunks of 25 CERTs, max 4 concurrent requests).
+
+Fields requested: `CERT,ASSET,DEP,NETINC,ROA,ROE,NETNIM,EQTOT,LNLSNET,INTINC,EINTEXP,NONII,NONIX` plus any `extra_fields`.
+
+Peers missing financial data for `repdte` are dropped from the analytical universe. Peers with financial data but some null derived metrics remain in the universe — they are excluded only from per-metric ranking denominators where their value is null.
+
+`peer_count` reflects the post-financial-filtering analytical universe.
+
+### Phase 4 — Compute Metrics, Rank, and Assemble
+
+**Derived metrics** (for subject and all peers):
+- `equity_ratio` = `EQTOT / ASSET * 100` (null if ASSET is 0 or either value is null)
+- `efficiency_ratio` = `NONIX / (net_interest_income + NONII) * 100` where `net_interest_income = INTINC - EINTEXP` (null if denominator is <= 0, or any input is null)
+- `loan_to_deposit` = `LNLSNET / DEP` (null if DEP is 0 or either is null)
+- `deposits_to_assets` = `DEP / ASSET` (null if ASSET is 0 or either is null)
+- `noninterest_income_share` = `NONII / (net_interest_income + NONII)` (null if denominator is <= 0, or any input is null)
+
+**Ranking uses competition rank** (`1, 2, 2, 4`): tied values receive the same rank, and the next rank skips by the number of ties. The subject receives the same competition rank as peers with equal values.
+
+For each metric:
+1. Collect non-null values from peers only (subject excluded).
+2. For `higher_is_better: true` — sort descending. For `higher_is_better: false` — sort ascending. For `higher_is_better: null` — sort descending.
+3. Assign competition ranks to the sorted peer values.
+4. Determine where the subject's value would rank using the same competition-rank logic. The subject receives the same rank as peers with equal values.
+5. `of` = count of peers with non-null values for this metric.
+6. Percentile = `(1 - (rank - 1) / of) * 100`, rounded to nearest integer. Top-ranked bank receives 100th percentile.
+7. If subject's metric value is null, its ranking entry for that metric is `null`.
+
+Compute medians from non-null peer values only (subject excluded).
+
+Sort `peers` by `asset` descending. Truncate to `limit`. Set `returned_count` = length of truncated array, `has_more` = `peer_count > returned_count`.
+
+**Timeout:** 90-second `AbortController` budget.
+
+**Caching:** Relies on existing `queryCache` in `fdicClient.ts`.
+
+## Text Output Formatting
+
+Text uses human-readable dates (e.g., "December 31, 2024" instead of "20241231"). Metric order is fixed and identical across subject rankings, medians, and peer rows: asset, dep, roa, roe, netnim, equity_ratio, efficiency_ratio, loan_to_deposit, deposits_to_assets, noninterest_income_share.
+
+### With Subject
+
+```
+Peer group analysis for Live Oak Banking Company (CERT 29846) as of December 31, 2024.
+27 peers matched (asset range $5,600,000k-$22,400,000k, charter classes: NM, active only).
+
+Subject rankings:
+  Total Assets:              rank 2 of 27  (93rd percentile)  $11,200,000k  median: $9,500,000k
+  Return on Assets:          rank 3 of 27  (89th percentile)  1.2500%       median: 0.9500%
+  Return on Equity:          rank 5 of 24  (79th percentile)  12.8000%      median: 9.2000%
+  Net Interest Margin:       rank 8 of 27  (70th percentile)  3.4500%       median: 3.1000%
+  Equity Capital Ratio:      rank 12 of 27 (56th percentile)  9.8000%       median: 10.1000%
+  Efficiency Ratio:          rank 6 of 27  (78th percentile)  58.2000%      median: 65.0000%
+  Loan-to-Deposit Ratio:     rank 15 of 27 (44th percentile)  0.8700        median: 0.8200
+  Deposits-to-Assets Ratio:  rank 10 of 27 (63rd percentile)  0.8750        median: 0.8400
+  Non-Interest Income Share: rank 4 of 25  (84th percentile)  0.1200        median: 0.0800
+
+Peers (27 returned):
+1. Some Peer Bank, Raleigh NC (CERT 12345) | Asset: $10,500,000k | ROA: 1.1000% | ROE: 10.5000%
+2. Another Bank, Charlotte NC (CERT 67890) | Asset: $9,800,000k | ROA: 0.9500% | ROE: 8.7000%
+```
+
+### Without Subject (explicit-criteria mode)
+
+```
+Peer group analysis as of December 31, 2024.
+27 institutions matched (asset range $5,000,000k-$20,000,000k, charter classes: N, state: NC, active only).
+
+Peer group medians:
+  Total Assets: $9,500,000k | ROA: 0.9500% | ROE: 9.2000% | Efficiency: 65.0000% | ...
+
+Peers (27 returned):
+1. ...
+```
+
+### Empty Peer Set
+
+```
+Peer group analysis for Live Oak Banking Company (CERT 29846) as of December 31, 2024.
+0 peers matched (asset range $5,600,000k-$22,400,000k, charter classes: NM, active only).
+```
+
+### Formatting Rules
+
+- Text is truncated at the existing CHARACTER_LIMIT (50,000 chars) with the standard truncation suffix.
+- Peer list in text shows up to `limit` peers, sorted by asset descending.
+- Each peer row shows identification plus 3-4 key metrics (asset, ROA, ROE). When the peer group spans multiple states or charter classes, `stalp` and/or `bkclass` are included in peer rows.
+- Warnings are prepended with "Warning: " prefix.
+- Null metrics display as "n/a".
+- Contextual metrics (loan_to_deposit, deposits_to_assets) are presented neutrally — no language implying "better" or "worse."
+
+## Composability with Existing Tools
+
+The peer CERTs in the `peers` array can be extracted and passed to `fdic_compare_bank_snapshots` for trend analysis:
+
+1. Call `fdic_peer_group_analysis` with `cert: 29846, repdte: "20241231"` → get peer CERTs.
+2. Call `fdic_compare_bank_snapshots` with `certs: [extracted peer CERTs], start_repdte: "20211231", end_repdte: "20241231"` → get growth/profitability trends across the peer group.
+
+This keeps the peer group tool focused on single-date positioning and avoids duplicating time-series logic.

--- a/docs/plans/2026-03-15-peer-group-analysis-plan.md
+++ b/docs/plans/2026-03-15-peer-group-analysis-plan.md
@@ -1,0 +1,1574 @@
+# Peer Group Analysis Tool — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an `fdic_peer_group_analysis` tool that builds a peer group for a bank and ranks it against peers on financial and efficiency metrics at a single report date.
+
+**Architecture:** Single new tool module (`src/tools/peerGroup.ts`) following the existing pattern of `analysis.ts`. Pure computation functions are exported for unit testing. The tool registers via `registerPeerGroupTools()` called from `src/index.ts`. Reuses existing `fdicClient.ts` infrastructure (queryEndpoint, batched chunking, caching, timeout pattern).
+
+**Tech Stack:** TypeScript, Zod (input validation), vitest (testing), existing MCP SDK registration pattern.
+
+**Design doc:** `docs/plans/2026-03-15-peer-group-analysis-design.md`
+
+---
+
+### Task 1: Pure computation functions — deriveMetrics and computeMedian
+
+**Files:**
+- Create: `src/tools/peerGroup.ts`
+- Create: `tests/peerGroup.test.ts`
+
+**Step 1: Write the failing tests**
+
+In `tests/peerGroup.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveMetrics,
+  computeMedian,
+} from "../src/tools/peerGroup.js";
+
+describe("deriveMetrics", () => {
+  it("computes all derived metrics from raw financial fields", () => {
+    const result = deriveMetrics({
+      ASSET: 1000,
+      DEP: 800,
+      ROA: 1.5,
+      ROE: 12.0,
+      NETNIM: 3.5,
+      EQTOT: 100,
+      LNLSNET: 600,
+      INTINC: 50,
+      EINTEXP: 15,
+      NONII: 10,
+      NONIX: 25,
+    });
+
+    expect(result.asset).toBe(1000);
+    expect(result.dep).toBe(800);
+    expect(result.roa).toBe(1.5);
+    expect(result.roe).toBe(12.0);
+    expect(result.netnim).toBe(3.5);
+    expect(result.equity_ratio).toBeCloseTo(10.0);
+    expect(result.efficiency_ratio).toBeCloseTo(55.556, 2);
+    expect(result.loan_to_deposit).toBeCloseTo(0.75);
+    expect(result.deposits_to_assets).toBeCloseTo(0.8);
+    expect(result.noninterest_income_share).toBeCloseTo(0.2222, 3);
+  });
+
+  it("returns null for equity_ratio when ASSET is zero", () => {
+    const result = deriveMetrics({
+      ASSET: 0, DEP: 800, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25,
+    });
+    expect(result.equity_ratio).toBeNull();
+    expect(result.deposits_to_assets).toBeNull();
+  });
+
+  it("returns null for efficiency_ratio when denominator is zero or negative", () => {
+    const result = deriveMetrics({
+      ASSET: 1000, DEP: 800, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 10, EINTEXP: 15, NONII: 5, NONIX: 25,
+    });
+    // net_interest_income = 10 - 15 = -5, denominator = -5 + 5 = 0
+    expect(result.efficiency_ratio).toBeNull();
+    expect(result.noninterest_income_share).toBeNull();
+  });
+
+  it("returns null for loan_to_deposit when DEP is zero", () => {
+    const result = deriveMetrics({
+      ASSET: 1000, DEP: 0, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25,
+    });
+    expect(result.loan_to_deposit).toBeNull();
+  });
+
+  it("handles null input fields gracefully", () => {
+    const result = deriveMetrics({
+      ASSET: null, DEP: null, ROA: null, ROE: null, NETNIM: null,
+      EQTOT: null, LNLSNET: null, INTINC: null, EINTEXP: null, NONII: null, NONIX: null,
+    });
+    expect(result.asset).toBeNull();
+    expect(result.equity_ratio).toBeNull();
+    expect(result.efficiency_ratio).toBeNull();
+  });
+});
+
+describe("computeMedian", () => {
+  it("returns the middle value for an odd-length array", () => {
+    expect(computeMedian([1, 3, 5])).toBe(3);
+  });
+
+  it("returns the average of middle values for an even-length array", () => {
+    expect(computeMedian([1, 3, 5, 7])).toBe(4);
+  });
+
+  it("returns the single value for a one-element array", () => {
+    expect(computeMedian([42])).toBe(42);
+  });
+
+  it("returns null for an empty array", () => {
+    expect(computeMedian([])).toBeNull();
+  });
+
+  it("does not modify the input array", () => {
+    const input = [5, 1, 3];
+    computeMedian(input);
+    expect(input).toEqual([5, 1, 3]);
+  });
+});
+```
+
+**Step 2: Create the source file with minimal exports to make tests pass**
+
+In `src/tools/peerGroup.ts`:
+
+```typescript
+type RawFinancials = Record<string, unknown>;
+
+export interface DerivedMetrics {
+  asset: number | null;
+  dep: number | null;
+  roa: number | null;
+  roe: number | null;
+  netnim: number | null;
+  equity_ratio: number | null;
+  efficiency_ratio: number | null;
+  loan_to_deposit: number | null;
+  deposits_to_assets: number | null;
+  noninterest_income_share: number | null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function safeRatio(
+  numerator: number | null,
+  denominator: number | null,
+): number | null {
+  if (numerator === null || denominator === null || denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function safeRatioPositiveDenom(
+  numerator: number | null,
+  denominator: number | null,
+): number | null {
+  if (
+    numerator === null ||
+    denominator === null ||
+    denominator <= 0
+  ) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+export function deriveMetrics(raw: RawFinancials): DerivedMetrics {
+  const asset = asNumber(raw.ASSET);
+  const dep = asNumber(raw.DEP);
+  const eqtot = asNumber(raw.EQTOT);
+  const lnlsnet = asNumber(raw.LNLSNET);
+  const intinc = asNumber(raw.INTINC);
+  const eintexp = asNumber(raw.EINTEXP);
+  const nonii = asNumber(raw.NONII);
+  const nonix = asNumber(raw.NONIX);
+
+  const netInterestIncome =
+    intinc !== null && eintexp !== null ? intinc - eintexp : null;
+  const revenueDenominator =
+    netInterestIncome !== null && nonii !== null
+      ? netInterestIncome + nonii
+      : null;
+
+  return {
+    asset,
+    dep,
+    roa: asNumber(raw.ROA),
+    roe: asNumber(raw.ROE),
+    netnim: asNumber(raw.NETNIM),
+    equity_ratio:
+      safeRatio(eqtot, asset) !== null
+        ? safeRatio(eqtot, asset)! * 100
+        : null,
+    efficiency_ratio:
+      safeRatioPositiveDenom(nonix, revenueDenominator) !== null
+        ? safeRatioPositiveDenom(nonix, revenueDenominator)! * 100
+        : null,
+    loan_to_deposit: safeRatio(lnlsnet, dep),
+    deposits_to_assets: safeRatio(dep, asset),
+    noninterest_income_share: safeRatioPositiveDenom(nonii, revenueDenominator),
+  };
+}
+
+export function computeMedian(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+```
+
+**Step 3: Run the tests**
+
+Run: `npx vitest run tests/peerGroup.test.ts`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/peerGroup.ts tests/peerGroup.test.ts
+git commit -m "feat: add deriveMetrics and computeMedian for peer group analysis"
+```
+
+---
+
+### Task 2: Competition ranking function
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+- Modify: `tests/peerGroup.test.ts`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/peerGroup.test.ts`:
+
+```typescript
+import {
+  deriveMetrics,
+  computeMedian,
+  computeCompetitionRank,
+} from "../src/tools/peerGroup.js";
+
+describe("computeCompetitionRank", () => {
+  it("ranks a value among peers (higher-is-better, descending sort)", () => {
+    // Peers: [10, 8, 6, 4, 2], subject: 7
+    // Sorted desc: 10, 8, 7, 6, 4, 2 → subject rank 3
+    const result = computeCompetitionRank(7, [10, 8, 6, 4, 2], true);
+    expect(result).toEqual({ rank: 3, of: 5, percentile: 60 });
+  });
+
+  it("ranks a value among peers (lower-is-better, ascending sort)", () => {
+    // Peers: [10, 8, 6, 4, 2], subject: 3
+    // Sorted asc: 2, 3, 4, 6, 8, 10 → subject rank 2
+    const result = computeCompetitionRank(3, [10, 8, 6, 4, 2], false);
+    expect(result).toEqual({ rank: 2, of: 5, percentile: 80 });
+  });
+
+  it("handles ties — subject gets same rank as equal peers", () => {
+    // Peers: [10, 8, 8, 4], subject: 8
+    // Sorted desc: 10, 8, 8, 8, 4 → competition rank: 10→1, 8→2, 8→2, 8→2, 4→5
+    // Subject rank = 2
+    const result = computeCompetitionRank(8, [10, 8, 8, 4], true);
+    expect(result).toEqual({ rank: 2, of: 4, percentile: 75 });
+  });
+
+  it("gives rank 1 and 100th percentile when subject is best", () => {
+    const result = computeCompetitionRank(99, [10, 20, 30], true);
+    expect(result).toEqual({ rank: 1, of: 3, percentile: 100 });
+  });
+
+  it("gives last rank and low percentile when subject is worst", () => {
+    const result = computeCompetitionRank(1, [10, 20, 30], true);
+    // Sorted desc: 30, 20, 10, 1 → subject rank 4
+    expect(result).toEqual({ rank: 4, of: 3, percentile: 0 });
+  });
+
+  it("handles null-direction metrics (descending sort by default)", () => {
+    const result = computeCompetitionRank(5, [10, 8, 3, 1], null);
+    expect(result).toEqual({ rank: 3, of: 4, percentile: 50 });
+  });
+
+  it("returns null when peer list is empty", () => {
+    expect(computeCompetitionRank(5, [], true)).toBeNull();
+  });
+});
+```
+
+**Step 2: Implement computeCompetitionRank**
+
+Add to `src/tools/peerGroup.ts`:
+
+```typescript
+export interface RankResult {
+  rank: number;
+  of: number;
+  percentile: number;
+}
+
+export function computeCompetitionRank(
+  subjectValue: number,
+  peerValues: number[],
+  higherIsBetter: boolean | null,
+): RankResult | null {
+  if (peerValues.length === 0) return null;
+
+  const ascending = higherIsBetter === false;
+  const all = [...peerValues, subjectValue];
+  const sorted = [...all].sort((a, b) =>
+    ascending ? a - b : b - a,
+  );
+
+  // Assign competition ranks
+  const ranks = new Map<number, number>();
+  let currentRank = 1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (!ranks.has(sorted[i])) {
+      ranks.set(sorted[i], currentRank);
+    }
+    currentRank = i + 2;
+  }
+
+  const rank = ranks.get(subjectValue)!;
+  const of = peerValues.length;
+  const percentile = Math.round((1 - (rank - 1) / of) * 100);
+
+  return { rank, of, percentile };
+}
+```
+
+**Step 3: Run the tests**
+
+Run: `npx vitest run tests/peerGroup.test.ts`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/peerGroup.ts tests/peerGroup.test.ts
+git commit -m "feat: add computeCompetitionRank with tie handling for peer group analysis"
+```
+
+---
+
+### Task 3: Text formatting and date formatting functions
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+- Modify: `tests/peerGroup.test.ts`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/peerGroup.test.ts`:
+
+```typescript
+import {
+  deriveMetrics,
+  computeMedian,
+  computeCompetitionRank,
+  formatRepdteHuman,
+} from "../src/tools/peerGroup.js";
+
+describe("formatRepdteHuman", () => {
+  it("formats YYYYMMDD as a human-readable date", () => {
+    expect(formatRepdteHuman("20241231")).toBe("December 31, 2024");
+  });
+
+  it("formats March date correctly", () => {
+    expect(formatRepdteHuman("20230331")).toBe("March 31, 2023");
+  });
+
+  it("returns the raw string for invalid dates", () => {
+    expect(formatRepdteHuman("bad")).toBe("bad");
+  });
+});
+```
+
+**Step 2: Implement formatRepdteHuman**
+
+Add to `src/tools/peerGroup.ts`:
+
+```typescript
+export function formatRepdteHuman(repdte: string): string {
+  if (repdte.length !== 8) return repdte;
+  const year = repdte.slice(0, 4);
+  const month = repdte.slice(4, 6);
+  const day = repdte.slice(6, 8);
+  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return repdte;
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+```
+
+**Step 3: Run the tests**
+
+Run: `npx vitest run tests/peerGroup.test.ts`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/peerGroup.ts tests/peerGroup.test.ts
+git commit -m "feat: add formatRepdteHuman for peer group text output"
+```
+
+---
+
+### Task 4: Metric definitions constant and METRIC_KEYS ordering
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+
+**Step 1: Add the constants**
+
+Add to `src/tools/peerGroup.ts`:
+
+```typescript
+interface MetricDefinition {
+  higher_is_better: boolean | null;
+  unit: string;
+  label: string;
+  ranking_note?: string;
+}
+
+export const METRIC_KEYS = [
+  "asset",
+  "dep",
+  "roa",
+  "roe",
+  "netnim",
+  "equity_ratio",
+  "efficiency_ratio",
+  "loan_to_deposit",
+  "deposits_to_assets",
+  "noninterest_income_share",
+] as const;
+
+export type MetricKey = (typeof METRIC_KEYS)[number];
+
+export const METRIC_DEFINITIONS: Record<MetricKey, MetricDefinition> = {
+  asset: { higher_is_better: true, unit: "$thousands", label: "Total Assets" },
+  dep: { higher_is_better: true, unit: "$thousands", label: "Total Deposits" },
+  roa: { higher_is_better: true, unit: "%", label: "Return on Assets" },
+  roe: { higher_is_better: true, unit: "%", label: "Return on Equity" },
+  netnim: { higher_is_better: true, unit: "%", label: "Net Interest Margin" },
+  equity_ratio: { higher_is_better: true, unit: "%", label: "Equity Capital Ratio" },
+  efficiency_ratio: { higher_is_better: false, unit: "%", label: "Efficiency Ratio" },
+  loan_to_deposit: {
+    higher_is_better: null,
+    unit: "ratio",
+    label: "Loan-to-Deposit Ratio",
+    ranking_note:
+      "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent.",
+  },
+  deposits_to_assets: {
+    higher_is_better: null,
+    unit: "ratio",
+    label: "Deposits-to-Assets Ratio",
+    ranking_note:
+      "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent.",
+  },
+  noninterest_income_share: {
+    higher_is_better: true,
+    unit: "ratio",
+    label: "Non-Interest Income Share",
+  },
+};
+```
+
+**Step 2: Run typecheck and existing tests**
+
+Run: `npx tsc --noEmit && npx vitest run tests/peerGroup.test.ts`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/peerGroup.ts
+git commit -m "feat: add METRIC_DEFINITIONS and METRIC_KEYS constants for peer group tool"
+```
+
+---
+
+### Task 5: Zod input schema with validation
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+- Modify: `tests/peerGroup.test.ts`
+
+**Step 1: Write the failing tests**
+
+Append to `tests/peerGroup.test.ts`:
+
+```typescript
+import {
+  deriveMetrics,
+  computeMedian,
+  computeCompetitionRank,
+  formatRepdteHuman,
+  PeerGroupInputSchema,
+} from "../src/tools/peerGroup.js";
+
+describe("PeerGroupInputSchema", () => {
+  it("accepts subject-driven mode with cert and repdte", () => {
+    const result = PeerGroupInputSchema.safeParse({ cert: 29846, repdte: "20241231" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts explicit-criteria mode without cert", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      asset_min: 5000000,
+      asset_max: 20000000,
+      charter_classes: ["N"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when repdte is missing", () => {
+    const result = PeerGroupInputSchema.safeParse({ cert: 29846 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when no peer-group constructor is provided", () => {
+    const result = PeerGroupInputSchema.safeParse({ repdte: "20241231" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when asset_min > asset_max", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      asset_min: 20000000,
+      asset_max: 5000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid state codes", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      state: "North Carolina",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid two-letter state code", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      state: "NC",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("applies defaults for active_only and limit", () => {
+    const result = PeerGroupInputSchema.parse({ cert: 29846, repdte: "20241231" });
+    expect(result.active_only).toBe(true);
+    expect(result.limit).toBe(50);
+  });
+});
+```
+
+**Step 2: Implement the schema**
+
+Add to `src/tools/peerGroup.ts`:
+
+```typescript
+import { z } from "zod";
+
+export const PeerGroupInputSchema = z
+  .object({
+    cert: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Subject institution CERT number. When provided, auto-derives peer criteria and ranks this bank against peers.",
+      ),
+    repdte: z
+      .string()
+      .regex(/^\d{8}$/)
+      .describe("Report date in YYYYMMDD format."),
+    asset_min: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Minimum total assets ($thousands) for peer selection. Defaults to 50% of subject's report-date assets when cert is provided.",
+      ),
+    asset_max: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Maximum total assets ($thousands) for peer selection. Defaults to 200% of subject's report-date assets when cert is provided.",
+      ),
+    charter_classes: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Charter class codes to include (e.g., ["N", "SM"]). Defaults to the subject\'s charter class when cert is provided.',
+      ),
+    state: z
+      .string()
+      .regex(/^[A-Z]{2}$/)
+      .optional()
+      .describe('Two-letter state code (e.g., "NC", "TX").'),
+    raw_filter: z
+      .string()
+      .optional()
+      .describe(
+        "Advanced: raw ElasticSearch query string appended to peer selection criteria with AND.",
+      ),
+    active_only: z
+      .boolean()
+      .default(true)
+      .describe("Limit to institutions where ACTIVE:1 (currently operating, FDIC-insured)."),
+    extra_fields: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Additional FDIC field names to include as raw values in the response. Does not affect peer selection.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(500)
+      .default(50)
+      .describe(
+        "Max peer records returned in the response. All matched peers are used for ranking regardless of this limit.",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      !value.cert &&
+      value.asset_min === undefined &&
+      value.asset_max === undefined &&
+      !value.charter_classes &&
+      !value.state &&
+      !value.raw_filter
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "At least one peer-group constructor is required: cert, asset_min, asset_max, charter_classes, state, or raw_filter.",
+        path: ["cert"],
+      });
+    }
+    if (
+      value.asset_min !== undefined &&
+      value.asset_max !== undefined &&
+      value.asset_min > value.asset_max
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "asset_min must be <= asset_max.",
+        path: ["asset_min"],
+      });
+    }
+  });
+```
+
+**Step 3: Run the tests**
+
+Run: `npx vitest run tests/peerGroup.test.ts`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/peerGroup.ts tests/peerGroup.test.ts
+git commit -m "feat: add PeerGroupInputSchema with validation rules"
+```
+
+---
+
+### Task 6: Tool registration and pipeline — Phase 1 & 2 (subject resolution and peer roster)
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+- Modify: `src/index.ts`
+
+**Step 1: Add registerPeerGroupTools with Phase 1 and Phase 2**
+
+Add to `src/tools/peerGroup.ts`:
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CHARACTER_LIMIT, ENDPOINTS } from "../constants.js";
+import {
+  queryEndpoint,
+  extractRecords,
+  truncateIfNeeded,
+  formatToolError,
+} from "../services/fdicClient.js";
+
+const CHUNK_SIZE = 25;
+const MAX_CONCURRENCY = 4;
+const ANALYSIS_TIMEOUT_MS = 90_000;
+const FINANCIAL_FIELDS =
+  "CERT,ASSET,DEP,NETINC,ROA,ROE,NETNIM,EQTOT,LNLSNET,INTINC,EINTEXP,NONII,NONIX";
+
+// Reuse from analysis.ts pattern
+function buildCertFilters(certs: number[]): string[] {
+  const filters: string[] = [];
+  for (let i = 0; i < certs.length; i += CHUNK_SIZE) {
+    const chunk = certs.slice(i, i + CHUNK_SIZE);
+    filters.push(chunk.map((cert) => `CERT:${cert}`).join(" OR "));
+  }
+  return filters;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  limit: number,
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= values.length) return;
+      results[currentIndex] = await mapper(values[currentIndex], currentIndex);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, () => worker()),
+  );
+  return results;
+}
+
+export function registerPeerGroupTools(server: McpServer): void {
+  server.registerTool(
+    "fdic_peer_group_analysis",
+    {
+      title: "Peer Group Analysis",
+      description: `Build a peer group for an FDIC-insured institution and rank it against peers on financial and efficiency metrics at a single report date.
+
+Three usage modes:
+  - Subject-driven: provide cert and repdte — auto-derives peer criteria from the subject's asset size and charter class
+  - Explicit criteria: provide repdte plus asset_min/asset_max, charter_classes, state, or raw_filter
+  - Subject with overrides: provide cert plus explicit criteria to override auto-derived defaults
+
+Metrics ranked (fixed order):
+  - Total Assets, Total Deposits, ROA, ROE, Net Interest Margin
+  - Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
+  - Deposits-to-Assets Ratio, Non-Interest Income Share
+
+Rankings use competition rank (1, 2, 2, 4) with metric-specific denominators. Subject is excluded from peer set.
+
+Output includes:
+  - Subject rankings and percentiles (when cert provided)
+  - Peer group medians
+  - Peer list with CERTs (pass to fdic_compare_bank_snapshots for trend analysis)
+  - Metric definitions with directionality metadata
+
+Override precedence: cert derives defaults, then explicit params override them.`,
+      inputSchema: PeerGroupInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
+
+      try {
+        const warnings: string[] = [];
+        let subjectProfile: Record<string, unknown> | null = null;
+        let subjectFinancials: Record<string, unknown> | null = null;
+
+        // --- Phase 1: Resolve subject ---
+        if (params.cert) {
+          const [profileResponse, financialsResponse] = await Promise.all([
+            queryEndpoint(
+              ENDPOINTS.INSTITUTIONS,
+              {
+                filters: `CERT:${params.cert}`,
+                fields: "CERT,NAME,CITY,STALP,BKCLASS",
+                limit: 1,
+              },
+              { signal: controller.signal },
+            ),
+            queryEndpoint(
+              ENDPOINTS.FINANCIALS,
+              {
+                filters: `CERT:${params.cert} AND REPDTE:${params.repdte}`,
+                fields: FINANCIAL_FIELDS,
+                limit: 1,
+              },
+              { signal: controller.signal },
+            ),
+          ]);
+
+          const profileRecords = extractRecords(profileResponse);
+          if (profileRecords.length === 0) {
+            return formatToolError(
+              new Error(`No institution found with CERT number ${params.cert}.`),
+            );
+          }
+          subjectProfile = profileRecords[0];
+
+          const financialRecords = extractRecords(financialsResponse);
+          if (financialRecords.length === 0) {
+            return formatToolError(
+              new Error(
+                `No financial data for CERT ${params.cert} at report date ${params.repdte}. ` +
+                  `Auto-derivation of peer criteria requires asset data at the specified report date.`,
+              ),
+            );
+          }
+          subjectFinancials = financialRecords[0];
+        }
+
+        // Derive defaults and apply overrides
+        const subjectAsset =
+          subjectFinancials && typeof subjectFinancials.ASSET === "number"
+            ? subjectFinancials.ASSET
+            : null;
+
+        const assetMin =
+          params.asset_min ??
+          (subjectAsset !== null ? subjectAsset * 0.5 : undefined);
+        const assetMax =
+          params.asset_max ??
+          (subjectAsset !== null ? subjectAsset * 2.0 : undefined);
+        const charterClasses =
+          params.charter_classes ??
+          (subjectProfile && typeof subjectProfile.BKCLASS === "string"
+            ? [subjectProfile.BKCLASS]
+            : undefined);
+        const { state, active_only, raw_filter } = params;
+
+        // --- Phase 2: Build peer roster ---
+        const filterParts: string[] = [];
+        if (assetMin !== undefined || assetMax !== undefined) {
+          const min = assetMin ?? 0;
+          const max = assetMax ?? "*";
+          filterParts.push(`ASSET:[${min} TO ${max}]`);
+        }
+        if (charterClasses && charterClasses.length > 0) {
+          const classFilter = charterClasses
+            .map((cls) => `BKCLASS:${cls}`)
+            .join(" OR ");
+          filterParts.push(
+            charterClasses.length > 1 ? `(${classFilter})` : classFilter,
+          );
+        }
+        if (state) filterParts.push(`STALP:${state}`);
+        if (active_only) filterParts.push("ACTIVE:1");
+        if (raw_filter) filterParts.push(`(${raw_filter})`);
+
+        const rosterResponse = await queryEndpoint(
+          ENDPOINTS.INSTITUTIONS,
+          {
+            filters: filterParts.join(" AND "),
+            fields: "CERT,NAME,CITY,STALP,BKCLASS",
+            limit: 10_000,
+            offset: 0,
+            sort_by: "CERT",
+            sort_order: "ASC",
+          },
+          { signal: controller.signal },
+        );
+
+        let rosterRecords = extractRecords(rosterResponse);
+        if (rosterResponse.meta.total > rosterRecords.length) {
+          warnings.push(
+            `Institution roster truncated to ${rosterRecords.length.toLocaleString()} records ` +
+              `out of ${rosterResponse.meta.total.toLocaleString()} matched institutions. ` +
+              `Narrow the peer group criteria for complete analysis.`,
+          );
+        }
+
+        // Remove subject from roster
+        if (params.cert) {
+          rosterRecords = rosterRecords.filter(
+            (r) => asNumber(r.CERT) !== params.cert,
+          );
+        }
+
+        const criteriaUsed = {
+          asset_min: assetMin ?? null,
+          asset_max: assetMax ?? null,
+          charter_classes: charterClasses ?? null,
+          state: state ?? null,
+          active_only,
+          raw_filter: raw_filter ?? null,
+        };
+
+        if (rosterRecords.length === 0) {
+          const output = {
+            ...(subjectProfile
+              ? {
+                  subject: {
+                    cert: params.cert,
+                    name: subjectProfile.NAME,
+                    city: subjectProfile.CITY,
+                    stalp: subjectProfile.STALP,
+                    bkclass: subjectProfile.BKCLASS,
+                    metrics: subjectFinancials
+                      ? deriveMetrics(subjectFinancials)
+                      : null,
+                    rankings: null,
+                  },
+                }
+              : {}),
+            peer_group: { repdte: params.repdte, criteria_used: criteriaUsed, medians: {} },
+            metric_definitions: METRIC_DEFINITIONS,
+            peers: [],
+            peer_count: 0,
+            returned_count: 0,
+            has_more: false,
+            message: "No peers matched the specified criteria.",
+            warnings,
+          };
+
+          const dateStr = formatRepdteHuman(params.repdte);
+          const subjectLabel = subjectProfile
+            ? ` for ${subjectProfile.NAME} (CERT ${params.cert})`
+            : "";
+          const text = `Peer group analysis${subjectLabel} as of ${dateStr}.\n0 peers matched.`;
+
+          return {
+            content: [{ type: "text", text }],
+            structuredContent: output,
+          };
+        }
+
+        // --- Phases 3 & 4 follow in next task ---
+        // PLACEHOLDER: will be replaced in Task 7
+        return formatToolError(new Error("Not yet implemented: phases 3-4"));
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return formatToolError(
+            new Error(
+              `Peer group analysis timed out after ${Math.floor(ANALYSIS_TIMEOUT_MS / 1000)} seconds. ` +
+                `Narrow the peer group criteria and try again.`,
+            ),
+          );
+        }
+        return formatToolError(err);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+  );
+}
+```
+
+**Step 2: Register in index.ts**
+
+In `src/index.ts`, add the import and registration call:
+
+```typescript
+import { registerPeerGroupTools } from "./tools/peerGroup.js";
+```
+
+Add after `registerAnalysisTools(server);`:
+
+```typescript
+registerPeerGroupTools(server);
+```
+
+**Step 3: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no type errors).
+
+**Step 4: Commit**
+
+```bash
+git add src/tools/peerGroup.ts src/index.ts
+git commit -m "feat: register fdic_peer_group_analysis tool with Phase 1-2 pipeline"
+```
+
+---
+
+### Task 7: Pipeline Phases 3 & 4 — Fetch financials, compute metrics, rank, and assemble
+
+**Files:**
+- Modify: `src/tools/peerGroup.ts`
+
+**Step 1: Replace the placeholder with the full Phase 3–4 implementation**
+
+Replace the `// --- Phases 3 & 4 follow in next task ---` placeholder block with:
+
+```typescript
+        // --- Phase 3: Fetch peer financials ---
+        const peerCerts = rosterRecords
+          .map((r) => asNumber(r.CERT))
+          .filter((c): c is number => c !== null);
+
+        const certFilters = buildCertFilters(peerCerts);
+        const extraFieldsCsv =
+          params.extra_fields && params.extra_fields.length > 0
+            ? "," + params.extra_fields.join(",")
+            : "";
+
+        const financialResponses = await mapWithConcurrency(
+          certFilters,
+          MAX_CONCURRENCY,
+          async (certFilter) =>
+            queryEndpoint(
+              ENDPOINTS.FINANCIALS,
+              {
+                filters: `(${certFilter}) AND REPDTE:${params.repdte}`,
+                fields: FINANCIAL_FIELDS + extraFieldsCsv,
+                limit: 10_000,
+                offset: 0,
+                sort_by: "CERT",
+                sort_order: "ASC",
+              },
+              { signal: controller.signal },
+            ),
+        );
+
+        const peerFinancialsByCert = new Map<number, Record<string, unknown>>();
+        for (const response of financialResponses) {
+          for (const record of extractRecords(response)) {
+            const cert = asNumber(record.CERT);
+            if (cert !== null) peerFinancialsByCert.set(cert, record);
+          }
+        }
+
+        // Build roster lookup
+        const rosterByCert = new Map(
+          rosterRecords
+            .map((r) => [asNumber(r.CERT), r] as const)
+            .filter((e): e is [number, Record<string, unknown>] => e[0] !== null),
+        );
+
+        // Compute metrics for peers that have financials
+        interface PeerEntry {
+          cert: number;
+          name: string;
+          city: string | null;
+          stalp: string | null;
+          bkclass: string | null;
+          metrics: DerivedMetrics;
+          extraFields: Record<string, unknown>;
+        }
+
+        const peers: PeerEntry[] = [];
+        for (const [cert, financials] of peerFinancialsByCert) {
+          const roster = rosterByCert.get(cert);
+          const metrics = deriveMetrics(financials);
+          const extraFields: Record<string, unknown> = {};
+          if (params.extra_fields) {
+            for (const field of params.extra_fields) {
+              extraFields[field] = financials[field] ?? null;
+            }
+          }
+          peers.push({
+            cert,
+            name: String(roster?.NAME ?? financials.NAME ?? cert),
+            city: roster?.CITY != null ? String(roster.CITY) : null,
+            stalp: roster?.STALP != null ? String(roster.STALP) : null,
+            bkclass: roster?.BKCLASS != null ? String(roster.BKCLASS) : null,
+            metrics,
+            extraFields,
+          });
+        }
+
+        const peerCount = peers.length;
+
+        // --- Phase 4: Rank and assemble ---
+        // Compute subject metrics
+        const subjectMetrics = subjectFinancials
+          ? deriveMetrics(subjectFinancials)
+          : null;
+
+        // Compute rankings and medians
+        const rankings: Record<string, RankResult | null> = {};
+        const medians: Record<string, number | null> = {};
+
+        for (const key of METRIC_KEYS) {
+          const peerValues = peers
+            .map((p) => p.metrics[key])
+            .filter((v): v is number => v !== null);
+
+          medians[key] = computeMedian(peerValues);
+
+          if (subjectMetrics && subjectMetrics[key] !== null) {
+            rankings[key] = computeCompetitionRank(
+              subjectMetrics[key]!,
+              peerValues,
+              METRIC_DEFINITIONS[key].higher_is_better,
+            );
+          } else {
+            rankings[key] = null;
+          }
+        }
+
+        // Sort peers by asset descending
+        peers.sort((a, b) => (b.metrics.asset ?? 0) - (a.metrics.asset ?? 0));
+        const returnedPeers = peers.slice(0, params.limit);
+        const returnedCount = returnedPeers.length;
+        const hasMore = peerCount > returnedCount;
+
+        // Build output
+        const output: Record<string, unknown> = {};
+
+        if (subjectProfile && subjectMetrics) {
+          output.subject = {
+            cert: params.cert,
+            name: subjectProfile.NAME,
+            city: subjectProfile.CITY,
+            stalp: subjectProfile.STALP,
+            bkclass: subjectProfile.BKCLASS,
+            metrics: subjectMetrics,
+            rankings,
+          };
+        }
+
+        output.peer_group = {
+          repdte: params.repdte,
+          criteria_used: criteriaUsed,
+          medians,
+        };
+        output.metric_definitions = METRIC_DEFINITIONS;
+        output.peers = returnedPeers.map((p) => ({
+          cert: p.cert,
+          name: p.name,
+          city: p.city,
+          stalp: p.stalp,
+          metrics: p.metrics,
+          ...p.extraFields,
+        }));
+        output.peer_count = peerCount;
+        output.returned_count = returnedCount;
+        output.has_more = hasMore;
+        output.message = null;
+        output.warnings = warnings;
+
+        // Build text output
+        const text = truncateIfNeeded(
+          formatPeerGroupText(output, params.repdte, subjectProfile, subjectMetrics, rankings, medians, returnedPeers, peerCount, warnings),
+          CHARACTER_LIMIT,
+        );
+
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: output,
+        };
+```
+
+Also add the `formatPeerGroupText` helper function before `registerPeerGroupTools`:
+
+```typescript
+function formatMetricValue(
+  key: MetricKey,
+  value: number | null,
+): string {
+  if (value === null) return "n/a";
+  const def = METRIC_DEFINITIONS[key];
+  if (def.unit === "$thousands") return `$${Math.round(value).toLocaleString()}k`;
+  if (def.unit === "%") return `${value.toFixed(4)}%`;
+  return value.toFixed(4);
+}
+
+function ordinalSuffix(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  const mod10 = n % 10;
+  if (mod10 === 1) return `${n}st`;
+  if (mod10 === 2) return `${n}nd`;
+  if (mod10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+interface PeerEntry {
+  cert: number;
+  name: string;
+  city: string | null;
+  stalp: string | null;
+  bkclass: string | null;
+  metrics: DerivedMetrics;
+  extraFields: Record<string, unknown>;
+}
+
+function formatPeerGroupText(
+  _output: Record<string, unknown>,
+  repdte: string,
+  subjectProfile: Record<string, unknown> | null,
+  subjectMetrics: DerivedMetrics | null,
+  rankings: Record<string, RankResult | null>,
+  medians: Record<string, number | null>,
+  returnedPeers: PeerEntry[],
+  peerCount: number,
+  warnings: string[],
+): string {
+  const parts: string[] = [];
+
+  // Warnings
+  for (const warning of warnings) {
+    parts.push(`Warning: ${warning}`);
+  }
+
+  // Header
+  const dateStr = formatRepdteHuman(repdte);
+  const subjectLabel = subjectProfile
+    ? ` for ${subjectProfile.NAME} (CERT ${subjectProfile.CERT ?? ""})`
+    : "";
+  parts.push(
+    `Peer group analysis${subjectLabel} as of ${dateStr}.`,
+  );
+  parts.push(`${peerCount} peers matched.`);
+
+  // Subject rankings
+  if (subjectMetrics && subjectProfile) {
+    parts.push("");
+    parts.push("Subject rankings:");
+    for (const key of METRIC_KEYS) {
+      const def = METRIC_DEFINITIONS[key];
+      const ranking = rankings[key];
+      const value = formatMetricValue(key, subjectMetrics[key]);
+      const medianValue = formatMetricValue(key, medians[key] ?? null);
+      if (ranking) {
+        const pctLabel = `${ordinalSuffix(ranking.percentile)} percentile`;
+        parts.push(
+          `  ${def.label.padEnd(28)} rank ${String(ranking.rank).padStart(2)} of ${String(ranking.of).padEnd(4)} (${pctLabel.padEnd(18)})  ${value.padStart(16)}  median: ${medianValue}`,
+        );
+      } else {
+        parts.push(`  ${def.label.padEnd(28)} n/a`);
+      }
+    }
+  } else if (peerCount > 0) {
+    // Explicit-criteria mode: show medians
+    parts.push("");
+    parts.push("Peer group medians:");
+    const medianParts = METRIC_KEYS.filter((k) => medians[k] !== null).map(
+      (k) => `${METRIC_DEFINITIONS[k].label}: ${formatMetricValue(k, medians[k] ?? null)}`,
+    );
+    parts.push(`  ${medianParts.join(" | ")}`);
+  }
+
+  // Peer list
+  if (returnedPeers.length > 0) {
+    parts.push("");
+    parts.push(`Peers (${returnedPeers.length} returned):`);
+    for (let i = 0; i < returnedPeers.length; i++) {
+      const p = returnedPeers[i];
+      const location = [p.city, p.stalp].filter(Boolean).join(" ");
+      const locationStr = location ? `, ${location}` : "";
+      parts.push(
+        `${i + 1}. ${p.name}${locationStr} (CERT ${p.cert}) | ` +
+          `Asset: ${formatMetricValue("asset", p.metrics.asset)} | ` +
+          `ROA: ${formatMetricValue("roa", p.metrics.roa)} | ` +
+          `ROE: ${formatMetricValue("roe", p.metrics.roe)}`,
+      );
+    }
+  }
+
+  return parts.join("\n");
+}
+```
+
+**Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/peerGroup.ts
+git commit -m "feat: complete Phase 3-4 pipeline with financial fetch, ranking, and text formatting"
+```
+
+---
+
+### Task 8: Integration tests via HTTP MCP
+
+**Files:**
+- Modify: `tests/mcp-http.test.ts`
+
+**Step 1: Write integration tests**
+
+Append to `tests/mcp-http.test.ts`:
+
+```typescript
+  it("includes fdic_peer_group_analysis in the tool list", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 100,
+      method: "tools/list",
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.tools.map((tool: { name: string }) => tool.name),
+    ).toContain("fdic_peer_group_analysis");
+  });
+
+  it("performs subject-driven peer group analysis", async () => {
+    getMock
+      // Phase 1: institutions lookup
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Subject Bank", CITY: "Wilmington", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 1: subject financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, ASSET: 1000, DEP: 800, NETINC: 20, ROA: 1.5, ROE: 12.0, NETNIM: 3.5, EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25 } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 2: peer roster
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 100, NAME: "Subject Bank", CITY: "Wilmington", STALP: "NC", BKCLASS: "NM" } },
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "NM" } },
+            { data: { CERT: 300, NAME: "Peer B", CITY: "Charlotte", STALP: "NC", BKCLASS: "NM" } },
+          ],
+          meta: { total: 3 },
+        },
+      })
+      // Phase 3: peer financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, ASSET: 900, DEP: 700, NETINC: 15, ROA: 1.2, ROE: 10.0, NETNIM: 3.0, EQTOT: 90, LNLSNET: 500, INTINC: 40, EINTEXP: 12, NONII: 8, NONIX: 22 } },
+            { data: { CERT: 300, ASSET: 1100, DEP: 850, NETINC: 25, ROA: 1.8, ROE: 14.0, NETNIM: 4.0, EQTOT: 120, LNLSNET: 700, INTINC: 60, EINTEXP: 18, NONII: 12, NONIX: 28 } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 101,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: { cert: 100, repdte: "20241231" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.peer_count).toBe(2);
+    expect(sc.returned_count).toBe(2);
+    expect(sc.subject.cert).toBe(100);
+    expect(sc.subject.rankings.roa).toMatchObject({ of: 2 });
+    expect(sc.subject.rankings.roa.rank).toBe(2);
+    expect(sc.peers).toHaveLength(2);
+    expect(sc.peers[0].cert).toBe(300); // highest asset first
+    expect(sc.metric_definitions.roa.higher_is_better).toBe(true);
+    expect(sc.metric_definitions.efficiency_ratio.higher_is_better).toBe(false);
+    expect(sc.warnings).toEqual([]);
+    expect(response.body.result.content[0].text).toContain("Subject Bank");
+    expect(response.body.result.content[0].text).toContain("December 31, 2024");
+  });
+
+  it("performs explicit-criteria peer group analysis without subject", async () => {
+    getMock
+      // Phase 2: peer roster (no Phase 1 since no cert)
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "N" } },
+            { data: { CERT: 300, NAME: "Peer B", CITY: "Charlotte", STALP: "NC", BKCLASS: "N" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      // Phase 3: peer financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, ASSET: 5000000, DEP: 4000000, NETINC: 100000, ROA: 1.0, ROE: 9.0, NETNIM: 3.0, EQTOT: 500000, LNLSNET: 3000000, INTINC: 200000, EINTEXP: 80000, NONII: 30000, NONIX: 100000 } },
+            { data: { CERT: 300, ASSET: 8000000, DEP: 6000000, NETINC: 200000, ROA: 1.5, ROE: 11.0, NETNIM: 3.5, EQTOT: 900000, LNLSNET: 4500000, INTINC: 350000, EINTEXP: 120000, NONII: 50000, NONIX: 150000 } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 102,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: {
+          repdte: "20241231",
+          asset_min: 5000000,
+          asset_max: 20000000,
+          charter_classes: ["N"],
+          state: "NC",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.subject).toBeUndefined();
+    expect(sc.peer_count).toBe(2);
+    expect(sc.peer_group.criteria_used.state).toBe("NC");
+    expect(sc.peer_group.medians.roa).toBe(1.25);
+    expect(response.body.result.content[0].text).toContain("Peer group medians");
+  });
+
+  it("returns empty result when no peers match", async () => {
+    getMock
+      // Phase 1: institutions
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Lonely Bank", CITY: "Nowhere", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 1: financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, ASSET: 1000, DEP: 800, ROA: 1.0, ROE: 8.0, NETNIM: 3.0, EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25 } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 2: roster returns only the subject
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Lonely Bank", CITY: "Nowhere", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 103,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: { cert: 100, repdte: "20241231" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.peer_count).toBe(0);
+    expect(sc.message).toBe("No peers matched the specified criteria.");
+    expect(sc.peers).toEqual([]);
+  });
+```
+
+**Step 2: Update the existing tool count assertion**
+
+In the existing test `"lists all registered tools including demographics"`, update the expected tool count from 11 to 12:
+
+```typescript
+expect(response.body.result.tools).toHaveLength(12);
+```
+
+**Step 3: Run all tests**
+
+Run: `npx vitest run`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/mcp-http.test.ts
+git commit -m "test: add integration tests for fdic_peer_group_analysis tool"
+```
+
+---
+
+### Task 9: Update README
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update the tool count and add the new tool to the table**
+
+In README.md, update `**11 tools**` to `**12 tools**` in the Features section.
+
+Add the new tool row to the Available Tools table:
+
+```markdown
+| `fdic_peer_group_analysis` | Build a peer group and rank an institution against peers on financial metrics |
+```
+
+**Step 2: Add a section describing peer group analysis usage**
+
+Add after the "Complex Prompts" section a new section:
+
+```markdown
+## Peer Group Analysis
+
+The `fdic_peer_group_analysis` tool builds a peer group for a bank and ranks it against peers on financial and efficiency metrics at a single report date.
+
+**Find peers for a specific bank (auto-derived criteria):**
+```
+cert: 29846
+repdte: 20241231
+(fdic_peer_group_analysis)
+```
+
+**Define a peer group with explicit criteria:**
+```
+repdte: 20241231
+asset_min: 5000000
+asset_max: 20000000
+charter_classes: ["N"]
+state: NC
+(fdic_peer_group_analysis)
+```
+
+**Override auto-derived defaults:**
+```
+cert: 29846
+repdte: 20241231
+asset_min: 3000000
+state: NC
+(fdic_peer_group_analysis)
+```
+
+The tool returns rankings (competition rank + percentile) and peer group medians for:
+- Total Assets, Total Deposits, ROA, ROE, Net Interest Margin
+- Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
+- Deposits-to-Assets Ratio, Non-Interest Income Share
+
+Peer CERTs from the response can be passed to `fdic_compare_bank_snapshots` for trend analysis across the peer group.
+```
+
+**Step 3: Run build to verify nothing is broken**
+
+Run: `npm run typecheck && npm test && npm run build`
+Expected: All PASS.
+
+**Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add fdic_peer_group_analysis to README"
+```
+
+---
+
+### Task 10: Final validation
+
+**Step 1: Run the full validation suite**
+
+Run: `npm run typecheck && npm test && npm run build`
+Expected: All pass with no warnings.
+
+**Step 2: Verify the build output includes the new tool**
+
+Run: `node dist/index.js` (briefly, then Ctrl+C) or check the dist output.
+
+**Step 3: Review all changes**
+
+Run: `git diff main --stat` to verify only the expected files were changed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerFinancialTools } from "./tools/financials.js";
 import { registerSodTools } from "./tools/sod.js";
 import { registerDemographicsTools } from "./tools/demographics.js";
 import { registerAnalysisTools } from "./tools/analysis.js";
+import { registerPeerGroupTools } from "./tools/peerGroup.js";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -28,6 +29,7 @@ export function createServer(): McpServer {
   registerSodTools(server);
   registerDemographicsTools(server);
   registerAnalysisTools(server);
+  registerPeerGroupTools(server);
 
   return server;
 }

--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -1,0 +1,820 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CHARACTER_LIMIT, ENDPOINTS } from "../constants.js";
+import {
+  queryEndpoint,
+  extractRecords,
+  truncateIfNeeded,
+  formatToolError,
+} from "../services/fdicClient.js";
+
+type RawFinancials = Record<string, unknown>;
+
+export interface DerivedMetrics {
+  asset: number | null;
+  dep: number | null;
+  roa: number | null;
+  roe: number | null;
+  netnim: number | null;
+  equity_ratio: number | null;
+  efficiency_ratio: number | null;
+  loan_to_deposit: number | null;
+  deposits_to_assets: number | null;
+  noninterest_income_share: number | null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function safeRatio(
+  numerator: number | null,
+  denominator: number | null,
+): number | null {
+  if (numerator === null || denominator === null || denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function safeRatioPositiveDenom(
+  numerator: number | null,
+  denominator: number | null,
+): number | null {
+  if (numerator === null || denominator === null || denominator <= 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+export function deriveMetrics(raw: RawFinancials): DerivedMetrics {
+  const asset = asNumber(raw.ASSET);
+  const dep = asNumber(raw.DEP);
+  const eqtot = asNumber(raw.EQTOT);
+  const lnlsnet = asNumber(raw.LNLSNET);
+  const intinc = asNumber(raw.INTINC);
+  const eintexp = asNumber(raw.EINTEXP);
+  const nonii = asNumber(raw.NONII);
+  const nonix = asNumber(raw.NONIX);
+
+  const netInterestIncome =
+    intinc !== null && eintexp !== null ? intinc - eintexp : null;
+  const revenueDenominator =
+    netInterestIncome !== null && nonii !== null
+      ? netInterestIncome + nonii
+      : null;
+
+  const equityRatioRaw = safeRatio(eqtot, asset);
+  const efficiencyRatioRaw = safeRatioPositiveDenom(nonix, revenueDenominator);
+
+  return {
+    asset,
+    dep,
+    roa: asNumber(raw.ROA),
+    roe: asNumber(raw.ROE),
+    netnim: asNumber(raw.NETNIM),
+    equity_ratio: equityRatioRaw !== null ? equityRatioRaw * 100 : null,
+    efficiency_ratio:
+      efficiencyRatioRaw !== null ? efficiencyRatioRaw * 100 : null,
+    loan_to_deposit: safeRatio(lnlsnet, dep),
+    deposits_to_assets: safeRatio(dep, asset),
+    noninterest_income_share: safeRatioPositiveDenom(nonii, revenueDenominator),
+  };
+}
+
+export function computeMedian(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export interface RankResult {
+  rank: number;
+  of: number;
+  percentile: number;
+}
+
+export function computeCompetitionRank(
+  subjectValue: number,
+  peerValues: number[],
+  higherIsBetter: boolean | null,
+): RankResult | null {
+  if (peerValues.length === 0) return null;
+
+  const ascending = higherIsBetter === false;
+  const all = [...peerValues, subjectValue];
+  const sorted = [...all].sort((a, b) =>
+    ascending ? a - b : b - a,
+  );
+
+  // Assign competition ranks: tied values get the same rank
+  const ranks = new Map<number, number>();
+  for (let i = 0; i < sorted.length; i++) {
+    if (!ranks.has(sorted[i])) {
+      ranks.set(sorted[i], i + 1);
+    }
+  }
+
+  const rank = ranks.get(subjectValue)!;
+  const of = peerValues.length;
+  const percentile = Math.round((1 - (rank - 1) / of) * 100);
+
+  return { rank, of, percentile };
+}
+
+export function formatRepdteHuman(repdte: string): string {
+  if (repdte.length !== 8) return repdte;
+  const year = repdte.slice(0, 4);
+  const month = repdte.slice(4, 6);
+  const day = repdte.slice(6, 8);
+  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return repdte;
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+interface MetricDefinition {
+  higher_is_better: boolean | null;
+  unit: string;
+  label: string;
+  ranking_note?: string;
+}
+
+export const METRIC_KEYS = [
+  "asset",
+  "dep",
+  "roa",
+  "roe",
+  "netnim",
+  "equity_ratio",
+  "efficiency_ratio",
+  "loan_to_deposit",
+  "deposits_to_assets",
+  "noninterest_income_share",
+] as const;
+
+export type MetricKey = (typeof METRIC_KEYS)[number];
+
+export const METRIC_DEFINITIONS: Record<MetricKey, MetricDefinition> = {
+  asset: { higher_is_better: true, unit: "$thousands", label: "Total Assets" },
+  dep: { higher_is_better: true, unit: "$thousands", label: "Total Deposits" },
+  roa: { higher_is_better: true, unit: "%", label: "Return on Assets" },
+  roe: { higher_is_better: true, unit: "%", label: "Return on Equity" },
+  netnim: {
+    higher_is_better: true,
+    unit: "%",
+    label: "Net Interest Margin",
+  },
+  equity_ratio: {
+    higher_is_better: true,
+    unit: "%",
+    label: "Equity Capital Ratio",
+  },
+  efficiency_ratio: {
+    higher_is_better: false,
+    unit: "%",
+    label: "Efficiency Ratio",
+  },
+  loan_to_deposit: {
+    higher_is_better: null,
+    unit: "ratio",
+    label: "Loan-to-Deposit Ratio",
+    ranking_note:
+      "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent.",
+  },
+  deposits_to_assets: {
+    higher_is_better: null,
+    unit: "ratio",
+    label: "Deposits-to-Assets Ratio",
+    ranking_note:
+      "Rank and percentile reflect position by value (1 = highest). Directionality is context-dependent.",
+  },
+  noninterest_income_share: {
+    higher_is_better: true,
+    unit: "ratio",
+    label: "Non-Interest Income Share",
+  },
+};
+
+export const PeerGroupInputSchema = z
+  .object({
+    cert: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Subject institution CERT number. When provided, auto-derives peer criteria and ranks this bank against peers.",
+      ),
+    repdte: z
+      .string()
+      .regex(/^\d{8}$/)
+      .describe("Report date in YYYYMMDD format."),
+    asset_min: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Minimum total assets ($thousands) for peer selection. Defaults to 50% of subject's report-date assets when cert is provided.",
+      ),
+    asset_max: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Maximum total assets ($thousands) for peer selection. Defaults to 200% of subject's report-date assets when cert is provided.",
+      ),
+    charter_classes: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Charter class codes to include (e.g., ["N", "SM"]). Defaults to the subject\'s charter class when cert is provided.',
+      ),
+    state: z
+      .string()
+      .regex(/^[A-Z]{2}$/)
+      .optional()
+      .describe('Two-letter state code (e.g., "NC", "TX").'),
+    raw_filter: z
+      .string()
+      .optional()
+      .describe(
+        "Advanced: raw ElasticSearch query string appended to peer selection criteria with AND.",
+      ),
+    active_only: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Limit to institutions where ACTIVE:1 (currently operating, FDIC-insured).",
+      ),
+    extra_fields: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Additional FDIC field names to include as raw values in the response. Does not affect peer selection.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(500)
+      .default(50)
+      .describe(
+        "Max peer records returned in the response. All matched peers are used for ranking regardless of this limit.",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      !value.cert &&
+      value.asset_min === undefined &&
+      value.asset_max === undefined &&
+      !value.charter_classes &&
+      !value.state &&
+      !value.raw_filter
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "At least one peer-group constructor is required: cert, asset_min, asset_max, charter_classes, state, or raw_filter.",
+        path: ["cert"],
+      });
+    }
+    if (
+      value.asset_min !== undefined &&
+      value.asset_max !== undefined &&
+      value.asset_min > value.asset_max
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "asset_min must be <= asset_max.",
+        path: ["asset_min"],
+      });
+    }
+  });
+
+const CHUNK_SIZE = 25;
+const MAX_CONCURRENCY = 4;
+const ANALYSIS_TIMEOUT_MS = 90_000;
+const FINANCIAL_FIELDS =
+  "CERT,ASSET,DEP,NETINC,ROA,ROE,NETNIM,EQTOT,LNLSNET,INTINC,EINTEXP,NONII,NONIX";
+
+function buildCertFilters(certs: number[]): string[] {
+  const filters: string[] = [];
+  for (let i = 0; i < certs.length; i += CHUNK_SIZE) {
+    const chunk = certs.slice(i, i + CHUNK_SIZE);
+    filters.push(chunk.map((cert) => `CERT:${cert}`).join(" OR "));
+  }
+  return filters;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  limit: number,
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= values.length) return;
+      results[currentIndex] = await mapper(values[currentIndex], currentIndex);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, () => worker()),
+  );
+  return results;
+}
+
+interface PeerEntry {
+  cert: number;
+  name: string;
+  city: string | null;
+  stalp: string | null;
+  bkclass: string | null;
+  metrics: DerivedMetrics;
+  extraFields: Record<string, unknown>;
+}
+
+function formatMetricValue(key: MetricKey, value: number | null): string {
+  if (value === null) return "n/a";
+  const def = METRIC_DEFINITIONS[key];
+  if (def.unit === "$thousands")
+    return `$${Math.round(value).toLocaleString()}k`;
+  if (def.unit === "%") return `${value.toFixed(4)}%`;
+  return value.toFixed(4);
+}
+
+function ordinalSuffix(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  const mod10 = n % 10;
+  if (mod10 === 1) return `${n}st`;
+  if (mod10 === 2) return `${n}nd`;
+  if (mod10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+function formatPeerGroupText(
+  repdte: string,
+  subjectProfile: Record<string, unknown> | null,
+  subjectMetrics: DerivedMetrics | null,
+  rankings: Record<string, RankResult | null>,
+  medians: Record<string, number | null>,
+  returnedPeers: PeerEntry[],
+  peerCount: number,
+  warnings: string[],
+): string {
+  const parts: string[] = [];
+
+  for (const warning of warnings) {
+    parts.push(`Warning: ${warning}`);
+  }
+
+  const dateStr = formatRepdteHuman(repdte);
+  const subjectLabel = subjectProfile
+    ? ` for ${subjectProfile.NAME} (CERT ${subjectProfile.CERT ?? ""})`
+    : "";
+  parts.push(`Peer group analysis${subjectLabel} as of ${dateStr}.`);
+  parts.push(`${peerCount} peers matched.`);
+
+  if (subjectMetrics && subjectProfile) {
+    parts.push("");
+    parts.push("Subject rankings:");
+    for (const key of METRIC_KEYS) {
+      const def = METRIC_DEFINITIONS[key];
+      const ranking = rankings[key];
+      const value = formatMetricValue(key, subjectMetrics[key]);
+      const medianValue = formatMetricValue(key, medians[key] ?? null);
+      if (ranking) {
+        const pctLabel = `${ordinalSuffix(ranking.percentile)} percentile`;
+        parts.push(
+          `  ${def.label.padEnd(28)} rank ${String(ranking.rank).padStart(2)} of ${String(ranking.of).padEnd(4)} (${pctLabel.padEnd(18)})  ${value.padStart(16)}  median: ${medianValue}`,
+        );
+      } else {
+        parts.push(`  ${def.label.padEnd(28)} n/a`);
+      }
+    }
+  } else if (peerCount > 0) {
+    parts.push("");
+    parts.push("Peer group medians:");
+    const medianParts = METRIC_KEYS.filter((k) => medians[k] !== null).map(
+      (k) =>
+        `${METRIC_DEFINITIONS[k].label}: ${formatMetricValue(k, medians[k] ?? null)}`,
+    );
+    parts.push(`  ${medianParts.join(" | ")}`);
+  }
+
+  if (returnedPeers.length > 0) {
+    parts.push("");
+    parts.push(`Peers (${returnedPeers.length} returned):`);
+    for (let i = 0; i < returnedPeers.length; i++) {
+      const p = returnedPeers[i];
+      const location = [p.city, p.stalp].filter(Boolean).join(" ");
+      const locationStr = location ? `, ${location}` : "";
+      parts.push(
+        `${i + 1}. ${p.name}${locationStr} (CERT ${p.cert}) | ` +
+          `Asset: ${formatMetricValue("asset", p.metrics.asset)} | ` +
+          `ROA: ${formatMetricValue("roa", p.metrics.roa)} | ` +
+          `ROE: ${formatMetricValue("roe", p.metrics.roe)}`,
+      );
+    }
+  }
+
+  return parts.join("\n");
+}
+
+export function registerPeerGroupTools(server: McpServer): void {
+  server.registerTool(
+    "fdic_peer_group_analysis",
+    {
+      title: "Peer Group Analysis",
+      description: `Build a peer group for an FDIC-insured institution and rank it against peers on financial and efficiency metrics at a single report date.
+
+Three usage modes:
+  - Subject-driven: provide cert and repdte — auto-derives peer criteria from the subject's asset size and charter class
+  - Explicit criteria: provide repdte plus asset_min/asset_max, charter_classes, state, or raw_filter
+  - Subject with overrides: provide cert plus explicit criteria to override auto-derived defaults
+
+Metrics ranked (fixed order):
+  - Total Assets, Total Deposits, ROA, ROE, Net Interest Margin
+  - Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
+  - Deposits-to-Assets Ratio, Non-Interest Income Share
+
+Rankings use competition rank (1, 2, 2, 4) with metric-specific denominators. Subject is excluded from peer set.
+
+Output includes:
+  - Subject rankings and percentiles (when cert provided)
+  - Peer group medians
+  - Peer list with CERTs (pass to fdic_compare_bank_snapshots for trend analysis)
+  - Metric definitions with directionality metadata
+
+Override precedence: cert derives defaults, then explicit params override them.`,
+      inputSchema: PeerGroupInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
+
+      try {
+        const warnings: string[] = [];
+        let subjectProfile: Record<string, unknown> | null = null;
+        let subjectFinancials: Record<string, unknown> | null = null;
+
+        // --- Phase 1: Resolve subject ---
+        if (params.cert) {
+          const [profileResponse, financialsResponse] = await Promise.all([
+            queryEndpoint(
+              ENDPOINTS.INSTITUTIONS,
+              {
+                filters: `CERT:${params.cert}`,
+                fields: "CERT,NAME,CITY,STALP,BKCLASS",
+                limit: 1,
+              },
+              { signal: controller.signal },
+            ),
+            queryEndpoint(
+              ENDPOINTS.FINANCIALS,
+              {
+                filters: `CERT:${params.cert} AND REPDTE:${params.repdte}`,
+                fields: FINANCIAL_FIELDS,
+                limit: 1,
+              },
+              { signal: controller.signal },
+            ),
+          ]);
+
+          const profileRecords = extractRecords(profileResponse);
+          if (profileRecords.length === 0) {
+            return formatToolError(
+              new Error(
+                `No institution found with CERT number ${params.cert}.`,
+              ),
+            );
+          }
+          subjectProfile = profileRecords[0];
+
+          const financialRecords = extractRecords(financialsResponse);
+          if (financialRecords.length === 0) {
+            return formatToolError(
+              new Error(
+                `No financial data for CERT ${params.cert} at report date ${params.repdte}. ` +
+                  `Auto-derivation of peer criteria requires asset data at the specified report date.`,
+              ),
+            );
+          }
+          subjectFinancials = financialRecords[0];
+        }
+
+        // Derive defaults and apply overrides
+        const subjectAsset =
+          subjectFinancials && typeof subjectFinancials.ASSET === "number"
+            ? subjectFinancials.ASSET
+            : null;
+
+        const assetMin =
+          params.asset_min ??
+          (subjectAsset !== null ? subjectAsset * 0.5 : undefined);
+        const assetMax =
+          params.asset_max ??
+          (subjectAsset !== null ? subjectAsset * 2.0 : undefined);
+        const charterClasses =
+          params.charter_classes ??
+          (subjectProfile && typeof subjectProfile.BKCLASS === "string"
+            ? [subjectProfile.BKCLASS]
+            : undefined);
+        const { state, active_only, raw_filter } = params;
+
+        // --- Phase 2: Build peer roster ---
+        const filterParts: string[] = [];
+        if (assetMin !== undefined || assetMax !== undefined) {
+          const min = assetMin ?? 0;
+          const max = assetMax ?? "*";
+          filterParts.push(`ASSET:[${min} TO ${max}]`);
+        }
+        if (charterClasses && charterClasses.length > 0) {
+          const classFilter = charterClasses
+            .map((cls) => `BKCLASS:${cls}`)
+            .join(" OR ");
+          filterParts.push(
+            charterClasses.length > 1 ? `(${classFilter})` : classFilter,
+          );
+        }
+        if (state) filterParts.push(`STALP:${state}`);
+        if (active_only) filterParts.push("ACTIVE:1");
+        if (raw_filter) filterParts.push(`(${raw_filter})`);
+
+        const rosterResponse = await queryEndpoint(
+          ENDPOINTS.INSTITUTIONS,
+          {
+            filters: filterParts.join(" AND "),
+            fields: "CERT,NAME,CITY,STALP,BKCLASS",
+            limit: 10_000,
+            offset: 0,
+            sort_by: "CERT",
+            sort_order: "ASC",
+          },
+          { signal: controller.signal },
+        );
+
+        let rosterRecords = extractRecords(rosterResponse);
+        if (rosterResponse.meta.total > rosterRecords.length) {
+          warnings.push(
+            `Institution roster truncated to ${rosterRecords.length.toLocaleString()} records ` +
+              `out of ${rosterResponse.meta.total.toLocaleString()} matched institutions. ` +
+              `Narrow the peer group criteria for complete analysis.`,
+          );
+        }
+
+        // Remove subject from roster
+        if (params.cert) {
+          rosterRecords = rosterRecords.filter(
+            (r) => asNumber(r.CERT) !== params.cert,
+          );
+        }
+
+        const criteriaUsed = {
+          asset_min: assetMin ?? null,
+          asset_max: assetMax ?? null,
+          charter_classes: charterClasses ?? null,
+          state: state ?? null,
+          active_only,
+          raw_filter: raw_filter ?? null,
+        };
+
+        if (rosterRecords.length === 0) {
+          const subjectMetrics = subjectFinancials
+            ? deriveMetrics(subjectFinancials)
+            : null;
+          const output: Record<string, unknown> = {};
+
+          if (subjectProfile) {
+            output.subject = {
+              cert: params.cert,
+              name: subjectProfile.NAME,
+              city: subjectProfile.CITY,
+              stalp: subjectProfile.STALP,
+              bkclass: subjectProfile.BKCLASS,
+              metrics: subjectMetrics,
+              rankings: null,
+            };
+          }
+
+          output.peer_group = {
+            repdte: params.repdte,
+            criteria_used: criteriaUsed,
+            medians: {},
+          };
+          output.metric_definitions = METRIC_DEFINITIONS;
+          output.peers = [];
+          output.peer_count = 0;
+          output.returned_count = 0;
+          output.has_more = false;
+          output.message = "No peers matched the specified criteria.";
+          output.warnings = warnings;
+
+          const text = formatPeerGroupText(
+            params.repdte,
+            subjectProfile,
+            subjectMetrics,
+            {},
+            {},
+            [],
+            0,
+            warnings,
+          );
+
+          return {
+            content: [{ type: "text", text }],
+            structuredContent: output,
+          };
+        }
+
+        // --- Phase 3: Fetch peer financials ---
+        const peerCerts = rosterRecords
+          .map((r) => asNumber(r.CERT))
+          .filter((c): c is number => c !== null);
+
+        const certFilters = buildCertFilters(peerCerts);
+        const extraFieldsCsv =
+          params.extra_fields && params.extra_fields.length > 0
+            ? "," + params.extra_fields.join(",")
+            : "";
+
+        const financialResponses = await mapWithConcurrency(
+          certFilters,
+          MAX_CONCURRENCY,
+          async (certFilter) =>
+            queryEndpoint(
+              ENDPOINTS.FINANCIALS,
+              {
+                filters: `(${certFilter}) AND REPDTE:${params.repdte}`,
+                fields: FINANCIAL_FIELDS + extraFieldsCsv,
+                limit: 10_000,
+                offset: 0,
+                sort_by: "CERT",
+                sort_order: "ASC",
+              },
+              { signal: controller.signal },
+            ),
+        );
+
+        const peerFinancialsByCert = new Map<
+          number,
+          Record<string, unknown>
+        >();
+        for (const response of financialResponses) {
+          for (const record of extractRecords(response)) {
+            const cert = asNumber(record.CERT);
+            if (cert !== null) peerFinancialsByCert.set(cert, record);
+          }
+        }
+
+        // Build roster lookup
+        const rosterByCert = new Map(
+          rosterRecords
+            .map((r) => [asNumber(r.CERT), r] as const)
+            .filter(
+              (e): e is [number, Record<string, unknown>] => e[0] !== null,
+            ),
+        );
+
+        // Compute metrics for peers that have financials
+        const peers: PeerEntry[] = [];
+        for (const [cert, financials] of peerFinancialsByCert) {
+          const roster = rosterByCert.get(cert);
+          const metrics = deriveMetrics(financials);
+          const extraFields: Record<string, unknown> = {};
+          if (params.extra_fields) {
+            for (const field of params.extra_fields) {
+              extraFields[field] = financials[field] ?? null;
+            }
+          }
+          peers.push({
+            cert,
+            name: String(roster?.NAME ?? financials.NAME ?? cert),
+            city: roster?.CITY != null ? String(roster.CITY) : null,
+            stalp: roster?.STALP != null ? String(roster.STALP) : null,
+            bkclass: roster?.BKCLASS != null ? String(roster.BKCLASS) : null,
+            metrics,
+            extraFields,
+          });
+        }
+
+        const peerCount = peers.length;
+
+        // --- Phase 4: Rank and assemble ---
+        const subjectMetrics = subjectFinancials
+          ? deriveMetrics(subjectFinancials)
+          : null;
+
+        const rankings: Record<string, RankResult | null> = {};
+        const medians: Record<string, number | null> = {};
+
+        for (const key of METRIC_KEYS) {
+          const peerValues = peers
+            .map((p) => p.metrics[key])
+            .filter((v): v is number => v !== null);
+
+          medians[key] = computeMedian(peerValues);
+
+          if (subjectMetrics && subjectMetrics[key] !== null) {
+            rankings[key] = computeCompetitionRank(
+              subjectMetrics[key]!,
+              peerValues,
+              METRIC_DEFINITIONS[key].higher_is_better,
+            );
+          } else {
+            rankings[key] = null;
+          }
+        }
+
+        // Sort peers by asset descending, truncate
+        peers.sort((a, b) => (b.metrics.asset ?? 0) - (a.metrics.asset ?? 0));
+        const returnedPeers = peers.slice(0, params.limit);
+        const returnedCount = returnedPeers.length;
+        const hasMore = peerCount > returnedCount;
+
+        // Build output
+        const output: Record<string, unknown> = {};
+
+        if (subjectProfile && subjectMetrics) {
+          output.subject = {
+            cert: params.cert,
+            name: subjectProfile.NAME,
+            city: subjectProfile.CITY,
+            stalp: subjectProfile.STALP,
+            bkclass: subjectProfile.BKCLASS,
+            metrics: subjectMetrics,
+            rankings,
+          };
+        }
+
+        output.peer_group = {
+          repdte: params.repdte,
+          criteria_used: criteriaUsed,
+          medians,
+        };
+        output.metric_definitions = METRIC_DEFINITIONS;
+        output.peers = returnedPeers.map((p) => ({
+          cert: p.cert,
+          name: p.name,
+          city: p.city,
+          stalp: p.stalp,
+          metrics: p.metrics,
+          ...p.extraFields,
+        }));
+        output.peer_count = peerCount;
+        output.returned_count = returnedCount;
+        output.has_more = hasMore;
+        output.message = null;
+        output.warnings = warnings;
+
+        const text = truncateIfNeeded(
+          formatPeerGroupText(
+            params.repdte,
+            subjectProfile,
+            subjectMetrics,
+            rankings,
+            medians,
+            returnedPeers,
+            peerCount,
+            warnings,
+          ),
+          CHARACTER_LIMIT,
+        );
+
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: output,
+        };
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return formatToolError(
+            new Error(
+              `Peer group analysis timed out after ${Math.floor(ANALYSIS_TIMEOUT_MS / 1000)} seconds. ` +
+                `Narrow the peer group criteria and try again.`,
+            ),
+          );
+        }
+        return formatToolError(err);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    },
+  );
+}

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -67,7 +67,7 @@ describe("HTTP MCP server", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.body.result.tools).toHaveLength(11);
+    expect(response.body.result.tools).toHaveLength(12);
     expect(
       response.body.result.tools.map((tool: { name: string }) => tool.name),
     ).toContain("fdic_search_demographics");
@@ -661,5 +661,176 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toContain(
       "Warning: Institution roster truncated to 10,000 records out of 10,500 matched institutions.",
     );
+  });
+
+  it("includes fdic_peer_group_analysis in the tool list", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 100,
+      method: "tools/list",
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.tools.map((tool: { name: string }) => tool.name),
+    ).toContain("fdic_peer_group_analysis");
+  });
+
+  it("performs subject-driven peer group analysis", async () => {
+    getMock
+      // Phase 1: institutions lookup
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Subject Bank", CITY: "Wilmington", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 1: subject financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, ASSET: 1000, DEP: 800, NETINC: 20, ROA: 1.5, ROE: 12.0, NETNIM: 3.5, EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25 } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 2: peer roster
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 100, NAME: "Subject Bank", CITY: "Wilmington", STALP: "NC", BKCLASS: "NM" } },
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "NM" } },
+            { data: { CERT: 300, NAME: "Peer B", CITY: "Charlotte", STALP: "NC", BKCLASS: "NM" } },
+          ],
+          meta: { total: 3 },
+        },
+      })
+      // Phase 3: peer financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, ASSET: 900, DEP: 700, NETINC: 15, ROA: 1.2, ROE: 10.0, NETNIM: 3.0, EQTOT: 90, LNLSNET: 500, INTINC: 40, EINTEXP: 12, NONII: 8, NONIX: 22 } },
+            { data: { CERT: 300, ASSET: 1100, DEP: 850, NETINC: 25, ROA: 1.8, ROE: 14.0, NETNIM: 4.0, EQTOT: 120, LNLSNET: 700, INTINC: 60, EINTEXP: 18, NONII: 12, NONIX: 28 } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 101,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: { cert: 100, repdte: "20241231" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.peer_count).toBe(2);
+    expect(sc.returned_count).toBe(2);
+    expect(sc.subject.cert).toBe(100);
+    expect(sc.subject.rankings.roa).toMatchObject({ of: 2 });
+    // Subject ROA 1.5 vs peers [1.2, 1.8] → sorted desc: 1.8, 1.5, 1.2 → subject rank 2
+    expect(sc.subject.rankings.roa.rank).toBe(2);
+    expect(sc.peers).toHaveLength(2);
+    // Peer B (CERT 300, ASSET 1100) should be first (highest asset)
+    expect(sc.peers[0].cert).toBe(300);
+    expect(sc.metric_definitions.roa.higher_is_better).toBe(true);
+    expect(sc.metric_definitions.efficiency_ratio.higher_is_better).toBe(false);
+    expect(sc.warnings).toEqual([]);
+    expect(sc.message).toBeNull();
+    expect(response.body.result.content[0].text).toContain("Subject Bank");
+    expect(response.body.result.content[0].text).toContain("December 31, 2024");
+  });
+
+  it("performs explicit-criteria peer group analysis without subject", async () => {
+    getMock
+      // Phase 2: peer roster (no Phase 1 since no cert)
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "N" } },
+            { data: { CERT: 300, NAME: "Peer B", CITY: "Charlotte", STALP: "NC", BKCLASS: "N" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      // Phase 3: peer financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, ASSET: 5000000, DEP: 4000000, NETINC: 100000, ROA: 1.0, ROE: 9.0, NETNIM: 3.0, EQTOT: 500000, LNLSNET: 3000000, INTINC: 200000, EINTEXP: 80000, NONII: 30000, NONIX: 100000 } },
+            { data: { CERT: 300, ASSET: 8000000, DEP: 6000000, NETINC: 200000, ROA: 1.5, ROE: 11.0, NETNIM: 3.5, EQTOT: 900000, LNLSNET: 4500000, INTINC: 350000, EINTEXP: 120000, NONII: 50000, NONIX: 150000 } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 102,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: {
+          repdte: "20241231",
+          asset_min: 5000000,
+          asset_max: 20000000,
+          charter_classes: ["N"],
+          state: "NC",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.subject).toBeUndefined();
+    expect(sc.peer_count).toBe(2);
+    expect(sc.peer_group.criteria_used.state).toBe("NC");
+    expect(sc.peer_group.medians.roa).toBe(1.25);
+    expect(response.body.result.content[0].text).toContain("Peer group medians");
+  });
+
+  it("returns empty result when no peers match", async () => {
+    getMock
+      // Phase 1: institutions
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Lonely Bank", CITY: "Nowhere", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 1: financials
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, ASSET: 1000, DEP: 800, ROA: 1.0, ROE: 8.0, NETNIM: 3.0, EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25 } }],
+          meta: { total: 1 },
+        },
+      })
+      // Phase 2: roster returns only the subject
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 100, NAME: "Lonely Bank", CITY: "Nowhere", STALP: "NC", BKCLASS: "NM" } }],
+          meta: { total: 1 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 103,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: { cert: 100, repdte: "20241231" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.peer_count).toBe(0);
+    expect(sc.message).toBe("No peers matched the specified criteria.");
+    expect(sc.peers).toEqual([]);
+    expect(sc.subject.rankings).toBeNull();
   });
 });

--- a/tests/peerGroup.test.ts
+++ b/tests/peerGroup.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveMetrics,
+  computeMedian,
+  computeCompetitionRank,
+  formatRepdteHuman,
+  PeerGroupInputSchema,
+} from "../src/tools/peerGroup.js";
+
+describe("deriveMetrics", () => {
+  it("computes all derived metrics from raw financial fields", () => {
+    const result = deriveMetrics({
+      ASSET: 1000,
+      DEP: 800,
+      ROA: 1.5,
+      ROE: 12.0,
+      NETNIM: 3.5,
+      EQTOT: 100,
+      LNLSNET: 600,
+      INTINC: 50,
+      EINTEXP: 15,
+      NONII: 10,
+      NONIX: 25,
+    });
+
+    expect(result.asset).toBe(1000);
+    expect(result.dep).toBe(800);
+    expect(result.roa).toBe(1.5);
+    expect(result.roe).toBe(12.0);
+    expect(result.netnim).toBe(3.5);
+    expect(result.equity_ratio).toBeCloseTo(10.0);
+    // efficiency_ratio = 25 / (35 + 10) * 100 = 55.556
+    expect(result.efficiency_ratio).toBeCloseTo(55.556, 2);
+    expect(result.loan_to_deposit).toBeCloseTo(0.75);
+    expect(result.deposits_to_assets).toBeCloseTo(0.8);
+    // noninterest_income_share = 10 / (35 + 10) = 0.2222
+    expect(result.noninterest_income_share).toBeCloseTo(0.2222, 3);
+  });
+
+  it("returns null for equity_ratio and deposits_to_assets when ASSET is zero", () => {
+    const result = deriveMetrics({
+      ASSET: 0, DEP: 800, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25,
+    });
+    expect(result.equity_ratio).toBeNull();
+    expect(result.deposits_to_assets).toBeNull();
+  });
+
+  it("returns null for efficiency_ratio when denominator is zero or negative", () => {
+    const result = deriveMetrics({
+      ASSET: 1000, DEP: 800, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 10, EINTEXP: 15, NONII: 5, NONIX: 25,
+    });
+    // net_interest_income = 10 - 15 = -5, denominator = -5 + 5 = 0
+    expect(result.efficiency_ratio).toBeNull();
+    expect(result.noninterest_income_share).toBeNull();
+  });
+
+  it("returns null for loan_to_deposit when DEP is zero", () => {
+    const result = deriveMetrics({
+      ASSET: 1000, DEP: 0, ROA: 1, ROE: 8, NETNIM: 3,
+      EQTOT: 100, LNLSNET: 600, INTINC: 50, EINTEXP: 15, NONII: 10, NONIX: 25,
+    });
+    expect(result.loan_to_deposit).toBeNull();
+  });
+
+  it("handles null input fields gracefully", () => {
+    const result = deriveMetrics({
+      ASSET: null, DEP: null, ROA: null, ROE: null, NETNIM: null,
+      EQTOT: null, LNLSNET: null, INTINC: null, EINTEXP: null, NONII: null, NONIX: null,
+    });
+    expect(result.asset).toBeNull();
+    expect(result.dep).toBeNull();
+    expect(result.roa).toBeNull();
+    expect(result.equity_ratio).toBeNull();
+    expect(result.efficiency_ratio).toBeNull();
+    expect(result.loan_to_deposit).toBeNull();
+    expect(result.deposits_to_assets).toBeNull();
+    expect(result.noninterest_income_share).toBeNull();
+  });
+});
+
+describe("computeMedian", () => {
+  it("returns the middle value for an odd-length array", () => {
+    expect(computeMedian([1, 3, 5])).toBe(3);
+  });
+
+  it("returns the average of middle values for an even-length array", () => {
+    expect(computeMedian([1, 3, 5, 7])).toBe(4);
+  });
+
+  it("returns the single value for a one-element array", () => {
+    expect(computeMedian([42])).toBe(42);
+  });
+
+  it("returns null for an empty array", () => {
+    expect(computeMedian([])).toBeNull();
+  });
+
+  it("does not modify the input array", () => {
+    const input = [5, 1, 3];
+    computeMedian(input);
+    expect(input).toEqual([5, 1, 3]);
+  });
+});
+
+describe("computeCompetitionRank", () => {
+  it("ranks a value among peers (higher-is-better, descending sort)", () => {
+    const result = computeCompetitionRank(7, [10, 8, 6, 4, 2], true);
+    expect(result).toEqual({ rank: 3, of: 5, percentile: 60 });
+  });
+
+  it("ranks a value among peers (lower-is-better, ascending sort)", () => {
+    const result = computeCompetitionRank(3, [10, 8, 6, 4, 2], false);
+    expect(result).toEqual({ rank: 2, of: 5, percentile: 80 });
+  });
+
+  it("handles ties — subject gets same rank as equal peers", () => {
+    // Peers: [10, 8, 8, 4], subject: 8
+    // All values desc: 10, 8, 8, 8, 4
+    // Competition ranks: 10→1, 8→2, 4→5
+    // Subject value 8 → rank 2
+    const result = computeCompetitionRank(8, [10, 8, 8, 4], true);
+    expect(result).toEqual({ rank: 2, of: 4, percentile: 75 });
+  });
+
+  it("gives rank 1 and 100th percentile when subject is best", () => {
+    const result = computeCompetitionRank(99, [10, 20, 30], true);
+    expect(result).toEqual({ rank: 1, of: 3, percentile: 100 });
+  });
+
+  it("gives last rank when subject is worst (higher-is-better)", () => {
+    const result = computeCompetitionRank(1, [10, 20, 30], true);
+    // All desc: 30, 20, 10, 1 → subject rank 4
+    expect(result).toEqual({ rank: 4, of: 3, percentile: 0 });
+  });
+
+  it("handles null-direction metrics (descending sort by default)", () => {
+    const result = computeCompetitionRank(5, [10, 8, 3, 1], null);
+    // All desc: 10, 8, 5, 3, 1 → subject rank 3
+    expect(result).toEqual({ rank: 3, of: 4, percentile: 50 });
+  });
+
+  it("returns null when peer list is empty", () => {
+    expect(computeCompetitionRank(5, [], true)).toBeNull();
+  });
+});
+
+describe("formatRepdteHuman", () => {
+  it("formats YYYYMMDD as a human-readable date", () => {
+    expect(formatRepdteHuman("20241231")).toBe("December 31, 2024");
+  });
+
+  it("formats March date correctly", () => {
+    expect(formatRepdteHuman("20230331")).toBe("March 31, 2023");
+  });
+
+  it("returns the raw string for invalid dates", () => {
+    expect(formatRepdteHuman("bad")).toBe("bad");
+  });
+});
+
+describe("PeerGroupInputSchema", () => {
+  it("accepts subject-driven mode with cert and repdte", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      cert: 29846,
+      repdte: "20241231",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts explicit-criteria mode without cert", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      asset_min: 5000000,
+      asset_max: 20000000,
+      charter_classes: ["N"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when repdte is missing", () => {
+    const result = PeerGroupInputSchema.safeParse({ cert: 29846 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when no peer-group constructor is provided", () => {
+    const result = PeerGroupInputSchema.safeParse({ repdte: "20241231" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when asset_min > asset_max", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      asset_min: 20000000,
+      asset_max: 5000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid state codes", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      state: "North Carolina",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid two-letter state code", () => {
+    const result = PeerGroupInputSchema.safeParse({
+      repdte: "20241231",
+      state: "NC",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("applies defaults for active_only and limit", () => {
+    const result = PeerGroupInputSchema.parse({
+      cert: 29846,
+      repdte: "20241231",
+    });
+    expect(result.active_only).toBe(true);
+    expect(result.limit).toBe(50);
+  });
+});


### PR DESCRIPTION
**Closes #18**

## Summary
Adds a new `fdic_peer_group_analysis` tool that builds a peer group for an FDIC-insured institution and ranks it against peers on 10 financial and efficiency metrics at a single report date. The tool is stateless — peer CERTs are returned in the response and can be passed to `fdic_compare_bank_snapshots` for trend analysis.

## Root Cause
The server covered all 8 FDIC BankFind API endpoints but lacked SDI-style peer group comparison functionality — one of the most common uses of bank financial data. No new external API was needed; the peer group analysis is computed entirely from existing `institutions` and `financials` endpoint data.

## Fix Strategy
Single new tool module (`src/tools/peerGroup.ts`) following the established pattern of `analysis.ts`. The tool supports three usage modes:

1. **Subject-driven**: provide `cert` and `repdte` — auto-derives peer criteria from the subject's report-date asset size and charter class
2. **Explicit criteria**: provide `repdte` plus `asset_min`/`asset_max`, `charter_classes`, `state`, or `raw_filter`
3. **Subject with overrides**: provide `cert` plus explicit criteria to override auto-derived defaults

The computation pipeline has four phases: resolve subject profile and financials → build peer roster → fetch peer financials (batched) → compute metrics, rank, and assemble output.

Key design decisions:
- **Competition rank** (`1, 2, 2, 4`) with metric-specific denominators — ties get the same rank, subject receives the same rank as equal-valued peers
- **Subject excluded** from peer set, medians, and ranking denominators
- **Metric definitions** included in output with `higher_is_better` directionality and `ranking_note` for contextual metrics
- **Override precedence**: `cert` derives defaults, explicit params override them
- **Asset defaults derived from report-date financials**, not the institutions snapshot, to match the analysis period

## Changes

| File | Change |
|------|--------|
| `src/tools/peerGroup.ts` | New tool module: input schema, derived metrics computation, competition ranking, median computation, text formatting, 4-phase pipeline, tool registration |
| `src/index.ts` | Import and register `registerPeerGroupTools` |
| `tests/peerGroup.test.ts` | 28 unit tests: `deriveMetrics` (happy path, zero/negative denominators, null inputs), `computeMedian` (odd/even/single/empty/immutability), `computeCompetitionRank` (higher/lower-is-better, ties, best/worst, null direction, empty peers), `formatRepdteHuman`, `PeerGroupInputSchema` validation |
| `tests/mcp-http.test.ts` | 4 integration tests: tool list inclusion, subject-driven analysis, explicit-criteria analysis, empty peer set. Updated tool count assertion from 11 to 12 |
| `README.md` | Updated tool count, added tool to table, added Peer Group Analysis section with usage examples |
| `docs/plans/2026-03-15-peer-group-analysis-design.md` | Design document covering input schema, output shape, computation pipeline, and text formatting |
| `docs/plans/2026-03-15-peer-group-analysis-plan.md` | Implementation plan with task breakdown |

## Validation
- [x] All 63 tests pass (28 new unit tests + 4 new integration tests + 31 existing tests)
- [x] TypeScript typecheck passes with no errors
- [x] Build succeeds
- [x] Subject-driven mode: auto-derives peer criteria, ranks subject, excludes subject from peer set
- [x] Explicit-criteria mode: returns medians without subject rankings
- [x] Empty peer set: returns valid response with `peer_count: 0` and informational message
- [x] Competition rank with ties verified (subject gets same rank as equal-valued peers)
- [x] Metric-specific ranking denominators (peers with null values excluded per-metric)
- [x] Null/zero guards on all derived metrics (equity_ratio, efficiency_ratio, loan_to_deposit, deposits_to_assets, noninterest_income_share)
- [x] Text output uses human-readable dates and fixed metric ordering
- [x] Roster truncation warning propagated correctly
- [x] Existing tool behavior unchanged (all prior tests pass unmodified except tool count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)