### PR TITLE
Fix docs and config bugs around dataset guidance and setup

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -5,4 +5,4 @@
 #   $EDITOR .envrc
 #   direnv allow
 
-export GITHUB_TOKEN=""
+# export GITHUB_TOKEN=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ TRANSPORT=http PORT=3000 node dist/index.js
 
 ## FDIC Data Notes
 
-- FDIC financial data is quarterly. Use `REPDTE` in `YYYYMMDD` format for financial, summary, and demographics queries.
+- FDIC financial and demographics data are quarterly and use `REPDTE` in `YYYYMMDD` format.
+- FDIC summary data are annual and use `YEAR` rather than `REPDTE`.
 - SOD data is annual branch-level data as of June 30. Use SOD for branch counts and branch deposit totals rather than quarterly financial fields.
 - Do not casually mix quarterly financial snapshots with annual branch data without saying so. If both are used in an analysis, state the date basis clearly.
 - FDIC amounts are generally reported in thousands of dollars. Preserve that convention unless a change explicitly converts units for presentation.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Two tools are server-side analysis helpers:
 
 - Monetary values are generally reported in thousands of dollars.
 - `CERT` is the stable FDIC institution identifier.
-- Financial, summary, and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- Financial and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- Summary data is annual and uses `YEAR`.
 - SOD data is annual branch-level data as of June 30.
 - Do not mix quarterly financial data and annual branch data without stating the date basis.
 
@@ -232,4 +233,4 @@ npm run build
 
 ## License
 
-This project is licensed under the ISC License.
+This project is licensed under the MIT License.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -18,7 +18,7 @@ Last reviewed: March 15, 2026.
 |------|-------------|-------------|-----------------|---------------|-------|
 | Claude Desktop | Yes | Yes | Yes | Good | Hosted connector path is preferred when available |
 | ChatGPT Developer Mode | No direct local stdio | Yes | Yes | Good | Requires reachable HTTPS MCP endpoint |
-| Gemini CLI | Yes | Not documented here | Yes | Good | Local trust settings can block startup |
+| Gemini CLI | Yes | Yes | Yes | Good | Local trust settings can block startup |
 | GitHub Copilot CLI | Yes | Not documented here | Yes | Good | Local config is straightforward |
 | Other MCP hosts | Varies | Varies | Generic only | Best effort | Validate transport support before relying on the server |
 

--- a/docs/prompting-guide.md
+++ b/docs/prompting-guide.md
@@ -23,7 +23,8 @@ This server works best when prompts are explicit about the dataset, time basis, 
 ## Date Rules
 
 - You can describe dates naturally in prompts. The model or tool layer may translate them into `REPDTE` values behind the scenes when needed.
-- Financial, summary, and demographics queries use `REPDTE` in `YYYYMMDD` format at the tool/query level.
+- Financial and demographics queries use `REPDTE` in `YYYYMMDD` format at the tool/query level.
+- Summary queries use `YEAR` rather than `REPDTE`.
 - Summary of Deposits data is annual branch data as of June 30.
 - Do not mix quarterly financial questions with annual branch questions unless the prompt acknowledges the different dates.
 

--- a/docs/technical/specification.md
+++ b/docs/technical/specification.md
@@ -50,7 +50,8 @@ Contract stability matters because MCP clients may automate against either or bo
 
 ## FDIC Data Constraints
 
-- Financial, summary, and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- Financial and demographics datasets are quarterly and use `REPDTE` in `YYYYMMDD`.
+- Summary data is annual and uses `YEAR`.
 - Summary of Deposits data is annual branch-level data as of June 30.
 - Monetary values are generally reported in thousands of dollars.
 - `CERT` is the stable institution identifier used across datasets.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -48,5 +48,6 @@ This page summarizes what each MCP tool is for and when to use it.
 
 ## Data Basis Reminder
 
-- Quarterly datasets: financials, summary, demographics
+- Quarterly datasets: financials, demographics
+- Annual summary dataset: summary
 - Annual June 30 dataset: SOD

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,7 +47,8 @@ Common causes:
 
 The datasets answer different questions and do not all update on the same schedule.
 
-- financials, summary, and demographics are quarterly
+- financials and demographics are quarterly
+- summary data is annual
 - SOD is annual branch-level data as of June 30
 - failures and history use their own event dates
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,3 +47,25 @@ Reference: issue #41 and user request to continue with the next-tier workflow hy
 
 - [x] Issue created and linked: #41.
 - [x] Parsed all workflow YAML files successfully with Ruby `YAML.load_file`.
+
+# Docs And Config Bug Batch
+
+Reference: issues #44, #55, #56, and #57 and the follow-up bug triage work.
+
+## Goals
+
+- [x] Fix summary dataset date-basis references that incorrectly describe summary data as quarterly or `REPDTE`-based.
+- [x] Fix the README license text to match the MIT `LICENSE` file.
+- [x] Prevent `.envrc.example` from exporting an empty `GITHUB_TOKEN`.
+- [x] Fix the Gemini CLI compatibility matrix entry to reflect documented remote HTTP support.
+
+## Acceptance Criteria
+
+- [x] Summary data is described as annual and `YEAR`-based across the affected docs and repo guidance.
+- [x] The README license section matches the `LICENSE` file.
+- [x] `.envrc.example` no longer overrides an existing `GITHUB_TOKEN` with an empty value.
+- [x] The compatibility matrix matches the Gemini CLI client setup page.
+
+## Review / Results
+
+- [ ] Final verification and PR creation pending.


### PR DESCRIPTION
Closes #44
Closes #55
Closes #56
Closes #57

## Summary
- fix summary dataset guidance so summary is described as annual and `YEAR`-based instead of quarterly and `REPDTE`-based
- fix the README license text to match the MIT `LICENSE` file
- stop `.envrc.example` from exporting an empty `GITHUB_TOKEN`
- fix the Gemini CLI compatibility matrix entry to match the documented hosted `httpUrl` setup

## Scope
- repo guidance: `AGENTS.md`, `README.md`
- end-user and technical docs: prompting guide, troubleshooting, technical specification, tool reference, compatibility matrix
- local config example: `.envrc.example`

## Validation
- searched the repo for the known stale wording patterns after the edits
- did not run app tests because this PR only changes docs and a sample env file
