### PR TITLE
Fix analysis output, local deploy script, and HTTP startup validation

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 failures=()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,17 @@ async function runStdio(): Promise<void> {
   console.error("FDIC BankFind MCP server running on stdio");
 }
 
+export function parseHttpPort(rawPort: string | undefined): number {
+  const port = Number.parseInt(rawPort ?? "3000", 10);
+  if (Number.isNaN(port)) {
+    throw new Error(`Invalid PORT value: ${rawPort ?? ""}`);
+  }
+  if (port < 0 || port > 65535) {
+    throw new Error(`PORT must be between 0 and 65535. Received: ${port}`);
+  }
+  return port;
+}
+
 export function createApp(): Express {
   const app = express();
   app.use(express.json());
@@ -86,7 +97,7 @@ export function createApp(): Express {
 
 async function runHTTP(): Promise<void> {
   const app = createApp();
-  const port = parseInt(process.env.PORT ?? "3000");
+  const port = parseHttpPort(process.env.PORT);
   app.listen(port, () => {
     console.error(
       `FDIC BankFind MCP server running on http://localhost:${port}/mcp`,

--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -104,6 +104,11 @@ function asNumber(value: unknown): number | null {
   return typeof value === "number" ? value : null;
 }
 
+export function maxOrNull(values: Array<number | null>): number | null {
+  const nonNullValues = values.filter((value): value is number => value !== null);
+  return nonNullValues.length > 0 ? Math.max(...nonNullValues) : null;
+}
+
 function buildCertFilters(certs: number[]): string[] {
   const filters: string[] = [];
 
@@ -416,7 +421,7 @@ function summarizeTimeSeries(
   const depositsPerOfficeEnd = ratio(depEnd, officesEnd);
   const depositsToAssetsStart = ratio(depStart, assetStart);
   const depositsToAssetsEnd = ratio(depEnd, assetEnd);
-  const peakAsset = Math.max(...assetSeries.filter((value): value is number => value !== null));
+  const peakAsset = maxOrNull(assetSeries);
   const troughRoaValues = roaSeries.filter((value): value is number => value !== null);
   const troughRoa = troughRoaValues.length > 0 ? Math.min(...troughRoaValues) : null;
   const comparison: ComparisonRecord = {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -69,3 +69,27 @@ Reference: issues #44, #55, #56, and #57 and the follow-up bug triage work.
 ## Review / Results
 
 - [ ] Final verification and PR creation pending.
+
+# Correctness Bug Batch
+
+Reference: issue #62 and bugs #46, #53, and #59.
+
+## Goals
+
+- [x] Fix all-null asset series handling in timeseries analysis output.
+- [x] Make `scripts/deploy-local.sh` fail immediately on shell command errors.
+- [x] Validate `PORT` explicitly for HTTP startup and return a clearer configuration error.
+- [x] Add or update tests for the code-path changes where practical.
+- [ ] Open a PR for the resulting fixes.
+
+## Acceptance Criteria
+
+- [x] Timeseries analysis handles all-null asset series without producing `-Infinity`.
+- [x] `scripts/deploy-local.sh` uses strict shell failure handling.
+- [x] Invalid `PORT` values fail with a clear startup error message.
+- [x] Relevant tests pass for the changed code paths.
+
+## Review / Results
+
+- [x] Issue created and linked: #62.
+- [x] Verified `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.

--- a/tests/analysis.test.ts
+++ b/tests/analysis.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { yearsBetween } from "../src/tools/analysis.js";
+import { maxOrNull, yearsBetween } from "../src/tools/analysis.js";
 
 describe("yearsBetween", () => {
   it("returns exact quarter-based year spans for FDIC reporting dates", () => {
@@ -10,5 +10,15 @@ describe("yearsBetween", () => {
 
   it("clamps reversed ranges to zero", () => {
     expect(yearsBetween("20250630", "20211231")).toBe(0);
+  });
+});
+
+describe("maxOrNull", () => {
+  it("returns the max when at least one value is present", () => {
+    expect(maxOrNull([null, 10, 7, null, 15])).toBe(15);
+  });
+
+  it("returns null when all values are null", () => {
+    expect(maxOrNull([null, null, null])).toBeNull();
   });
 });

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -27,7 +27,7 @@ vi.mock("axios", () => {
   };
 });
 
-import { createApp } from "../src/index.js";
+import { createApp, parseHttpPort } from "../src/index.js";
 import { clearQueryCache } from "../src/services/fdicClient.js";
 import packageJson from "../package.json";
 
@@ -56,6 +56,22 @@ describe("HTTP MCP server", () => {
       server: "fdic-mcp-server",
       version: expectedVersion,
     });
+  });
+
+  it("parses the default HTTP port when PORT is not set", () => {
+    expect(parseHttpPort(undefined)).toBe(3000);
+  });
+
+  it("throws a clear error for a non-numeric PORT", () => {
+    expect(() => parseHttpPort("abc")).toThrow(
+      "Invalid PORT value: abc",
+    );
+  });
+
+  it("throws a clear error for an out-of-range PORT", () => {
+    expect(() => parseHttpPort("70000")).toThrow(
+      "PORT must be between 0 and 65535. Received: 70000",
+    );
   });
 
   it("lists all registered tools including demographics", async () => {


### PR DESCRIPTION
Closes #62
Closes #46
Closes #53
Closes #59

## Summary
- prevent all-null asset series from flowing through `Math.max(...[])` in timeseries analysis
- make `scripts/deploy-local.sh` fail immediately on command errors
- validate `PORT` explicitly for HTTP startup and return clearer configuration errors
- add focused tests for the new analysis and HTTP port parsing paths

## Changes
- add `maxOrNull()` in analysis code and use it for `asset_peak`
- add `parseHttpPort()` in the HTTP startup path with explicit NaN and range checks
- change `scripts/deploy-local.sh` to `set -euo pipefail`
- extend `tests/analysis.test.ts` and `tests/mcp-http.test.ts`
- update `tasks/todo.md` with the tracked work and validation results

## Validation
- `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`
- `npm run typecheck`
- `npm run build`
