### PR TITLE
Refactor repository documentation and docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thanks for contributing to `fdic-mcp-server`.
+
+## Before You Start
+
+- Read [README.md](./README.md) for the project overview.
+- Read [AGENTS.md](./AGENTS.md) for repo-specific execution rules.
+- Review the published docs entry point at [docs/index.md](./docs/index.md).
+
+## Development Setup
+
+Prerequisites:
+
+- Node.js 18 or later
+- npm
+
+Install and validate:
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+Run locally over stdio:
+
+```bash
+node dist/index.js
+```
+
+Run locally over HTTP:
+
+```bash
+TRANSPORT=http PORT=3000 node dist/index.js
+```
+
+## Workflow
+
+1. Create a focused branch from `main`.
+2. Keep changes small and explicit.
+3. Add or update tests when behavior, output shape, ranking, or error handling changes.
+4. Run the full validation commands before opening a pull request.
+5. Document any user-facing behavior changes in the docs or release notes.
+
+## Pull Requests
+
+Include:
+
+- What changed
+- Why it changed
+- How it was validated
+- Any follow-up risks or open questions
+
+## Documentation Changes
+
+If you change prompts, tool contracts, client setup guidance, or technical behavior, update the relevant pages under [docs/](./docs/index.md).
+
+## Support
+
+- Open a bug report or feature request in the GitHub issue tracker: <https://github.com/jflamb/fdic-mcp-server/issues>
+- For documentation issues, include the page path and the specific gap or inaccuracy

--- a/README.md
+++ b/README.md
@@ -1,83 +1,58 @@
 # FDIC BankFind MCP Server
 
-An MCP (Model Context Protocol) server that provides access to the [FDIC BankFind Suite API](https://api.fdic.gov/banks/docs/), giving LLMs programmatic access to public data on FDIC-insured financial institutions.
+`fdic-mcp-server` is an MCP (Model Context Protocol) server for the [FDIC BankFind Suite API](https://api.fdic.gov/banks/docs/). It gives LLM hosts a clean way to search FDIC-insured institutions, retrieve public banking records, and run common multi-bank analysis workflows without custom FDIC API plumbing.
 
-## Features
+It is useful when you want an MCP-compatible client to answer questions about banks, failures, branches, quarterly financials, deposit data, or peer performance using a stable tool surface and machine-readable responses.
 
-- **No API key required** — The FDIC BankFind API is publicly available
-- **12 tools** covering BankFind datasets plus built-in analytical tools
-- **Flexible ElasticSearch-style filtering** on all endpoints
-- **Pagination support** for large result sets
-- **Dual transport**: stdio (local) or HTTP (remote)
-- **Structured tool output** via `structuredContent` for MCP clients
-- **Built-in analytical batching** for multi-bank comparisons
-- **Short-lived response caching** for repeated analytical prompts
+## Table Of Contents
 
-## Available Tools
+- [Project Status](#project-status)
+- [Why This Project Exists](#why-this-project-exists)
+- [Documentation](#documentation)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Available Tools](#available-tools)
+- [Data Notes](#data-notes)
+- [Support](#support)
+- [Contributing](#contributing)
+- [License](#license)
 
-| Tool | Description |
-|------|-------------|
-| `fdic_search_institutions` | Search FDIC-insured banks and savings institutions |
-| `fdic_get_institution` | Get details for a specific institution by CERT number |
-| `fdic_search_failures` | Search failed bank records |
-| `fdic_get_institution_failure` | Get failure details for a specific institution |
-| `fdic_search_locations` | Search branch/office locations |
-| `fdic_search_history` | Search structural change events (mergers, name changes, etc.) |
-| `fdic_search_financials` | Search quarterly Call Report financial data |
-| `fdic_search_summary` | Search annual financial summary data |
-| `fdic_search_sod` | Search Summary of Deposits (branch-level deposit data) |
-| `fdic_search_demographics` | Search quarterly demographics and market-structure data |
-| `fdic_compare_bank_snapshots` | Compare two reporting snapshots across banks and rank growth/profitability changes |
-| `fdic_peer_group_analysis` | Build a peer group and rank an institution against peers on financial metrics |
+## Project Status
 
-Two tools are server-side analysis helpers:
-- `fdic_compare_bank_snapshots` batches roster lookup, financial snapshots, and optional demographics snapshots inside the MCP server so complex trend prompts do not require many separate tool calls
-- `fdic_peer_group_analysis` builds a peer group from asset size, charter class, and geography criteria, then ranks an institution against peers on financial and efficiency metrics
+Active development. The server is usable today and the tool surface is covered by tests, but the project is still evolving as client support and analysis workflows improve.
 
-Two tools are convenience lookups rather than separate BankFind datasets:
-- `fdic_get_institution` wraps the `institutions` dataset
-- `fdic_get_institution_failure` wraps the `failures` dataset
+## Why This Project Exists
 
-`fdic_compare_bank_snapshots` supports both `snapshot` comparisons and `timeseries` analysis across a quarterly range. It computes derived efficiency and balance-sheet metrics and assigns insight tags for notable growth patterns
+The FDIC BankFind Suite API is public and useful, but it is not packaged for MCP clients out of the box. This project solves that by:
 
-## Filter Syntax
+- exposing BankFind datasets as MCP tools
+- preserving both human-readable and machine-readable responses
+- adding server-side analysis helpers for multi-bank comparison workflows
+- supporting both local stdio hosts and remote HTTP hosts
 
-All tools support ElasticSearch query string syntax for filtering:
+## Documentation
 
-```
-# Exact match
-NAME:"Chase Bank"
-
-# State filter
-STNAME:"California"
-
-# Numeric range (assets in $thousands)
-ASSET:[1000000 TO *]
-
-# Date range (hyphenated format for failures/history datasets)
-FAILDATE:[2008-01-01 TO 2010-12-31]
-
-# Date range (compact YYYYMMDD format for financials/demographics/summary datasets)
-REPDTE:[20230101 TO 20231231]
-
-# Combine with AND / OR
-STNAME:"Texas" AND ACTIVE:1 AND ASSET:[500000 TO *]
-
-# Exclude
-!(BKCLASS:NM OR BKCLASS:N)
-```
-
-Field names vary by dataset. For example:
-- `institutions` commonly uses fields like `STNAME`, `ASSET`, `ACTIVE`
-- `failures` commonly uses fields like `FAILDATE`, `COST`, `RESTYPE`
-- `locations` commonly uses fields like `STALP`, `CITY`, `BRNUM`
-- `sod` commonly uses fields like `STALPBR`, `CITYBR`, `DEPSUMBR`
-
-Use the tool description or `fields` parameter to tailor queries to the dataset you are calling.
+- GitHub Pages docs entry point: <https://jflamb.github.io/fdic-mcp-server/>
+- Local docs home: [docs/index.md](./docs/index.md)
+- Getting started: [docs/getting-started.md](./docs/getting-started.md)
+- Prompting guide: [docs/prompting-guide.md](./docs/prompting-guide.md)
+- Usage examples: [docs/usage-examples.md](./docs/usage-examples.md)
+- Tool reference: [docs/tool-reference.md](./docs/tool-reference.md)
+- Client setup: [docs/clients.md](./docs/clients.md)
+- Troubleshooting and FAQ: [docs/troubleshooting.md](./docs/troubleshooting.md)
+- Compatibility matrix: [docs/compatibility-matrix.md](./docs/compatibility-matrix.md)
+- Technical specification: [docs/technical/specification.md](./docs/technical/specification.md)
+- Architecture: [docs/technical/architecture.md](./docs/technical/architecture.md)
+- Key decisions: [docs/technical/decisions.md](./docs/technical/decisions.md)
+- Release notes: [docs/release-notes/index.md](./docs/release-notes/index.md)
+- Security policy: [SECURITY.md](./SECURITY.md)
 
 ## Installation
 
-### From npm
+Prerequisites:
+
+- Node.js 18 or later
+- npm
 
 Run directly without a global install:
 
@@ -85,70 +60,48 @@ Run directly without a global install:
 npx fdic-mcp-server
 ```
 
-Or install globally:
+Install globally:
 
 ```bash
 npm install -g fdic-mcp-server
 fdic-mcp-server
 ```
 
-### From GitHub Packages
-
-The GitHub Packages mirror is published as `@jflamb/fdic-mcp-server`.
+Install from GitHub Packages:
 
 ```bash
 npm install -g @jflamb/fdic-mcp-server --registry=https://npm.pkg.github.com
 fdic-mcp-server
 ```
 
-### From source
+Install from source:
 
 ```bash
+git clone https://github.com/jflamb/fdic-mcp-server.git
+cd fdic-mcp-server
 npm install
 npm run build
 ```
 
-## Development
-
-```bash
-npm run typecheck
-npm test
-npm run build
-```
-
-## CI And Releases
-
-- Pull requests should target `main`
-- Continuous integration runs on pushes to `main` and on pull requests targeting `main`
-- Package publish is reserved for semantic version tags like `v1.2.3`
-- Release tags must point at a commit already on `main`
-
-To prepare a release:
-
-```bash
-npm version patch
-git push origin main --follow-tags
-```
-
-Publishing from GitHub Actions is intended to use npm trusted publishing via GitHub Actions OIDC rather than a long-lived `NPM_TOKEN`.
-
 ## Usage
 
-Client-specific setup notes for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI are in [docs/clients.md](./docs/clients.md).
+### Run Locally
 
-### CLI bundle
-
-The build produces two outputs:
-- `dist/index.js`: CLI entrypoint for stdio/HTTP server execution
-- `dist/server.js`: import-safe library bundle exporting `createServer`, `createApp`, and `main`
-
-### stdio (for Claude Desktop / local MCP clients)
+Stdio transport:
 
 ```bash
 node dist/index.js
 ```
 
-**Claude Desktop config** (`~/Library/Application\ Support/Claude/claude_desktop_config.json`):
+HTTP transport:
+
+```bash
+TRANSPORT=http PORT=3000 node dist/index.js
+```
+
+The HTTP MCP endpoint is `http://localhost:3000/mcp`.
+
+### Minimal MCP Configuration
 
 ```json
 {
@@ -161,7 +114,7 @@ node dist/index.js
 }
 ```
 
-If running from a local clone instead of the npm package:
+If you are running from a local clone instead of the published package:
 
 ```json
 {
@@ -174,58 +127,28 @@ If running from a local clone instead of the npm package:
 }
 ```
 
-### HTTP server
+Client-specific setup details are in [docs/clients.md](./docs/clients.md).
 
-```bash
-TRANSPORT=http PORT=3000 node dist/index.js
-```
+### Usage Examples
 
-The MCP endpoint will be available at `http://localhost:3000/mcp`.
+Find active banks in North Carolina with assets over $1 billion:
 
-For direct HTTP MCP clients, include:
-- `Content-Type: application/json`
-- `Accept: application/json, text/event-stream`
-
-The streamable HTTP transport expects both response types to be accepted.
-
-## Example Queries
-
-**Find all active banks in North Carolina with assets over $1 billion:**
-```
+```text
 filters: STNAME:"North Carolina" AND ACTIVE:1 AND ASSET:[1000000 TO *]
 ```
 
-**Get the 10 costliest bank failures since 2000:**
-```
+Get the 10 costliest bank failures since January 1, 2000:
+
+```text
 filters: FAILDATE:[2000-01-01 TO *]
 sort_by: COST
 sort_order: DESC
 limit: 10
 ```
 
-**Get all branches of a specific bank:**
-```
-cert: 3511
-(fdic_search_locations)
-```
+Compare North Carolina banks between two quarterly report dates:
 
-**Get quarterly financials for Bank of America for 2023:**
-```
-cert: 3511
-filters: REPDTE:[20230101 TO 20231231]
-(fdic_search_financials)
-```
-
-**Get demographics history for a bank:**
-```
-cert: 3511
-sort_by: REPDTE
-sort_order: DESC
-(fdic_search_demographics)
-```
-
-**Rank banks by growth across two snapshots (default `analysis_mode: snapshot`):**
-```
+```text
 state: North Carolina
 start_repdte: 20211231
 end_repdte: 20250630
@@ -234,177 +157,70 @@ sort_order: DESC
 (fdic_compare_bank_snapshots)
 ```
 
-**Analyze quarterly trends with streaks and derived metrics (`analysis_mode: timeseries`):**
-```
-state: North Carolina
-start_repdte: 20211231
-end_repdte: 20250630
-analysis_mode: timeseries
-sort_by: asset_growth_pct
-sort_order: DESC
-(fdic_compare_bank_snapshots)
-```
+Build a peer group for a specific bank:
 
-**Find peers for a specific bank (auto-derived criteria):**
-```
+```text
 cert: 29846
 repdte: 20241231
 (fdic_peer_group_analysis)
 ```
 
-**Define a peer group with explicit criteria:**
-```
-repdte: 20241231
-asset_min: 5000000
-asset_max: 20000000
-charter_classes: ["N"]
-state: NC
-(fdic_peer_group_analysis)
-```
+More examples are in [docs/usage-examples.md](./docs/usage-examples.md).
 
-**Override auto-derived defaults:**
-```
-cert: 29846
-repdte: 20241231
-asset_min: 3000000
-state: NC
-(fdic_peer_group_analysis)
-```
+## Available Tools
 
-## Peer Group Analysis
+| Tool | Description |
+|------|-------------|
+| `fdic_search_institutions` | Search FDIC-insured banks and savings institutions |
+| `fdic_get_institution` | Get details for a specific institution by CERT number |
+| `fdic_search_failures` | Search failed bank records |
+| `fdic_get_institution_failure` | Get failure details for a specific institution |
+| `fdic_search_locations` | Search branch and office locations |
+| `fdic_search_history` | Search structural change events such as mergers and name changes |
+| `fdic_search_financials` | Search quarterly Call Report financial data |
+| `fdic_search_summary` | Search annual financial summary data |
+| `fdic_search_sod` | Search Summary of Deposits branch-level deposit data |
+| `fdic_search_demographics` | Search quarterly demographics and market-structure data |
+| `fdic_compare_bank_snapshots` | Compare two reporting snapshots across banks and rank growth and profitability changes |
+| `fdic_peer_group_analysis` | Build a peer group and rank an institution against peers on financial metrics |
 
-The `fdic_peer_group_analysis` tool builds a peer group for a bank and ranks it against peers on financial and efficiency metrics at a single report date.
+Two tools are server-side analysis helpers:
 
-The tool returns rankings (competition rank + percentile) and peer group medians for:
-- Total Assets, Total Deposits, ROA, ROE, Net Interest Margin
-- Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
-- Deposits-to-Assets Ratio, Non-Interest Income Share
-
-The subject bank is excluded from the peer set and ranking denominators. Ranking denominators are metric-specific — if some peers lack data for a metric, the denominator reflects only peers with valid values.
-
-Peer CERTs from the response can be passed to `fdic_compare_bank_snapshots` for trend analysis across the peer group.
-
-## Complex Prompts
-
-The built-in `fdic_compare_bank_snapshots` tool is meant to make analysis-heavy prompts performant by batching FDIC calls inside the MCP server. The server also caches repeated state/date lookups for a short period, which helps iterative analysis. Good examples:
-
-- Identify North Carolina banks with the strongest asset growth from 2021 to 2025, then compare whether that growth came with higher deposits, more branches, or better profitability
-- Rank a set of banks by deposit growth percentage between two report dates and check which ones also improved ROA or ROE
-- Compare current active banks in a state between two snapshots to see which institutions grew while reducing office counts
-- Analyze whether rapid asset growth was accompanied by stronger profitability or just balance-sheet expansion
-- Analyze quarterly trends from 2021 through 2025 and call out inflection points, sustained asset-growth streaks, or multi-quarter ROA declines
-- Identify banks whose deposits-per-office and assets-per-office improved even while total branch counts fell
-- Separate banks with branch-supported growth from banks that mainly expanded their balance sheets
-
-The tool can take either:
-- `state` plus optional `institution_filters` to build a roster
-- `certs` to compare a specific list of institutions directly
-
-Notable outputs from `fdic_compare_bank_snapshots`:
-- point-to-point changes for assets, deposits, net income, ROA, ROE, and office counts
-- derived metrics such as `assets_per_office_change`, `deposits_per_office_change`, and `deposits_to_assets_change`
-- insight tags (see [Insight Tags](#insight-tags) below)
-- in `timeseries` mode, quarterly series plus streak metrics
-
-### Insight Tags
-
-The analysis tool assigns insight tags to individual comparisons and aggregates them in a top-level `insights` summary. All possible tags:
-
-| Tag | Meaning |
-|-----|---------|
-| `growth_with_better_profitability` | Asset growth >= 25%, deposit growth >= 15%, and ROA improved |
-| `growth_with_branch_expansion` | Asset growth >= 25%, deposit growth >= 15%, and office count increased |
-| `balance_sheet_growth_without_profitability` | Asset growth >= 20% but ROA and ROE both flat or declining |
-| `growth_with_branch_consolidation` | Positive asset growth while office count decreased |
-| `deposit_mix_softening` | Deposits declined both in absolute terms and as a share of total assets |
-| `sustained_asset_growth` | (timeseries only) Three or more consecutive quarters of rising assets |
-| `multi_quarter_roa_decline` | (timeseries only) Two or more consecutive quarters of falling ROA |
-
-## Response Shape
-
-All tools return:
-- a human-readable text representation in `content[0].text`
-- machine-readable data in `structuredContent`
-
-Typical search response shape:
-
-```json
-{
-  "total": 1,
-  "offset": 0,
-  "count": 1,
-  "has_more": false,
-  "institutions": [
-    {
-      "CERT": 3511,
-      "NAME": "Wells Fargo Bank, National Association"
-    }
-  ]
-}
-```
-
-Typical lookup miss response shape:
-
-```json
-{
-  "found": false,
-  "cert": 999999999,
-  "message": "No institution found with CERT number 999999999."
-}
-```
-
-Typical analysis response shape (`fdic_compare_bank_snapshots`):
-
-```json
-{
-  "total_candidates": 150,
-  "analyzed_count": 142,
-  "start_repdte": "20211231",
-  "end_repdte": "20250630",
-  "analysis_mode": "snapshot",
-  "sort_by": "asset_growth",
-  "sort_order": "DESC",
-  "warnings": [],
-  "insights": {
-    "growth_with_better_profitability": ["Bank A", "Bank B"],
-    "growth_with_branch_expansion": ["Bank A"],
-    "balance_sheet_growth_without_profitability": [],
-    "growth_with_branch_consolidation": ["Bank C"],
-    "deposit_mix_softening": [],
-    "sustained_asset_growth": [],
-    "multi_quarter_roa_decline": []
-  },
-  "total": 142,
-  "offset": 0,
-  "count": 10,
-  "has_more": true,
-  "next_offset": 10,
-  "comparisons": [
-    {
-      "cert": 12345,
-      "name": "Bank A",
-      "asset_growth": 50000,
-      "asset_growth_pct": 45.2,
-      "insights": ["growth_with_better_profitability", "growth_with_branch_expansion"]
-    }
-  ]
-}
-```
-
-The `warnings` array is populated when the server detects a data issue, such as the institution roster being truncated because it exceeded the FDIC API's per-request limit.
-
-In most successful analyses, `warnings` will be empty.
-
-The `sustained_asset_growth` and `multi_quarter_roa_decline` insight summaries are only populated for `analysis_mode: "timeseries"`.
+- `fdic_compare_bank_snapshots` batches roster lookup, financial snapshots, and optional demographics snapshots inside the MCP server
+- `fdic_peer_group_analysis` builds a peer group from asset size, charter class, and geography criteria and then ranks an institution against peers
 
 ## Data Notes
 
-- Monetary values are in **$thousands** unless otherwise noted
-- The `CERT` field is the unique FDIC Certificate Number for each institution
-- The `ACTIVE` field: `1` = currently active, `0` = inactive/closed
-- Report dates (`REPDTE`) are in `YYYYMMDD` format
-- The financials endpoint covers **1,100+ Call Report variables** — use `fields` to narrow results
-- `fdic_search_financials` defaults to `sort_order: DESC` for most-recent-first results
-- Most other search tools default to `sort_order: ASC`
-- The demographics endpoint is useful for office counts, metro/micro flags, territory assignments, and related geographic reference attributes
-- The demographics dataset is quarterly historical data, not just a current snapshot
+- Monetary values are generally reported in thousands of dollars.
+- `CERT` is the stable FDIC institution identifier.
+- Financial, summary, and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- SOD data is annual branch-level data as of June 30.
+- Do not mix quarterly financial data and annual branch data without stating the date basis.
+
+## Support
+
+Use the GitHub issue tracker for bugs, documentation problems, and feature requests: <https://github.com/jflamb/fdic-mcp-server/issues>
+
+The main support docs are:
+
+- [docs/support.md](./docs/support.md)
+- [docs/prompting-guide.md](./docs/prompting-guide.md)
+- [docs/usage-examples.md](./docs/usage-examples.md)
+- [docs/troubleshooting.md](./docs/troubleshooting.md)
+- [SECURITY.md](./SECURITY.md)
+
+## Contributing
+
+Contributor guidance lives in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+For local validation, run:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+```
+
+## License
+
+This project is licensed under the ISC License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+This project is under active development. Security fixes are applied to the latest released version on `main`.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | Best effort only |
+
+## Reporting A Vulnerability
+
+Do not open a public GitHub issue for a suspected security vulnerability.
+
+Instead:
+
+- email the maintainer if you already have a direct contact path, or
+- use GitHub Security Advisories for private reporting if enabled for the repository, or
+- if neither is available, open a minimal issue asking for a private contact path without disclosing exploit details
+
+Please include:
+
+- a clear description of the issue
+- affected versions or commit range if known
+- reproduction steps or a proof of concept
+- impact assessment
+- any suggested remediation
+
+## What To Expect
+
+- acknowledgment as soon as practical
+- an initial triage to confirm severity and scope
+- coordination on a fix and disclosure timing when the report is valid
+
+## Security Scope
+
+This repository:
+
+- does not require FDIC API credentials
+- should not contain secrets or API keys
+- exposes public FDIC data only
+
+Security-sensitive areas still include:
+
+- HTTP transport behavior
+- dependency vulnerabilities
+- malformed input handling in tool arguments and request parsing
+- accidental disclosure through logs or debug output
+
+## Operational Guidance
+
+- Prefer trusted publishing and short-lived credentials for package release workflows.
+- Do not commit secrets, tokens, or private endpoints.
+- Keep dependencies current and review CI or publishing workflow changes carefully.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+title: FDIC BankFind MCP Server
+description: Documentation for the MCP server that exposes the FDIC BankFind Suite API to LLM clients.
+theme: minima
+markdown: kramdown
+plugins:
+  - jekyll-seo-tag

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,8 +1,14 @@
+---
+title: Client Setup
+---
+
 # Client Setup
 
-This page collects minimal setup notes for common MCP clients.
+This page collects setup notes for common MCP clients.
 
-The examples below assume you already installed the published package:
+## Before You Configure A Client
+
+Install the published package:
 
 ```bash
 npm install -g fdic-mcp-server

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,0 +1,50 @@
+---
+title: MCP Host Compatibility Matrix
+---
+
+# MCP Host Compatibility Matrix
+
+This matrix summarizes the level of setup guidance and expected support for common MCP hosts documented in this repository.
+
+Last reviewed: March 15, 2026.
+
+| Host | Local Stdio | Remote HTTP | Documented Here | Support Level | Notes |
+|------|-------------|-------------|-----------------|---------------|-------|
+| Claude Desktop | Yes | No documented path here | Yes | Good | Best fit for local stdio setups |
+| ChatGPT Developer Mode | No direct local stdio | Yes | Yes | Good | Requires reachable HTTPS MCP endpoint |
+| Gemini CLI | Yes | Not documented here | Yes | Good | Local trust settings can block startup |
+| GitHub Copilot CLI | Yes | Not documented here | Yes | Good | Local config is straightforward |
+| Other MCP hosts | Varies | Varies | Generic only | Best effort | Validate transport support before relying on the server |
+
+## Support Level Meanings
+
+- `Good`: documented in this repo and expected to work with the current guidance
+- `Best effort`: likely compatible in principle, but not covered by host-specific instructions here
+
+## Notes By Host
+
+### Claude Desktop
+
+- Uses local stdio configuration
+- Restart required after config changes
+
+### ChatGPT Developer Mode
+
+- Requires remote HTTP or SSE
+- Local binaries are not enough unless exposed through a reachable HTTPS endpoint
+- Workspace or admin settings may affect availability
+
+### Gemini CLI
+
+- Local stdio works well
+- Project trust settings may need attention if the folder is not trusted
+
+### GitHub Copilot CLI
+
+- Local MCP registration is simple
+- New servers are typically available immediately after config update
+
+## Recommendation
+
+- Use Claude Desktop, Gemini CLI, or GitHub Copilot CLI for the simplest local setup
+- Use ChatGPT when you want a remotely hosted MCP app and are prepared to run HTTP transport

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,20 @@
+---
+title: Contributing
+---
+
+# Contributing
+
+The full contributor workflow lives in the repository root at `CONTRIBUTING.md`.
+
+## Summary
+
+- Create a focused branch from `main`.
+- Keep changes small and explicit.
+- Update tests for behavior or contract changes.
+- Update the docs when prompts, client setup, or technical behavior changes.
+- Run `npm run typecheck`, `npm test`, and `npm run build` before opening a pull request.
+
+## Repository Guide
+
+- GitHub view: <https://github.com/jflamb/fdic-mcp-server/blob/main/CONTRIBUTING.md>
+- Local file: `CONTRIBUTING.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,90 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+This server gives MCP-compatible clients access to public FDIC BankFind datasets and a set of server-side analysis tools for comparing institutions and peer groups.
+
+## Prerequisites
+
+- Node.js 18 or later
+- npm
+- An MCP-compatible host such as Claude Desktop, ChatGPT Developer Mode, Gemini CLI, or GitHub Copilot CLI
+
+## Install
+
+Run directly without a global install:
+
+```bash
+npx fdic-mcp-server
+```
+
+Install globally:
+
+```bash
+npm install -g fdic-mcp-server
+fdic-mcp-server
+```
+
+Install from source:
+
+```bash
+git clone https://github.com/jflamb/fdic-mcp-server.git
+cd fdic-mcp-server
+npm install
+npm run build
+```
+
+## Run The Server
+
+Stdio transport:
+
+```bash
+node dist/index.js
+```
+
+HTTP transport:
+
+```bash
+TRANSPORT=http PORT=3000 node dist/index.js
+```
+
+The HTTP MCP endpoint is available at `http://localhost:3000/mcp`.
+
+## Connect A Client
+
+Use the client-specific instructions in [Client Setup](./clients.md).
+
+For most local MCP hosts, the minimal stdio configuration looks like this:
+
+```json
+{
+  "mcpServers": {
+    "fdic": {
+      "command": "npx",
+      "args": ["-y", "fdic-mcp-server"]
+    }
+  }
+}
+```
+
+## Verify It Works
+
+Try a simple prompt in your MCP host:
+
+```text
+Find active FDIC-insured banks in North Carolina with more than $1 billion in assets.
+```
+
+Expected behavior:
+
+- the model should call `fdic_search_institutions`
+- filters should include `STNAME:"North Carolina"`, `ACTIVE:1`, and `ASSET:[1000000 TO *]`
+- results should come back with both human-readable output and machine-readable `structuredContent`
+
+## What To Read Next
+
+- [Prompting Guide](./prompting-guide.md)
+- [Usage Examples](./usage-examples.md)
+- [Technical Specification](./technical/specification.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+---
+title: FDIC BankFind MCP Server Docs
+---
+
+# FDIC BankFind MCP Server
+
+Documentation for the MCP server that exposes the FDIC BankFind Suite API as LLM-friendly tools and server-side analysis workflows.
+
+## Start Here
+
+- [Getting Started](./getting-started.md): install the package, run the server, and connect it to an MCP client
+- [Prompting Guide](./prompting-guide.md): write reliable prompts that work with FDIC data and this server's toolset
+- [Usage Examples](./usage-examples.md): copyable examples for search, comparison, and peer analysis workflows
+- [Tool Reference](./tool-reference.md): quick guidance on which MCP tool to use for which job
+- [Client Setup](./clients.md): client-specific setup notes for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI
+- [Troubleshooting And FAQ](./troubleshooting.md): common setup and data questions, plus targeted fixes
+- [Compatibility Matrix](./compatibility-matrix.md): quick support snapshot by MCP host
+
+## Technical Documentation
+
+- [Technical Specification](./technical/specification.md): architecture, transport model, tool surface, and data contracts
+- [Architecture](./technical/architecture.md): code layout and request flow
+- [Key Decisions](./technical/decisions.md): important design choices and why they were made
+
+## Project Information
+
+- [Release Notes](./release-notes/index.md): versioned changes and upgrade notes
+- [Support](./support.md): where to get help and how to report issues
+- [Contributing](./contributing.md): contributor workflow and validation expectations
+- [Security](./security.md): vulnerability reporting expectations and security scope
+
+## Documentation Scope
+
+This documentation is organized for three audiences:
+
+- MCP users who need fast setup and practical prompt examples
+- maintainers and contributors who need architecture and decision context
+- evaluators comparing the server's capabilities, release history, and support model

--- a/docs/prompting-guide.md
+++ b/docs/prompting-guide.md
@@ -1,0 +1,74 @@
+---
+title: Prompting Guide
+---
+
+# Prompting Guide
+
+This server works best when prompts are explicit about the dataset, time basis, geography, and ranking criteria.
+
+## Prompting Principles
+
+- Name the institution, state, or peer group clearly.
+- State the date basis when using quarterly or annual FDIC data.
+- Ask for ranking criteria explicitly when comparing institutions.
+- Prefer one analysis question per prompt unless you want the model to chain tools.
+- Distinguish between quarterly financial data and annual branch deposit data.
+
+## Date Rules
+
+- Financial, summary, and demographics queries use `REPDTE` in `YYYYMMDD` format.
+- Summary of Deposits data is annual branch data as of June 30.
+- Do not mix quarterly financial questions with annual branch questions unless the prompt acknowledges the different dates.
+
+## Good Prompt Patterns
+
+Institution search:
+
+```text
+Find active banks in Texas with total assets above $5 billion.
+```
+
+Single-institution lookup:
+
+```text
+Get the FDIC institution record for CERT 3511.
+```
+
+Quarterly financial history:
+
+```text
+Show Bank of America quarterly financial data for 2024, sorted newest first.
+```
+
+Snapshot comparison:
+
+```text
+Compare North Carolina banks between 20211231 and 20250630 and rank them by deposit growth percentage.
+```
+
+Peer analysis:
+
+```text
+Build a peer group for CERT 29846 at 20241231 and tell me where it ranks on ROA, ROE, and efficiency ratio.
+```
+
+## Prompting Pitfalls
+
+- "Find the best banks" is too vague. Say what "best" means.
+- "Use latest branch data and latest financials" can mix annual and quarterly sources unintentionally.
+- "Compare all banks" may be too broad for the FDIC API limits. Add geography or peer filters.
+
+## Prompting For Better Analysis
+
+Ask for:
+
+- a specific state or list of CERTs
+- a start and end report date
+- a metric such as `asset_growth_pct`, `roa_change`, or `efficiency_ratio`
+- whether you want a single snapshot comparison or a quarterly time series
+
+## Recommended Follow-On Prompts
+
+- "Now explain which of the top growers also improved profitability."
+- "Show the same peer group but sort by efficiency ratio instead of assets."
+- "Call out any warnings or missing data that affect the ranking."

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,7 @@
+---
+title: Release Notes
+---
+
+# Release Notes
+
+- [Version 1.1.0](./v1.1.0.md)

--- a/docs/release-notes/v1.1.0.md
+++ b/docs/release-notes/v1.1.0.md
@@ -1,0 +1,42 @@
+---
+title: Version 1.1.0
+---
+
+# FDIC MCP Server 1.1.0
+
+## Highlights
+
+This release adds a peer group analysis workflow for FDIC-insured institutions and improves local client setup guidance.
+
+## Added
+
+- Added `fdic_peer_group_analysis`, a server-side analysis tool for single-date peer benchmarking.
+- Added support for three peer group construction modes:
+  - subject-driven (`cert` plus `repdte`)
+  - explicit criteria
+  - subject-driven with explicit overrides
+- Added derived peer benchmarking metrics:
+  - total assets
+  - total deposits
+  - return on assets
+  - return on equity
+  - net interest margin
+  - equity capital ratio
+  - efficiency ratio
+  - loan-to-deposit ratio
+  - deposits-to-assets ratio
+  - non-interest income share
+- Added subject rankings with competition-rank semantics and metric-specific percentile denominators.
+- Added peer group medians and machine-readable metric metadata in `structuredContent`.
+- Added returned peer CERT lists so peer groups can be passed directly into `fdic_compare_bank_snapshots` for follow-on trend analysis.
+
+## Improved
+
+- Added human-readable text summaries for peer group analysis, including report dates, peer criteria, warnings, and compact peer tables.
+- Added client setup guidance and local deployment helper documentation.
+- Added a local deployment helper script to validate, build, and install the server globally from a source checkout.
+
+## Notes
+
+- The npm package remains available as `fdic-mcp-server`.
+- Peer group analysis remains single-date by design. Use `fdic_compare_bank_snapshots` for cross-period trend analysis.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+---
+title: Security
+---
+
+# Security
+
+For repository security reporting, see the root-level `SECURITY.md`.
+
+## Summary
+
+- report vulnerabilities privately rather than through public issues
+- the project supports the latest release on `main`
+- sensitive areas include HTTP transport behavior, dependency security, malformed input handling, and accidental disclosure through logs
+
+## Repository Policy
+
+- GitHub view: <https://github.com/jflamb/fdic-mcp-server/blob/main/SECURITY.md>
+- Local file: `SECURITY.md`

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,28 @@
+---
+title: Support
+---
+
+# Support
+
+## Get Help
+
+- Open a GitHub issue for bugs, documentation problems, or feature requests: <https://github.com/jflamb/fdic-mcp-server/issues>
+- Review the documentation entry point at [Home](./index.md)
+- Check [Usage Examples](./usage-examples.md) and [Prompting Guide](./prompting-guide.md) before filing prompt-quality issues
+
+## What To Include In An Issue
+
+- the MCP host you used
+- whether you ran the server over stdio or HTTP
+- the exact prompt or tool arguments involved
+- the expected behavior
+- the actual behavior
+- relevant logs or error messages
+
+## Troubleshooting Checklist
+
+- Confirm you are using Node.js 18 or later.
+- Confirm the MCP host supports the transport you configured.
+- If using ChatGPT, confirm the server is exposed over reachable HTTPS rather than local stdio only.
+- If using a packaged install, confirm the binary path in the client config is correct.
+- If results look wrong, confirm the report date basis and dataset match your question.

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -1,0 +1,33 @@
+---
+title: Architecture
+---
+
+# Architecture
+
+## High-Level Flow
+
+1. An MCP host calls a tool exposed by the server.
+2. The server validates arguments and dispatches to the relevant tool implementation in `src/tools`.
+3. Tool implementations call the FDIC client in `src/services/fdicClient.ts`.
+4. The FDIC client handles request construction, pagination, and API error normalization.
+5. The tool formats both human-readable `content` and machine-readable `structuredContent`.
+
+## Code Layout
+
+- `src/index.ts`: server construction and transport wiring
+- `src/tools/*.ts`: MCP tool definitions and response shaping
+- `src/services/fdicClient.ts`: FDIC API access, pagination, retries, and error handling
+- `tests/*.test.ts`: tool behavior and contract coverage
+- `scripts/build.js`: build entry point
+
+## Design Boundaries
+
+- Tool logic stays in `src/tools` instead of scattering FDIC-specific logic through transport code.
+- The FDIC client centralizes HTTP and pagination concerns.
+- Analysis tools batch multiple FDIC lookups inside the server to reduce client-side orchestration cost.
+
+## Operational Notes
+
+- The package supports both direct CLI execution and imported server construction via `dist/server.js`.
+- Short-lived caching is used to make repeated analysis prompts more efficient.
+- The HTTP transport is intended for hosts that cannot launch local stdio processes.

--- a/docs/technical/decisions.md
+++ b/docs/technical/decisions.md
@@ -1,0 +1,41 @@
+---
+title: Key Decisions
+---
+
+# Key Decisions
+
+## Decision 1: Use MCP Tool Contracts With Dual Output Shapes
+
+Rationale:
+
+- MCP hosts benefit from concise summaries for humans and structured payloads for follow-on automation.
+- Preserving both `content` and `structuredContent` keeps the server useful across clients with different capabilities.
+
+## Decision 2: Keep FDIC API Access Centralized
+
+Rationale:
+
+- `src/services/fdicClient.ts` owns request construction, pagination, and normalization.
+- This reduces duplicated FDIC-specific behavior across tools and makes error handling more consistent.
+
+## Decision 3: Include Server-Side Analysis Helpers
+
+Rationale:
+
+- Complex prompts often require many FDIC calls and intermediate joins.
+- `fdic_compare_bank_snapshots` and `fdic_peer_group_analysis` reduce client orchestration overhead and improve prompt reliability.
+
+## Decision 4: Preserve FDIC Time Bases Explicitly
+
+Rationale:
+
+- Quarterly financial data and annual SOD data answer different questions.
+- Clear documentation and explicit parameter naming reduce analysis mistakes caused by mixing incompatible time bases.
+
+## Decision 5: Publish End-User And Maintainer Docs Together
+
+Rationale:
+
+- Users need setup, prompting, and examples.
+- Maintainers need architecture and decision records.
+- A single `docs/` site keeps those materials versioned with the codebase and available through GitHub Pages.

--- a/docs/technical/specification.md
+++ b/docs/technical/specification.md
@@ -1,0 +1,56 @@
+---
+title: Technical Specification
+---
+
+# Technical Specification
+
+## Purpose
+
+`fdic-mcp-server` exposes public FDIC BankFind Suite datasets through MCP tools so LLM hosts can search institutions, retrieve records, and perform common multi-bank analysis without custom FDIC API integration.
+
+## Supported Transports
+
+- stdio for local MCP hosts
+- streamable HTTP for remote MCP hosts
+
+## Tool Surface
+
+Core search and lookup tools:
+
+- `fdic_search_institutions`
+- `fdic_get_institution`
+- `fdic_search_failures`
+- `fdic_get_institution_failure`
+- `fdic_search_locations`
+- `fdic_search_history`
+- `fdic_search_financials`
+- `fdic_search_summary`
+- `fdic_search_sod`
+- `fdic_search_demographics`
+
+Server-side analysis tools:
+
+- `fdic_compare_bank_snapshots`
+- `fdic_peer_group_analysis`
+
+## Data Contracts
+
+All tools return:
+
+- `content` for human-readable summaries
+- `structuredContent` for machine-readable output
+
+Contract stability matters because MCP clients may automate against either or both shapes.
+
+## FDIC Data Constraints
+
+- Financial, summary, and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- Summary of Deposits data is annual branch-level data as of June 30.
+- Monetary values are generally reported in thousands of dollars.
+- `CERT` is the stable institution identifier used across datasets.
+
+## Non-Goals
+
+- No private credentials or API keys
+- No proprietary data enrichment outside the FDIC public API
+- No breaking tool-contract changes without explicit coordination

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,0 +1,46 @@
+---
+title: Tool Reference
+---
+
+# Tool Reference
+
+This page summarizes what each MCP tool is for and when to use it.
+
+## Search And Lookup Tools
+
+| Tool | Use It When | Notes |
+|------|-------------|-------|
+| `fdic_search_institutions` | You need institution search results by name, state, status, asset size, or other institution fields | Good default entry point for bank discovery |
+| `fdic_get_institution` | You already know the FDIC `CERT` and need one institution record | Convenience wrapper over the institutions dataset |
+| `fdic_search_failures` | You need failed-bank records, failure dates, costs, or resolution details | Uses failure-specific fields such as `FAILDATE` and `COST` |
+| `fdic_get_institution_failure` | You already know the failed institution `CERT` and want a direct lookup | Convenience wrapper over the failures dataset |
+| `fdic_search_locations` | You need branch or office locations for one bank or a geography | Useful for office-level footprint questions |
+| `fdic_search_history` | You need structural-change records such as mergers or name changes | Use when the question is about institution history |
+
+## Financial And Deposit Datasets
+
+| Tool | Use It When | Notes |
+|------|-------------|-------|
+| `fdic_search_financials` | You need quarterly Call Report data | Uses `REPDTE` in `YYYYMMDD` |
+| `fdic_search_summary` | You need annual summary data | Different from branch-level SOD data |
+| `fdic_search_sod` | You need Summary of Deposits branch-level deposit data | Annual data as of June 30 |
+| `fdic_search_demographics` | You need quarterly demographics or market-structure fields, including office counts | Useful for office-count comparisons and geography context |
+
+## Analysis Tools
+
+| Tool | Use It When | Notes |
+|------|-------------|-------|
+| `fdic_compare_bank_snapshots` | You want to compare multiple banks across two quarterly report dates or over a quarterly time series | Best for growth, profitability, branch-count, and trend analysis |
+| `fdic_peer_group_analysis` | You want to benchmark one institution against a peer group at a single report date | Best for ranking a bank against comparable institutions |
+
+## Choosing The Right Tool
+
+- Use search tools when you want raw records.
+- Use lookup tools when you already know the `CERT`.
+- Use `fdic_compare_bank_snapshots` when the question compares banks across time.
+- Use `fdic_peer_group_analysis` when the question is "How does this bank rank against peers right now?"
+
+## Data Basis Reminder
+
+- Quarterly datasets: financials, summary, demographics
+- Annual June 30 dataset: SOD

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,120 @@
+---
+title: Troubleshooting And FAQ
+---
+
+# Troubleshooting And FAQ
+
+## Quick Checks
+
+Before debugging a client-specific issue, verify:
+
+- Node.js is version 18 or later
+- the package is installed or the local build exists
+- the MCP host supports the transport you configured
+- your client config points at the correct binary or HTTP URL
+- your prompt matches the FDIC dataset and time basis you actually need
+
+## FAQ
+
+### Why does ChatGPT not connect to my local binary?
+
+ChatGPT Developer Mode expects a remotely reachable MCP server over HTTP or SSE. A local stdio command such as `/opt/homebrew/bin/fdic-mcp-server` is not enough by itself.
+
+Use the server's HTTP transport:
+
+```bash
+TRANSPORT=http PORT=3000 fdic-mcp-server
+```
+
+Then expose it through a reachable HTTPS URL.
+
+### Why do I get no results for a bank I know exists?
+
+Common causes:
+
+- the filter field is wrong for that dataset
+- the bank is inactive and you filtered on `ACTIVE:1`
+- the report date is outside the relevant range
+- you are using SOD-style branch questions against a quarterly dataset
+
+### Why do results look inconsistent across tools?
+
+The datasets answer different questions and do not all update on the same schedule.
+
+- financials, summary, and demographics are quarterly
+- SOD is annual branch-level data as of June 30
+- failures and history use their own event dates
+
+If you compare across datasets, state the date basis clearly.
+
+### Why does a comparison return warnings?
+
+Warnings usually mean the server detected incomplete or potentially misleading analysis conditions, such as a truncated roster or missing values for some institutions.
+
+The tool still returns data, but you should read the warnings before drawing conclusions.
+
+### Why does peer group ranking denominator change by metric?
+
+Rankings are metric-specific. If some peers do not have a valid value for ROA, efficiency ratio, or another metric, they are excluded from that metric's denominator.
+
+## Troubleshooting By Symptom
+
+### The MCP host says the server failed to start
+
+Check:
+
+- whether the command path exists
+- whether the package was installed under a different npm prefix
+- whether you built the project before pointing a client at `dist/index.js`
+
+Useful commands:
+
+```bash
+which fdic-mcp-server
+node dist/index.js
+```
+
+### The HTTP client connects but tool calls fail
+
+Check:
+
+- that the server is running with `TRANSPORT=http`
+- that the MCP endpoint is `/mcp`
+- that the client sends `Content-Type: application/json`
+- that the client accepts both `application/json` and `text/event-stream`
+
+### The model keeps choosing the wrong tool
+
+Improve the prompt by stating:
+
+- whether you want raw records or analysis
+- whether you already know the `CERT`
+- the date basis
+- the ranking metric or geography
+
+See [Prompting Guide](./prompting-guide.md) and [Tool Reference](./tool-reference.md).
+
+### I asked about branches and got quarterly figures instead
+
+You likely needed SOD or demographics data instead of quarterly financials.
+
+- Use `fdic_search_sod` for branch deposit totals
+- Use `fdic_search_demographics` for office counts and market-structure fields
+- Use `fdic_search_locations` for branch records
+
+### A local client cannot find the binary after global install
+
+Your npm global prefix may differ from the examples. Run:
+
+```bash
+npm prefix -g
+which fdic-mcp-server
+```
+
+Then update the client configuration with the actual binary path.
+
+## Still Stuck
+
+- Review [Client Setup](./clients.md)
+- Review [Support](./support.md)
+- Open an issue with the exact MCP host, transport, prompt, and observed error

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,0 +1,150 @@
+---
+title: Usage Examples
+---
+
+# Usage Examples
+
+The examples below are phrased as natural-language prompts, followed by the expected MCP tool direction.
+
+## Search Institutions
+
+Prompt:
+
+```text
+Find active FDIC-insured banks in North Carolina with more than $1 billion in assets.
+```
+
+Expected tool:
+
+- `fdic_search_institutions`
+
+Expected filter shape:
+
+```text
+STNAME:"North Carolina" AND ACTIVE:1 AND ASSET:[1000000 TO *]
+```
+
+## Look Up A Known CERT
+
+Prompt:
+
+```text
+Get institution details for CERT 3511.
+```
+
+Expected tool:
+
+- `fdic_get_institution`
+
+## Review Bank Failures
+
+Prompt:
+
+```text
+List the 10 costliest bank failures since January 1, 2000.
+```
+
+Expected tool:
+
+- `fdic_search_failures`
+
+Expected parameters:
+
+```text
+filters: FAILDATE:[2000-01-01 TO *]
+sort_by: COST
+sort_order: DESC
+limit: 10
+```
+
+## Pull Quarterly Financials
+
+Prompt:
+
+```text
+Show quarterly financials for CERT 3511 during 2023.
+```
+
+Expected tool:
+
+- `fdic_search_financials`
+
+Expected parameters:
+
+```text
+cert: 3511
+filters: REPDTE:[20230101 TO 20231231]
+```
+
+## Compare Growth Across Two Dates
+
+Prompt:
+
+```text
+Compare North Carolina banks between 20211231 and 20250630 and rank them by asset growth.
+```
+
+Expected tool:
+
+- `fdic_compare_bank_snapshots`
+
+Expected parameters:
+
+```text
+state: North Carolina
+start_repdte: 20211231
+end_repdte: 20250630
+sort_by: asset_growth
+sort_order: DESC
+```
+
+## Run A Time-Series Analysis
+
+Prompt:
+
+```text
+Analyze North Carolina banks from 20211231 through 20250630 and identify sustained asset-growth streaks.
+```
+
+Expected tool:
+
+- `fdic_compare_bank_snapshots`
+
+Expected parameters:
+
+```text
+state: North Carolina
+start_repdte: 20211231
+end_repdte: 20250630
+analysis_mode: timeseries
+sort_by: asset_growth_pct
+sort_order: DESC
+```
+
+## Build A Peer Group
+
+Prompt:
+
+```text
+Build a peer group for CERT 29846 at 20241231 and rank it against peers on ROA and efficiency ratio.
+```
+
+Expected tool:
+
+- `fdic_peer_group_analysis`
+
+Expected parameters:
+
+```text
+cert: 29846
+repdte: 20241231
+```
+
+## Response Model
+
+All tools return:
+
+- human-readable text in `content`
+- machine-readable data in `structuredContent`
+
+Use the machine-readable payload for follow-on automation or tool chaining.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,32 @@
+# Documentation Refactor
+
+Reference: user request on 2026-03-15 to refactor repository and published documentation for GitHub best practices and GitHub Pages.
+
+## Goals
+
+- [x] Review the existing README and `docs/` content to identify gaps.
+- [x] Rewrite `README.md` with stronger repository onboarding, navigation, and contributor guidance.
+- [x] Build a GitHub Pages-ready documentation set under `docs/`.
+- [x] Publish release notes through `docs/` instead of keeping them only under `.github/`.
+- [x] Add technical architecture and decision records in a stable docs location.
+- [x] Add plain-language end-user guides, prompting guidance, usage examples, and a tool reference.
+- [x] Add support and contributing entry points.
+- [x] Add repository support for publishing `docs/` with GitHub Pages.
+- [x] Validate the repo with `npm run typecheck`, `npm test`, and `npm run build`.
+
+## Acceptance Criteria
+
+- [x] `README.md` follows common GitHub repository documentation conventions and links to the docs site entry point.
+- [x] `docs/index.md` acts as a clear documentation home page for GitHub Pages.
+- [x] Release notes, technical specifications, and end-user docs are easy to scan and cross-linked.
+- [x] Contributors have a dedicated guide instead of relying on the README alone.
+- [x] The documentation reflects current MCP client setup and current tool capabilities.
+- [x] Validation commands complete successfully after the refactor.
+
+## Review / Results
+
+- [x] Completed on branch `docs/github-pages-refactor`.
+- [x] Validation passed: `npm run typecheck`, `npm test`, `npm run build`.
+- [x] Added `SECURITY.md`.
+- [x] Added troubleshooting and FAQ documentation.
+- [x] Added an MCP host compatibility and support matrix.


### PR DESCRIPTION
## Summary
- refactor `README.md` to follow stronger GitHub repository documentation conventions
- add a GitHub Pages-ready docs site under `docs/` covering getting started, prompting, examples, tool reference, troubleshooting, compatibility, technical docs, support, security, and release notes
- add contributor and security guidance plus a GitHub Pages deployment workflow

## Why
Closes #23.

This project had useful documentation, but it was concentrated in the README and one client-setup page. This change makes the repository easier to evaluate on GitHub and gives users a clearer published docs entry point.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- GitHub Pages has already been enabled for the repository and is configured for workflow-based publishing.
- The unrelated local `AGENTS.md` edit was intentionally excluded from this PR.
