### PR TITLE
Fix peer-group rank denominator semantics

### DIFF
--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -118,7 +118,7 @@ export function computeCompetitionRank(
   }
 
   const rank = ranks.get(subjectValue)!;
-  const of = peerValues.length;
+  const of = all.length;
   const percentile = Math.round((1 - (rank - 1) / of) * 100);
 
   return { rank, of, percentile };
@@ -449,7 +449,7 @@ Metrics ranked (fixed order):
   - Equity Capital Ratio, Efficiency Ratio, Loan-to-Deposit Ratio
   - Deposits-to-Assets Ratio, Non-Interest Income Share
 
-Rankings use competition rank (1, 2, 2, 4) with metric-specific denominators. Subject is excluded from peer set.
+Rankings use competition rank (1, 2, 2, 4). Rank, denominator, and percentile all use the same comparison set: matched peers plus the subject institution.
 
 Output includes:
   - Subject rankings and percentiles (when cert provided)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -93,3 +93,25 @@ Reference: issue #62 and bugs #46, #53, and #59.
 
 - [x] Issue created and linked: #62.
 - [x] Verified `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.
+
+# Peer Group Ranking Semantics
+
+Reference: issue #64 and bug #45.
+
+## Goals
+
+- [x] Make rank, denominator, and percentile use the same comparison set in peer-group output.
+- [x] Update tests to reflect the chosen ranking contract.
+- [x] Update user-facing wording where it currently implies different denominator semantics.
+- [ ] Open a PR for the resulting fix.
+
+## Acceptance Criteria
+
+- [x] `rank` and `of` describe the same comparison set.
+- [x] Percentile remains in-range and matches the same comparison set.
+- [x] Tests cover best, worst, tie, and small-peer-group scenarios under the updated semantics.
+
+## Review / Results
+
+- [x] Issue created and linked: #64.
+- [x] Verified `npm test -- tests/peerGroup.test.ts tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -746,7 +746,7 @@ describe("HTTP MCP server", () => {
     expect(sc.peer_count).toBe(2);
     expect(sc.returned_count).toBe(2);
     expect(sc.subject.cert).toBe(100);
-    expect(sc.subject.rankings.roa).toMatchObject({ of: 2 });
+    expect(sc.subject.rankings.roa).toMatchObject({ of: 3 });
     // Subject ROA 1.5 vs peers [1.2, 1.8] → sorted desc: 1.8, 1.5, 1.2 → subject rank 2
     expect(sc.subject.rankings.roa.rank).toBe(2);
     expect(sc.peers).toHaveLength(2);

--- a/tests/peerGroup.test.ts
+++ b/tests/peerGroup.test.ts
@@ -108,12 +108,12 @@ describe("computeMedian", () => {
 describe("computeCompetitionRank", () => {
   it("ranks a value among peers (higher-is-better, descending sort)", () => {
     const result = computeCompetitionRank(7, [10, 8, 6, 4, 2], true);
-    expect(result).toEqual({ rank: 3, of: 5, percentile: 60 });
+    expect(result).toEqual({ rank: 3, of: 6, percentile: 67 });
   });
 
   it("ranks a value among peers (lower-is-better, ascending sort)", () => {
     const result = computeCompetitionRank(3, [10, 8, 6, 4, 2], false);
-    expect(result).toEqual({ rank: 2, of: 5, percentile: 80 });
+    expect(result).toEqual({ rank: 2, of: 6, percentile: 83 });
   });
 
   it("handles ties — subject gets same rank as equal peers", () => {
@@ -122,24 +122,24 @@ describe("computeCompetitionRank", () => {
     // Competition ranks: 10→1, 8→2, 4→5
     // Subject value 8 → rank 2
     const result = computeCompetitionRank(8, [10, 8, 8, 4], true);
-    expect(result).toEqual({ rank: 2, of: 4, percentile: 75 });
+    expect(result).toEqual({ rank: 2, of: 5, percentile: 80 });
   });
 
   it("gives rank 1 and 100th percentile when subject is best", () => {
     const result = computeCompetitionRank(99, [10, 20, 30], true);
-    expect(result).toEqual({ rank: 1, of: 3, percentile: 100 });
+    expect(result).toEqual({ rank: 1, of: 4, percentile: 100 });
   });
 
-  it("gives last rank when subject is worst (higher-is-better)", () => {
+  it("gives last rank within the full comparison set when subject is worst", () => {
     const result = computeCompetitionRank(1, [10, 20, 30], true);
     // All desc: 30, 20, 10, 1 → subject rank 4
-    expect(result).toEqual({ rank: 4, of: 3, percentile: 0 });
+    expect(result).toEqual({ rank: 4, of: 4, percentile: 25 });
   });
 
   it("handles null-direction metrics (descending sort by default)", () => {
     const result = computeCompetitionRank(5, [10, 8, 3, 1], null);
     // All desc: 10, 8, 5, 3, 1 → subject rank 3
-    expect(result).toEqual({ rank: 3, of: 4, percentile: 50 });
+    expect(result).toEqual({ rank: 3, of: 5, percentile: 60 });
   });
 
   it("returns null when peer list is empty", () => {


### PR DESCRIPTION
Closes #64
Closes #45

## Summary
- make peer-group rank, denominator, and percentile use the same comparison set
- remove confusing outputs like `rank 4 of 3`
- update tests and tool wording to match the new contract

## Changes
- change `computeCompetitionRank()` so `of` uses the same set as `rank` and percentile: matched peers plus the subject institution
- keep competition-rank semantics for ties
- update peer-group unit tests for best, worst, tie, and null-direction cases
- update the HTTP integration test that inspects structured subject rankings
- update the tool description in `src/tools/peerGroup.ts`

## Validation
- `npm test -- tests/peerGroup.test.ts tests/mcp-http.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
- this changes the structured/output contract for `of` and percentile values in peer-group rankings
- I left archival design-plan docs unchanged; the live tool contract and tests are updated
