### PR TITLE
Improve docs site overview, navigation, and styling

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,5 +2,13 @@ title: FDIC BankFind MCP Server
 description: Documentation for the MCP server that exposes the FDIC BankFind Suite API to LLM clients.
 theme: minima
 markdown: kramdown
+permalink: pretty
+exclude:
+  - plans
 plugins:
   - jekyll-seo-tag
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/docs/_includes/breadcrumbs.html
+++ b/docs/_includes/breadcrumbs.html
@@ -1,0 +1,16 @@
+{% if page.breadcrumbs %}
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <ol>
+    {% for crumb in page.breadcrumbs %}
+    <li>
+      {% if crumb.url %}
+      <a href="{{ crumb.url | relative_url }}">{{ crumb.title }}</a>
+      {% else %}
+      <span>{{ crumb.title }}</span>
+      {% endif %}
+    </li>
+    {% endfor %}
+    <li aria-current="page">{{ page.title }}</li>
+  </ol>
+</nav>
+{% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/docs.css' | relative_url }}">
+    {% seo %}
+  </head>
+  <body class="{% if page.body_class %}{{ page.body_class }}{% endif %}">
+    <div class="site-shell">
+      <header class="site-header">
+        <div class="site-header__inner">
+          <a class="brand" href="{{ '/' | relative_url }}">
+            <span class="brand__eyebrow">FDIC Bank Data Docs</span>
+            <span class="brand__title">FDIC BankFind MCP Server</span>
+          </a>
+          <nav class="top-nav" aria-label="Primary">
+            <a href="{{ '/' | relative_url }}"{% if page.nav_group == 'overview' %} class="is-active"{% endif %}>Overview</a>
+            <a href="{{ '/user-guide/' | relative_url }}"{% if page.nav_group == 'user' %} class="is-active"{% endif %}>User Docs</a>
+            <a href="{{ '/technical/' | relative_url }}"{% if page.nav_group == 'technical' %} class="is-active"{% endif %}>Technical Docs</a>
+            <a href="{{ '/project-information/' | relative_url }}"{% if page.nav_group == 'project' %} class="is-active"{% endif %}>Project Info</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="page-shell">
+        <div class="page-frame">
+          {% include breadcrumbs.html %}
+
+          {% if page.title %}
+          <header class="page-header">
+            {% if page.kicker %}
+            <p class="page-kicker">{{ page.kicker }}</p>
+            {% endif %}
+            <h1>{{ page.title }}</h1>
+            {% if page.summary %}
+            <p class="page-summary">{{ page.summary }}</p>
+            {% endif %}
+          </header>
+          {% endif %}
+
+          <article class="doc-content">
+            {{ content }}
+          </article>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -1,0 +1,364 @@
+:root {
+  --bg: #f5f7f4;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: #ffffff;
+  --ink: #12211d;
+  --muted: #5b6b66;
+  --line: rgba(18, 33, 29, 0.12);
+  --accent: #0e7c66;
+  --accent-deep: #0b5d4e;
+  --accent-soft: #e1f3ee;
+  --gold: #d9a441;
+  --shadow: 0 18px 44px rgba(11, 40, 34, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(14, 124, 102, 0.18), transparent 24rem),
+    linear-gradient(180deg, #eef6f2 0%, var(--bg) 28rem);
+  color: var(--ink);
+  font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.65;
+}
+
+a {
+  color: var(--accent-deep);
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+.site-shell {
+  min-height: 100vh;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: rgba(245, 247, 244, 0.86);
+  border-bottom: 1px solid rgba(18, 33, 29, 0.08);
+}
+
+.site-header__inner {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.brand__eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.brand__title {
+  font-size: 1.12rem;
+  font-weight: 700;
+}
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.top-nav a {
+  text-decoration: none;
+  color: var(--muted);
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  transition: 160ms ease;
+}
+
+.top-nav a:hover,
+.top-nav a.is-active {
+  color: var(--accent-deep);
+  background: var(--accent-soft);
+}
+
+.page-shell {
+  padding: 2.25rem 1.25rem 3rem;
+}
+
+.page-frame {
+  max-width: 980px;
+  margin: 0 auto;
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.85);
+  border-radius: 32px;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.5rem 2.5rem;
+}
+
+.breadcrumbs {
+  margin-bottom: 1rem;
+}
+
+.breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.breadcrumbs li:not(:last-child)::after {
+  content: "/";
+  margin-left: 0.5rem;
+  color: rgba(18, 33, 29, 0.32);
+}
+
+.breadcrumbs a {
+  text-decoration: none;
+}
+
+.page-header {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, rgba(14, 124, 102, 0.14), rgba(217, 164, 65, 0.1)),
+    var(--surface-strong);
+  border: 1px solid rgba(14, 124, 102, 0.08);
+}
+
+.page-kicker {
+  margin: 0 0 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.05;
+}
+
+.page-summary {
+  max-width: 48rem;
+  margin: 0.9rem 0 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+}
+
+.doc-content h2,
+.doc-content h3,
+.doc-content h4 {
+  line-height: 1.15;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.doc-content p,
+.doc-content ul,
+.doc-content ol,
+.doc-content table,
+.doc-content pre,
+.doc-content blockquote {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.doc-content ul,
+.doc-content ol {
+  padding-left: 1.3rem;
+}
+
+.doc-content code {
+  background: rgba(14, 124, 102, 0.08);
+  border-radius: 0.4rem;
+  padding: 0.15rem 0.35rem;
+  font-size: 0.94em;
+}
+
+.doc-content pre {
+  overflow-x: auto;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: #10211d;
+  color: #edf8f4;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.doc-content pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+.doc-content table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+}
+
+.doc-content th,
+.doc-content td {
+  padding: 0.9rem 0.95rem;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+}
+
+.doc-content th {
+  background: rgba(14, 124, 102, 0.08);
+}
+
+.doc-content tr:last-child td {
+  border-bottom: 0;
+}
+
+.doc-content blockquote {
+  margin-left: 0;
+  padding: 1rem 1.2rem;
+  border-left: 4px solid var(--gold);
+  background: rgba(217, 164, 65, 0.08);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.hero-grid,
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.hero-panel {
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(14, 124, 102, 0.08);
+  border-radius: var(--radius-md);
+}
+
+.hero-panel--accent {
+  background:
+    linear-gradient(135deg, rgba(14, 124, 102, 0.1), rgba(217, 164, 65, 0.12)),
+    rgba(255, 255, 255, 0.92);
+}
+
+.hero-panel h2,
+.hero-panel h3 {
+  margin-top: 0;
+}
+
+.card {
+  display: block;
+  padding: 1.15rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 10px 24px rgba(11, 40, 34, 0.04);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(11, 40, 34, 0.08);
+  border-color: rgba(14, 124, 102, 0.2);
+}
+
+.card__eyebrow {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.section-intro {
+  font-size: 1.02rem;
+  color: var(--muted);
+  max-width: 50rem;
+}
+
+.callout {
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(14, 124, 102, 0.14);
+  border-radius: var(--radius-md);
+  background: rgba(14, 124, 102, 0.06);
+}
+
+.meta-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  padding: 0;
+  list-style: none;
+}
+
+.meta-list li {
+  padding: 0.95rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--line);
+}
+
+@media (max-width: 720px) {
+  .site-header__inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .page-shell {
+    padding: 1rem 0.7rem 2rem;
+  }
+
+  .page-frame {
+    padding: 1rem 1rem 1.8rem;
+    border-radius: 22px;
+  }
+
+  .page-header {
+    padding: 1.2rem;
+  }
+}

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,8 +1,14 @@
 ---
 title: Client Setup
+nav_group: user
+kicker: User Docs
+summary: Configure the server in Claude Desktop, ChatGPT, Gemini CLI, or GitHub Copilot CLI, with transport-specific caveats called out.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Client Setup
 
 This page collects setup notes for common MCP clients.
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,8 +1,14 @@
 ---
 title: MCP Host Compatibility Matrix
+nav_group: project
+kicker: Project Info
+summary: A concise support snapshot showing which MCP hosts are directly documented here, which transports they use, and what level of support to expect.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
 ---
-
-# MCP Host Compatibility Matrix
 
 This matrix summarizes the level of setup guidance and expected support for common MCP hosts documented in this repository.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,14 @@
 ---
 title: Contributing
+nav_group: project
+kicker: Project Info
+summary: The contributor workflow at a glance, with validation expectations and links back to the repository-level guide.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
 ---
-
-# Contributing
 
 The full contributor workflow lives in the repository root at `CONTRIBUTING.md`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,14 @@
 ---
 title: Getting Started
+nav_group: user
+kicker: User Docs
+summary: Install the package, run the server locally, connect it to an MCP host, and verify that basic institution queries work.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Getting Started
 
 This server gives MCP-compatible clients access to public FDIC BankFind datasets and a set of server-side analysis tools for comparing institutions and peer groups.
 
@@ -54,7 +60,7 @@ The HTTP MCP endpoint is available at `http://localhost:3000/mcp`.
 
 ## Connect A Client
 
-Use the client-specific instructions in [Client Setup](./clients.md).
+Use the client-specific instructions in [Client Setup]({{ '/clients/' | relative_url }}).
 
 For most local MCP hosts, the minimal stdio configuration looks like this:
 
@@ -85,6 +91,6 @@ Expected behavior:
 
 ## What To Read Next
 
-- [Prompting Guide](./prompting-guide.md)
-- [Usage Examples](./usage-examples.md)
-- [Technical Specification](./technical/specification.md)
+- [Prompting Guide]({{ '/prompting-guide/' | relative_url }})
+- [Usage Examples]({{ '/usage-examples/' | relative_url }})
+- [Technical Specification]({{ '/technical/specification/' | relative_url }})

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,38 +1,88 @@
 ---
-title: FDIC BankFind MCP Server Docs
+title: Documentation Overview
+nav_group: overview
+kicker: Documentation Home
+summary: A starting point for users, maintainers, and evaluators who need to understand what the project solves and where to go next.
+body_class: overview-page
 ---
 
-# FDIC BankFind MCP Server
+<div class="hero-grid">
+  <section class="hero-panel hero-panel--accent">
+    <h2>What problem this project solves</h2>
+    <p>
+      The FDIC BankFind Suite API is public, but it is not packaged for MCP hosts in a way that is easy to use from prompts.
+      This server turns those datasets into MCP tools with stable machine-readable output, then adds analysis helpers for multi-bank comparison and peer benchmarking.
+    </p>
+  </section>
+  <section class="hero-panel">
+    <h2>What you can do with it</h2>
+    <ul>
+      <li>Search institutions, failures, branches, and historical changes.</li>
+      <li>Pull quarterly financial and demographics records with explicit report dates.</li>
+      <li>Compare institutions across two snapshots or a time series.</li>
+      <li>Benchmark a bank against a generated peer group.</li>
+    </ul>
+  </section>
+</div>
 
-Documentation for the MCP server that exposes the FDIC BankFind Suite API as LLM-friendly tools and server-side analysis workflows.
+## Choose your path
 
-## Start Here
+<p class="section-intro">
+  The docs are organized by audience so you can start from the right level of detail instead of scanning every page.
+</p>
 
-- [Getting Started](./getting-started.md): install the package, run the server, and connect it to an MCP client
-- [Prompting Guide](./prompting-guide.md): write reliable prompts that work with FDIC data and this server's toolset
-- [Usage Examples](./usage-examples.md): copyable examples for search, comparison, and peer analysis workflows
-- [Tool Reference](./tool-reference.md): quick guidance on which MCP tool to use for which job
-- [Client Setup](./clients.md): client-specific setup notes for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI
-- [Troubleshooting And FAQ](./troubleshooting.md): common setup and data questions, plus targeted fixes
-- [Compatibility Matrix](./compatibility-matrix.md): quick support snapshot by MCP host
+<div class="card-grid">
+  <a class="card" href="{{ '/user-guide/' | relative_url }}">
+    <span class="card__eyebrow">For Users</span>
+    <h3>User Docs</h3>
+    <p>Installation, client setup, prompting guidance, practical examples, and troubleshooting.</p>
+  </a>
+  <a class="card" href="{{ '/technical/' | relative_url }}">
+    <span class="card__eyebrow">For Maintainers</span>
+    <h3>Technical Docs</h3>
+    <p>Architecture, contracts, implementation boundaries, and the reasoning behind key design decisions.</p>
+  </a>
+  <a class="card" href="{{ '/project-information/' | relative_url }}">
+    <span class="card__eyebrow">For Evaluators</span>
+    <h3>Project Info</h3>
+    <p>Release notes, support expectations, compatibility guidance, contribution workflow, and security reporting.</p>
+  </a>
+</div>
 
-## Technical Documentation
+## At a glance
 
-- [Technical Specification](./technical/specification.md): architecture, transport model, tool surface, and data contracts
-- [Architecture](./technical/architecture.md): code layout and request flow
-- [Key Decisions](./technical/decisions.md): important design choices and why they were made
+<ul class="meta-list">
+  <li><strong>Data source:</strong> FDIC BankFind Suite API</li>
+  <li><strong>Protocol:</strong> MCP over stdio or streamable HTTP</li>
+  <li><strong>Best for:</strong> LLM-hosted banking research and comparative analysis</li>
+  <li><strong>Key caution:</strong> keep quarterly financial data and annual SOD data separate unless you state the date basis clearly</li>
+</ul>
 
-## Project Information
+## Recommended starting points
 
-- [Release Notes](./release-notes/index.md): versioned changes and upgrade notes
-- [Support](./support.md): where to get help and how to report issues
-- [Contributing](./contributing.md): contributor workflow and validation expectations
-- [Security](./security.md): vulnerability reporting expectations and security scope
+<div class="card-grid">
+  <a class="card" href="{{ '/getting-started/' | relative_url }}">
+    <span class="card__eyebrow">Setup</span>
+    <h3>Getting Started</h3>
+    <p>Install the package, run the server, and verify a client can call it.</p>
+  </a>
+  <a class="card" href="{{ '/prompting-guide/' | relative_url }}">
+    <span class="card__eyebrow">Prompting</span>
+    <h3>Prompting Guide</h3>
+    <p>Use clearer prompts for dates, datasets, peer groups, and rankings.</p>
+  </a>
+  <a class="card" href="{{ '/technical/specification/' | relative_url }}">
+    <span class="card__eyebrow">Contract</span>
+    <h3>Technical Specification</h3>
+    <p>Understand the supported transports, tool surface, and output expectations.</p>
+  </a>
+  <a class="card" href="{{ '/compatibility-matrix/' | relative_url }}">
+    <span class="card__eyebrow">Hosts</span>
+    <h3>Compatibility Matrix</h3>
+    <p>See which MCP hosts are directly documented and what support level to expect.</p>
+  </a>
+</div>
 
-## Documentation Scope
-
-This documentation is organized for three audiences:
-
-- MCP users who need fast setup and practical prompt examples
-- maintainers and contributors who need architecture and decision context
-- evaluators comparing the server's capabilities, release history, and support model
+<div class="callout">
+  <strong>Note:</strong> the internal design notes under <code>docs/plans/</code> are intentionally excluded from the published site. The published docs are meant to be user-facing and maintainable, not a dump of every working note in the repository.
+</div>

--- a/docs/project-information.md
+++ b/docs/project-information.md
@@ -1,0 +1,39 @@
+---
+title: Project Info
+nav_group: project
+kicker: Project Guide
+summary: Release notes, support policies, contribution workflow, compatibility guidance, and security reporting.
+breadcrumbs:
+  - title: Overview
+    url: /
+---
+
+This section is for maintainers, evaluators, and contributors who need the operational context around the software rather than the API usage alone.
+
+<div class="card-grid">
+  <a class="card" href="{{ '/release-notes/' | relative_url }}">
+    <span class="card__eyebrow">Changes</span>
+    <h3>Release Notes</h3>
+    <p>Versioned history of what changed and what users should expect when they upgrade.</p>
+  </a>
+  <a class="card" href="{{ '/support/' | relative_url }}">
+    <span class="card__eyebrow">Help</span>
+    <h3>Support</h3>
+    <p>Where to file issues, what information to include, and what to check before escalating a problem.</p>
+  </a>
+  <a class="card" href="{{ '/compatibility-matrix/' | relative_url }}">
+    <span class="card__eyebrow">Hosts</span>
+    <h3>Compatibility Matrix</h3>
+    <p>Current documentation and support posture by MCP host and transport type.</p>
+  </a>
+  <a class="card" href="{{ '/contributing/' | relative_url }}">
+    <span class="card__eyebrow">Workflow</span>
+    <h3>Contributing</h3>
+    <p>How to make changes, validate them, and keep the documentation aligned with behavior.</p>
+  </a>
+  <a class="card" href="{{ '/security/' | relative_url }}">
+    <span class="card__eyebrow">Reporting</span>
+    <h3>Security</h3>
+    <p>Supported versions, private reporting expectations, and the security-sensitive areas of the project.</p>
+  </a>
+</div>

--- a/docs/prompting-guide.md
+++ b/docs/prompting-guide.md
@@ -1,8 +1,14 @@
 ---
 title: Prompting Guide
+nav_group: user
+kicker: User Docs
+summary: Write prompts that state the right dataset, date basis, geography, and comparison logic so the server can choose the right tool reliably.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Prompting Guide
 
 This server works best when prompts are explicit about the dataset, time basis, geography, and ranking criteria.
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,7 +1,12 @@
 ---
 title: Release Notes
+nav_group: project
+kicker: Project Info
+summary: Versioned release history for the server, including feature additions and notable behavior changes.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
 ---
-
-# Release Notes
-
-- [Version 1.1.0](./v1.1.0.md)
+- [Version 1.1.0]({{ '/release-notes/v1.1.0/' | relative_url }})

--- a/docs/release-notes/v1.1.0.md
+++ b/docs/release-notes/v1.1.0.md
@@ -1,8 +1,16 @@
 ---
 title: Version 1.1.0
+nav_group: project
+kicker: Release Notes
+summary: Peer group analysis, improved client guidance, and supporting local deployment workflow updates in the 1.1.0 release.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
+  - title: Release Notes
+    url: /release-notes/
 ---
-
-# FDIC MCP Server 1.1.0
 
 ## Highlights
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,8 +1,14 @@
 ---
 title: Security
+nav_group: project
+kicker: Project Info
+summary: Supported-version expectations and the route for reporting security issues without exposing them publicly.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
 ---
-
-# Security
 
 For repository security reporting, see the root-level `SECURITY.md`.
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,14 +1,20 @@
 ---
 title: Support
+nav_group: project
+kicker: Project Info
+summary: Where to get help, what to include in an issue, and which checks to perform before filing a bug or prompt-quality report.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Project Info
+    url: /project-information/
 ---
-
-# Support
 
 ## Get Help
 
 - Open a GitHub issue for bugs, documentation problems, or feature requests: <https://github.com/jflamb/fdic-mcp-server/issues>
-- Review the documentation entry point at [Home](./index.md)
-- Check [Usage Examples](./usage-examples.md) and [Prompting Guide](./prompting-guide.md) before filing prompt-quality issues
+- Review the documentation entry point at [Overview]({{ '/' | relative_url }})
+- Check [Usage Examples]({{ '/usage-examples/' | relative_url }}) and [Prompting Guide]({{ '/prompting-guide/' | relative_url }}) before filing prompt-quality issues
 
 ## What To Include In An Issue
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -1,8 +1,14 @@
 ---
 title: Architecture
+nav_group: technical
+kicker: Technical Docs
+summary: The end-to-end request flow and the code boundaries between transports, tools, and FDIC API access.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Technical Docs
+    url: /technical/
 ---
-
-# Architecture
 
 ## High-Level Flow
 

--- a/docs/technical/decisions.md
+++ b/docs/technical/decisions.md
@@ -1,8 +1,14 @@
 ---
 title: Key Decisions
+nav_group: technical
+kicker: Technical Docs
+summary: The main design decisions that shape tool contracts, centralized FDIC access, and the published documentation strategy.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Technical Docs
+    url: /technical/
 ---
-
-# Key Decisions
 
 ## Decision 1: Use MCP Tool Contracts With Dual Output Shapes
 

--- a/docs/technical/index.md
+++ b/docs/technical/index.md
@@ -1,0 +1,29 @@
+---
+title: Technical Docs
+nav_group: technical
+kicker: Maintainer Guide
+summary: Architecture, tool contracts, and design decisions for contributors working inside the codebase.
+breadcrumbs:
+  - title: Overview
+    url: /
+---
+
+The technical docs are aimed at maintainers and advanced contributors who need to understand how the server is wired, where responsibilities live, and which design choices are deliberate.
+
+<div class="card-grid">
+  <a class="card" href="{{ '/technical/specification/' | relative_url }}">
+    <span class="card__eyebrow">Contract</span>
+    <h3>Technical Specification</h3>
+    <p>Transport support, tool surface, output contracts, FDIC data constraints, and explicit non-goals.</p>
+  </a>
+  <a class="card" href="{{ '/technical/architecture/' | relative_url }}">
+    <span class="card__eyebrow">Structure</span>
+    <h3>Architecture</h3>
+    <p>Request flow, code layout, and the boundaries between transport, tools, and FDIC API integration.</p>
+  </a>
+  <a class="card" href="{{ '/technical/decisions/' | relative_url }}">
+    <span class="card__eyebrow">Rationale</span>
+    <h3>Key Decisions</h3>
+    <p>The design choices that shape tool contracts, server-side analysis, and data time-basis handling.</p>
+  </a>
+</div>

--- a/docs/technical/specification.md
+++ b/docs/technical/specification.md
@@ -1,8 +1,14 @@
 ---
 title: Technical Specification
+nav_group: technical
+kicker: Technical Docs
+summary: The contract-level view of the server: supported transports, exposed tools, output shape, data constraints, and explicit non-goals.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: Technical Docs
+    url: /technical/
 ---
-
-# Technical Specification
 
 ## Purpose
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,8 +1,14 @@
 ---
 title: Tool Reference
+nav_group: user
+kicker: User Docs
+summary: Decide which MCP tool to use based on whether you need raw records, direct lookups, cross-period comparisons, or peer benchmarking.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Tool Reference
 
 This page summarizes what each MCP tool is for and when to use it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,14 @@
 ---
 title: Troubleshooting And FAQ
+nav_group: user
+kicker: User Docs
+summary: Common setup failures, transport mismatches, dataset confusion, and prompt issues, with fast checks before escalation.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Troubleshooting And FAQ
 
 ## Quick Checks
 
@@ -92,7 +98,7 @@ Improve the prompt by stating:
 - the date basis
 - the ranking metric or geography
 
-See [Prompting Guide](./prompting-guide.md) and [Tool Reference](./tool-reference.md).
+See [Prompting Guide]({{ '/prompting-guide/' | relative_url }}) and [Tool Reference]({{ '/tool-reference/' | relative_url }}).
 
 ### I asked about branches and got quarterly figures instead
 
@@ -115,6 +121,6 @@ Then update the client configuration with the actual binary path.
 
 ## Still Stuck
 
-- Review [Client Setup](./clients.md)
-- Review [Support](./support.md)
+- Review [Client Setup]({{ '/clients/' | relative_url }})
+- Review [Support]({{ '/support/' | relative_url }})
 - Open an issue with the exact MCP host, transport, prompt, and observed error

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,8 +1,14 @@
 ---
 title: Usage Examples
+nav_group: user
+kicker: User Docs
+summary: Copyable prompts and expected tool behavior for institution search, financial retrieval, snapshot comparison, and peer analysis.
+breadcrumbs:
+  - title: Overview
+    url: /
+  - title: User Docs
+    url: /user-guide/
 ---
-
-# Usage Examples
 
 The examples below are phrased as natural-language prompts, followed by the expected MCP tool direction.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,44 @@
+---
+title: User Docs
+nav_group: user
+kicker: Audience Guide
+summary: Installation, client setup, prompting, examples, and troubleshooting for people using the server through an MCP host.
+breadcrumbs:
+  - title: Overview
+    url: /
+---
+
+The user docs are for people who want to get the server running quickly, choose the right MCP tool, and avoid common data-model mistakes.
+
+<div class="card-grid">
+  <a class="card" href="{{ '/getting-started/' | relative_url }}">
+    <span class="card__eyebrow">Start Here</span>
+    <h3>Getting Started</h3>
+    <p>Install the package, run the server, and confirm that a client can call it successfully.</p>
+  </a>
+  <a class="card" href="{{ '/clients/' | relative_url }}">
+    <span class="card__eyebrow">Connect</span>
+    <h3>Client Setup</h3>
+    <p>Host-specific setup notes for Claude Desktop, ChatGPT, Gemini CLI, and GitHub Copilot CLI.</p>
+  </a>
+  <a class="card" href="{{ '/prompting-guide/' | relative_url }}">
+    <span class="card__eyebrow">Prompting</span>
+    <h3>Prompting Guide</h3>
+    <p>Prompt patterns that work well with FDIC data, dates, and the server’s analysis tools.</p>
+  </a>
+  <a class="card" href="{{ '/usage-examples/' | relative_url }}">
+    <span class="card__eyebrow">Examples</span>
+    <h3>Usage Examples</h3>
+    <p>Copyable prompts and parameter shapes for institution search, comparisons, and peer analysis.</p>
+  </a>
+  <a class="card" href="{{ '/tool-reference/' | relative_url }}">
+    <span class="card__eyebrow">Tooling</span>
+    <h3>Tool Reference</h3>
+    <p>Pick the right MCP tool based on whether you need raw records, lookups, time-series analysis, or peer ranking.</p>
+  </a>
+  <a class="card" href="{{ '/troubleshooting/' | relative_url }}">
+    <span class="card__eyebrow">Support</span>
+    <h3>Troubleshooting And FAQ</h3>
+    <p>Resolve startup, transport, and dataset-selection issues before opening a support request.</p>
+  </a>
+</div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,3 +30,5 @@ Reference: user request on 2026-03-15 to refactor repository and published docum
 - [x] Added `SECURITY.md`.
 - [x] Added troubleshooting and FAQ documentation.
 - [x] Added an MCP host compatibility and support matrix.
+- [x] Added a documentation overview page organized by audience.
+- [x] Added custom docs-site styling and breadcrumb navigation for sub-pages.


### PR DESCRIPTION
## Summary
- refactor the docs home into an overview page focused on the problems the project solves
- organize the published docs by audience with section landing pages for user docs, technical docs, and project information
- add breadcrumb navigation and a lightweight custom visual shell for the GitHub Pages site

## Why
Closes #25.

The published docs had the right content, but the site still read like a flat list of markdown files. This change makes the docs easier to navigate and gives readers a clearer starting point based on their role.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- `docs/plans/` is now excluded from the published site.
- The unrelated local `AGENTS.md` edit was intentionally excluded from this PR.
- The Jekyll structure was reviewed statically; I did not run a separate local browser render of the generated site.
