### PR TITLE
Document hosted onboarding and publish to MCP registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,25 @@ jobs:
       - name: Publish to npm
         run: npm publish
 
+      - name: Install MCP Registry publisher
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: ./mcp-publisher login github-oidc
+
+      - name: Sync server.json version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node scripts/sync-server-json.mjs "${VERSION}"
+
+      - name: Publish to official MCP Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: ./mcp-publisher publish
+
       - name: Prepare GitHub Packages bundle
         run: node scripts/prepare-gpr-package.mjs
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The FDIC BankFind Suite API is public and useful, but it is not packaged for MCP
 ## Documentation
 
 - GitHub Pages docs entry point: <https://jflamb.github.io/fdic-mcp-server/>
+- Hosted MCP endpoint: <https://bankfind.jflamb.com/mcp>
 - Local docs home: [docs/index.md](./docs/index.md)
 - Getting started: [docs/getting-started.md](./docs/getting-started.md)
 - Prompting guide: [docs/prompting-guide.md](./docs/prompting-guide.md)
@@ -84,6 +85,14 @@ npm run build
 ```
 
 ## Usage
+
+### Hosted Endpoint
+
+If your MCP host supports remote MCP URLs, use:
+
+```text
+https://bankfind.jflamb.com/mcp
+```
 
 ### Run Locally
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -14,6 +14,18 @@ This page collects setup notes for common MCP clients.
 
 ## Before You Configure A Client
 
+Hosted MCP endpoint:
+
+```text
+https://bankfind.jflamb.com/mcp
+```
+
+If your host supports remote MCP URLs, prefer the hosted endpoint over a local install.
+
+Asking a model to install `https://www.npmjs.com/package/fdic-mcp-server` for you only works in agentic environments that can run commands or edit local MCP config. It is not the normal path for chat products that only accept a remote MCP URL.
+
+## When You Need Local Installation
+
 Install the published package:
 
 ```bash
@@ -56,21 +68,19 @@ After editing the file, restart Claude Desktop.
 
 ## ChatGPT
 
-ChatGPT Developer Mode supports MCP apps/connectors, but it expects a remote MCP server over streaming HTTP or SSE, not a local stdio process. This means you cannot point ChatGPT directly at `/opt/homebrew/bin/fdic-mcp-server` unless you expose it through the server's HTTP transport.
+ChatGPT Developer Mode supports MCP apps/connectors, but it expects a remote MCP server over streaming HTTP or SSE, not a local stdio process.
 
-Run the server over HTTP:
+Use this hosted URL:
 
-```bash
-TRANSPORT=http PORT=3000 /opt/homebrew/bin/fdic-mcp-server
+```text
+https://bankfind.jflamb.com/mcp
 ```
-
-Then expose it at a reachable HTTPS URL, for example through a tunnel or your own deployment.
 
 In ChatGPT:
 
 1. Go to `Settings -> Apps -> Advanced settings -> Developer mode` and enable Developer mode.
 2. Open the Apps settings page and create an app for your MCP server.
-3. Use your remote MCP URL.
+3. Use `https://bankfind.jflamb.com/mcp`.
 4. Refresh tools from the app details page if needed.
 
 Notes:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,21 +12,30 @@ breadcrumbs:
 
 This server gives MCP-compatible clients access to public FDIC BankFind datasets and a set of server-side analysis tools for comparing institutions and peer groups.
 
-## Easiest Option: Use A Hosted MCP URL
+## Easiest Option: Use The Hosted Endpoint
 
 If your MCP host supports connecting to a remote MCP server by URL, that is the lowest-friction way to get started because it avoids local installation entirely.
+
+Hosted MCP URL:
+
+```text
+https://bankfind.jflamb.com/mcp
+```
 
 Use this path when:
 
 - your host supports remote MCP URLs or hosted apps
-- you already have a deployed HTTPS copy of this server
 - you want to skip local `npm` and terminal setup
 
-Current example:
+Do not assume a plain chat product can install the npm package for you just from a prompt. That only works in agentic environments that can actually run shell commands or edit MCP configuration on your machine.
 
-- ChatGPT Developer Mode can connect to a remote MCP server URL, as covered in the client setup guidance
+Examples:
 
-If you do not have a deployed URL, or your host only supports local stdio servers, use the local install path below.
+- ChatGPT Developer Mode can connect to the hosted endpoint directly
+- Any MCP host that accepts a public streamable HTTP MCP URL can use the same endpoint
+- Local coding agents such as Codex or Claude Code may be able to install the npm package for you, but that is a separate workflow from connecting to a hosted MCP URL
+
+If your host only supports local stdio servers, use the local install path below.
 
 ## Local Install Path
 
@@ -79,6 +88,12 @@ The HTTP MCP endpoint is available at `http://localhost:3000/mcp`.
 ### Connect A Client
 
 Use the client-specific instructions in [Client Setup]({{ '/clients/' | relative_url }}).
+
+For remote-URL hosts, use:
+
+```text
+https://bankfind.jflamb.com/mcp
+```
 
 For most local MCP hosts, the minimal stdio configuration looks like this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ body_class: overview-page
 <div class="card-grid">
   <a class="card" href="{{ '/getting-started/' | relative_url }}">
     <span class="card__eyebrow">First Step</span>
-    <h3>Get running locally</h3>
-    <p>Install the package, start the server, and confirm an MCP client can query FDIC institution data.</p>
+    <h3>Connect to the live endpoint</h3>
+    <p>Start with the hosted MCP URL when your host accepts remote servers. Use the local install path only when your host requires stdio.</p>
   </a>
   <a class="card" href="{{ '/release-notes/v1.1.0/' | relative_url }}">
     <span class="card__eyebrow">Latest Release</span>
@@ -44,6 +44,12 @@ body_class: overview-page
     <p>Use copy-pasteable prompt patterns that are explicit about dates, metrics, and dataset boundaries.</p>
   </a>
 </div>
+
+Hosted MCP URL:
+
+```text
+https://bankfind.jflamb.com/mcp
+```
 
 ## Choose your path
 

--- a/docs/technical/cloud-run-deployment.md
+++ b/docs/technical/cloud-run-deployment.md
@@ -12,6 +12,10 @@ breadcrumbs:
 
 This project can be deployed to Google Cloud Run with GitHub Actions using Workload Identity Federation rather than a long-lived Google service account key.
 
+Current live endpoint:
+
+- `https://bankfind.jflamb.com/mcp`
+
 ## What The Repo Provides
 
 - A container image definition in `Dockerfile`
@@ -58,6 +62,10 @@ On every push to `main`, the workflow:
 2. Builds the container image
 3. Pushes the image to Artifact Registry
 4. Deploys the new revision to Cloud Run
+
+## Registry Publication
+
+Release tags also publish metadata to the official MCP Registry using the documented `mcp-publisher` GitHub OIDC flow. The registry metadata lives in `server.json` and is kept aligned with `package.json` during the release workflow.
 
 ## Endpoint Shape
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fdic-mcp-server",
   "version": "1.1.0",
   "description": "MCP server for the FDIC BankFind Suite API",
+  "mcpName": "io.github.jflamb/fdic-mcp-server",
   "main": "dist/server.js",
   "files": [
     "dist",
@@ -20,6 +21,7 @@
     "prepack": "npm run build",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "pack:check": "npm pack --dry-run",
+    "registry:sync": "node scripts/sync-server-json.mjs",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "deploy:local": "bash scripts/deploy-local.sh"

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const serverJson = JSON.parse(fs.readFileSync("server.json", "utf8"));
+const version = process.argv[2] || packageJson.version;
+
+serverJson.version = version;
+
+if (Array.isArray(serverJson.packages)) {
+  for (const pkg of serverJson.packages) {
+    if (pkg.registryType === "npm") {
+      pkg.version = version;
+    }
+  }
+}
+
+fs.writeFileSync("server.json", `${JSON.stringify(serverJson, null, 2)}\n`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jflamb/fdic-mcp-server",
+  "title": "FDIC BankFind MCP Server",
+  "description": "Search FDIC-insured institutions, branch data, failures, and peer analysis through MCP over stdio or streamable HTTP.",
+  "version": "1.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "fdic-mcp-server",
+      "version": "1.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://bankfind.jflamb.com/mcp"
+    }
+  ]
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -7,3 +7,4 @@
 - On docs landing pages, prefer fewer, wider cards when those cards contain body copy; dense four-column layouts make the text harder to scan.
 - When documenting onboarding, lead with the least-friction path that is genuinely available and position local terminal-based setup as the fallback.
 - In end-user docs, do not imply that users must speak in API-native field formats like `YYYYMMDD` unless that is truly required; distinguish user-facing prompt style from tool-level parameter formats.
+- When documenting MCP onboarding, distinguish clearly between hosted-URL connection flows and agentic local-install flows; do not imply that plain chat products can install a local npm package just because coding agents can.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,28 +1,26 @@
-# Cloud Run Deployment Setup
+# Hosted Onboarding And Registry Publication
 
-Reference: issue #33 and user request to investigate and implement Cloud Run deployment for the HTTP MCP server.
+Reference: issue #35 and user request to update the docs around the live hosted endpoint and automate publication to a public MCP registry.
 
 ## Goals
 
-- [x] Verify the active Google Cloud project and billing status.
-- [x] Enable the Google Cloud services required for Cloud Run deployment.
-- [x] Add containerization assets for this repository.
-- [x] Add GitHub Actions deployment automation using Workload Identity Federation.
-- [x] Document the one-time Google Cloud and DNS setup still required outside the repo.
-- [ ] Validate with `npm run typecheck`, `npm test`, and `npm run build`.
+- [x] Verify that the hosted endpoint is live and suitable for onboarding docs.
+- [x] Update end-user docs to prioritize the live hosted endpoint where appropriate.
+- [x] Add official MCP Registry metadata to the repository.
+- [x] Automate official MCP Registry publication from the release workflow.
+- [x] Validate with `npm run typecheck`, `npm test`, and `npm run build`.
 
 ## Acceptance Criteria
 
-- [x] The project can be containerized and deployed to Cloud Run in HTTP mode.
-- [x] The repo contains the deployment automation needed for GitHub Actions.
-- [x] The deployment approach avoids long-lived Google service account keys.
-- [x] The remaining manual GCP or DNS steps are explicit and minimal.
-- [ ] Validation commands pass after the repo changes.
+- [x] Getting Started and client setup pages point to the hosted endpoint as the easiest path when remote URLs are supported.
+- [x] The repo contains registry metadata for the hosted MCP server.
+- [x] Release tags publish metadata to at least one public MCP registry.
+- [x] The workflow uses the documented official MCP Registry OIDC path instead of long-lived registry secrets.
+- [x] Validation commands pass after the repo changes.
 
 ## Review / Results
 
-- [x] Enabled `run.googleapis.com`, `artifactregistry.googleapis.com`, `cloudbuild.googleapis.com`, `iamcredentials.googleapis.com`, and `secretmanager.googleapis.com`.
-- [x] Created Artifact Registry repository `fdic-mcp` in `us-central1`.
-- [x] Created deployer and runtime service accounts plus GitHub Workload Identity Federation binding for `jflamb/fdic-mcp-server`.
-- [x] Configured GitHub repository variables for Cloud Run deployment.
-- [x] Manually deployed `fdic-mcp-server` to Cloud Run and verified `https://fdic-mcp-server-72624156793.us-central1.run.app/health`.
+- [x] Verified the live custom-domain endpoint `https://bankfind.jflamb.com/mcp`.
+- [x] Added `server.json` metadata plus release-time version synchronization for the official MCP Registry.
+- [x] Updated onboarding docs to prefer the hosted endpoint and clarify that npm-install-by-prompt only applies to agentic environments with machine access.
+- [x] Verified `npm run typecheck`, `npm test`, `npm run build`, and `npm run registry:sync`.


### PR DESCRIPTION
## Summary
- update onboarding docs to lead with the hosted MCP endpoint and clarify when local installation still applies
- add official MCP Registry metadata plus a small sync script for release-time version alignment
- extend the release workflow to publish to the official MCP Registry via GitHub OIDC on version tags

## Validation
- npm run registry:sync
- npm run typecheck
- npm test
- npm run build

Closes #35