### PR TITLE
Polish docs cards and onboarding flow

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -198,7 +198,7 @@ a:hover {
 }
 
 .doc-content pre {
-  overflow-x: auto;
+  overflow-x: visible;
   padding: 1rem 1.1rem;
   border-radius: var(--radius-md);
   background: #10211d;
@@ -210,33 +210,40 @@ a:hover {
   background: transparent;
   padding: 0;
   color: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .code-block {
-  position: relative;
   margin-bottom: 1rem;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  background: #10211d;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.code-block__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem 0.65rem 0;
 }
 
 .code-block .copy-button {
-  position: absolute;
-  top: 0.8rem;
-  right: 0.8rem;
   border: 0;
   border-radius: 999px;
-  background: rgba(225, 243, 238, 0.96);
-  color: var(--accent-deep);
+  background: rgba(225, 243, 238, 0.12);
+  color: rgba(237, 248, 244, 0.78);
   font: inherit;
-  font-size: 0.88rem;
-  font-weight: 700;
-  padding: 0.38rem 0.72rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 0.24rem 0.58rem;
   cursor: pointer;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
-  transition: transform 140ms ease, background 140ms ease, color 140ms ease;
+  transition: background 140ms ease, color 140ms ease;
 }
 
 .code-block .copy-button:hover {
-  transform: translateY(-1px);
-  background: #ffffff;
+  background: rgba(225, 243, 238, 0.2);
+  color: #ffffff;
 }
 
 .code-block .copy-button:focus-visible {
@@ -246,7 +253,8 @@ a:hover {
 
 .code-block pre {
   margin-bottom: 0;
-  padding-top: 3rem;
+  padding-top: 0.65rem;
+  box-shadow: none;
 }
 
 .doc-content table {
@@ -284,7 +292,7 @@ a:hover {
 .hero-grid,
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1rem;
 }
 
@@ -342,6 +350,7 @@ a:hover {
 .card p {
   margin: 0;
   color: var(--muted);
+  line-height: 1.48;
 }
 
 .section-intro {
@@ -370,6 +379,12 @@ a:hover {
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.75);
   border: 1px solid var(--line);
+}
+
+@media (min-width: 860px) {
+  .card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 720px) {

--- a/docs/assets/js/docs.js
+++ b/docs/assets/js/docs.js
@@ -12,12 +12,16 @@ document.addEventListener("DOMContentLoaded", () => {
     block.parentNode.insertBefore(wrapper, block);
     wrapper.appendChild(block);
 
+    const toolbar = document.createElement("div");
+    toolbar.className = "code-block__toolbar";
+    wrapper.insertBefore(toolbar, block);
+
     const button = document.createElement("button");
     button.type = "button";
     button.className = "copy-button";
     button.textContent = "Copy";
     button.setAttribute("aria-label", "Copy code block");
-    wrapper.appendChild(button);
+    toolbar.appendChild(button);
 
     button.addEventListener("click", async () => {
       const content = code.innerText;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 nav_group: user
 kicker: User Docs
-summary: Install the package, run the server locally, connect it to an MCP host, and verify that basic institution queries work.
+summary: Start with a hosted MCP URL when your host supports it, or use the local install path when you need a stdio server on your own machine.
 breadcrumbs:
   - title: Overview
     url: /
@@ -12,13 +12,31 @@ breadcrumbs:
 
 This server gives MCP-compatible clients access to public FDIC BankFind datasets and a set of server-side analysis tools for comparing institutions and peer groups.
 
-## Prerequisites
+## Easiest Option: Use A Hosted MCP URL
+
+If your MCP host supports connecting to a remote MCP server by URL, that is the lowest-friction way to get started because it avoids local installation entirely.
+
+Use this path when:
+
+- your host supports remote MCP URLs or hosted apps
+- you already have a deployed HTTPS copy of this server
+- you want to skip local `npm` and terminal setup
+
+Current example:
+
+- ChatGPT Developer Mode can connect to a remote MCP server URL, as covered in the client setup guidance
+
+If you do not have a deployed URL, or your host only supports local stdio servers, use the local install path below.
+
+## Local Install Path
+
+### Prerequisites
 
 - Node.js 18 or later
 - npm
 - An MCP-compatible host such as Claude Desktop, ChatGPT Developer Mode, Gemini CLI, or GitHub Copilot CLI
 
-## Install
+### Install
 
 Run directly without a global install:
 
@@ -42,7 +60,7 @@ npm install
 npm run build
 ```
 
-## Run The Server
+### Run The Server
 
 Stdio transport:
 
@@ -58,7 +76,7 @@ TRANSPORT=http PORT=3000 node dist/index.js
 
 The HTTP MCP endpoint is available at `http://localhost:3000/mcp`.
 
-## Connect A Client
+### Connect A Client
 
 Use the client-specific instructions in [Client Setup]({{ '/clients/' | relative_url }}).
 
@@ -75,7 +93,7 @@ For most local MCP hosts, the minimal stdio configuration looks like this:
 }
 ```
 
-## Verify It Works
+### Verify It Works
 
 Try a simple prompt in your MCP host:
 

--- a/docs/technical/index.md
+++ b/docs/technical/index.md
@@ -26,4 +26,9 @@ The technical docs are aimed at maintainers and advanced contributors who need t
     <h3>Key Decisions</h3>
     <p>The design choices that shape tool contracts, server-side analysis, and data time-basis handling.</p>
   </a>
+  <a class="card" href="{{ '/tool-reference/' | relative_url }}">
+    <span class="card__eyebrow">Surface Area</span>
+    <h3>Tool Reference</h3>
+    <p>Pick the right MCP tool based on whether you need raw records, lookups, time-series analysis, or peer ranking.</p>
+  </a>
 </div>

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,13 +1,13 @@
 ---
 title: Tool Reference
-nav_group: user
-kicker: User Docs
+nav_group: technical
+kicker: Technical Docs
 summary: Decide which MCP tool to use based on whether you need raw records, direct lookups, cross-period comparisons, or peer benchmarking.
 breadcrumbs:
   - title: Overview
     url: /
-  - title: User Docs
-    url: /user-guide/
+  - title: Technical Docs
+    url: /technical/
 ---
 
 This page summarizes what each MCP tool is for and when to use it.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,7 +14,7 @@ The user docs are for people who want to get the server running quickly, choose 
   <a class="card" href="{{ '/getting-started/' | relative_url }}">
     <span class="card__eyebrow">Start Here</span>
     <h3>Getting Started</h3>
-    <p>Install the package, run the server, and confirm that a client can call it successfully.</p>
+    <p>Start with a hosted MCP URL when your host supports it, or use the local install path when it does not.</p>
   </a>
   <a class="card" href="{{ '/clients/' | relative_url }}">
     <span class="card__eyebrow">Connect</span>
@@ -30,11 +30,6 @@ The user docs are for people who want to get the server running quickly, choose 
     <span class="card__eyebrow">Examples</span>
     <h3>Usage Examples</h3>
     <p>Copyable prompts and parameter shapes for institution search, comparisons, and peer analysis.</p>
-  </a>
-  <a class="card" href="{{ '/tool-reference/' | relative_url }}">
-    <span class="card__eyebrow">Tooling</span>
-    <h3>Tool Reference</h3>
-    <p>Pick the right MCP tool based on whether you need raw records, lookups, time-series analysis, or peer ranking.</p>
   </a>
   <a class="card" href="{{ '/troubleshooting/' | relative_url }}">
     <span class="card__eyebrow">Support</span>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3,3 +3,5 @@
 - When a user gives UX feedback on published docs, treat it as a concrete correction and capture the underlying rule here before closing the follow-up work.
 - For docs landing pages, prioritize high-signal project status and starting points above lower-value summary blocks or decorative notes.
 - For docs intended for copy-paste workflows, code blocks should offer an obvious copy affordance instead of assuming users will select text manually.
+- On docs landing pages, prefer fewer, wider cards when those cards contain body copy; dense four-column layouts make the text harder to scan.
+- When documenting onboarding, lead with the least-friction path that is genuinely available and position local terminal-based setup as the fallback.


### PR DESCRIPTION
## Summary
- reduce card density and tighten tile copy for better readability on overview pages
- make code-block copy controls more subtle and wrap long code lines instead of forcing horizontal scrolling
- update Getting Started to lead with hosted MCP URL onboarding where supported, and move Tool Reference into Technical Docs

## Why
Closes #29.

This is a follow-up Pages polish pass based on reviewing the live site after the previous docs work was merged.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- The remote URL onboarding guidance is intentionally conditional: it is presented as the easiest path when the MCP host supports remote URLs and a deployed server is available.
- The unrelated local `AGENTS.md` edit remains intentionally excluded.
