### PR TITLE
Validate FDIC API response shapes in the client layer

### DIFF
--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -60,6 +60,48 @@ export function clearQueryCache(): void {
   queryCache.clear();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function validateFdicResponseShape(
+  endpoint: string,
+  payload: unknown,
+): FdicResponse {
+  if (!isRecord(payload)) {
+    throw new Error(
+      `Unexpected FDIC API response shape for endpoint ${endpoint}: expected an object payload.`,
+    );
+  }
+
+  const { data, meta } = payload;
+
+  if (!Array.isArray(data)) {
+    throw new Error(
+      `Unexpected FDIC API response shape for endpoint ${endpoint}: expected 'data' to be an array.`,
+    );
+  }
+
+  if (!isRecord(meta) || typeof meta.total !== "number") {
+    throw new Error(
+      `Unexpected FDIC API response shape for endpoint ${endpoint}: expected 'meta.total' to be a number.`,
+    );
+  }
+
+  return {
+    data: data.map((item, index) => {
+      if (!isRecord(item) || !isRecord(item.data)) {
+        throw new Error(
+          `Unexpected FDIC API response shape for endpoint ${endpoint}: expected data[${index}] to contain an object 'data' property.`,
+        );
+      }
+
+      return { data: item.data };
+    }),
+    meta: { total: meta.total },
+  };
+}
+
 export async function queryEndpoint(
   endpoint: string,
   params: QueryParams,
@@ -96,7 +138,7 @@ export async function queryEndpoint(
         params: queryParams,
         signal: options.signal,
       });
-      return response.data;
+      return validateFdicResponseShape(endpoint, response.data);
     } catch (err) {
       if (
         options.signal?.aborted ||
@@ -153,7 +195,14 @@ export async function queryEndpoint(
 export function extractRecords(
   response: FdicResponse,
 ): Array<Record<string, unknown>> {
-  return response.data.map((item) => item.data);
+  return response.data.map((item, index) => {
+    if (!isRecord(item) || !isRecord(item.data)) {
+      throw new Error(
+        `Unexpected FDIC API response shape: expected data[${index}] to contain an object 'data' property.`,
+      );
+    }
+    return item.data;
+  });
 }
 
 export function buildPaginationInfo(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -115,3 +115,24 @@ Reference: issue #64 and bug #45.
 
 - [x] Issue created and linked: #64.
 - [x] Verified `npm test -- tests/peerGroup.test.ts tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.
+
+# FDIC Response Shape Hardening
+
+Reference: issue #47.
+
+## Goals
+
+- [x] Validate the FDIC API response shape centrally in the client layer.
+- [x] Replace low-level shape errors with explicit, actionable error messages.
+- [x] Add tests for malformed FDIC response payloads.
+- [ ] Open a PR for the hardening change.
+
+## Acceptance Criteria
+
+- [x] Unexpected FDIC response shapes fail with clear errors.
+- [x] Cached requests do not retain malformed-response failures.
+- [x] Tests cover malformed top-level and malformed record-level response shapes.
+
+## Review / Results
+
+- [x] Verified `npm test -- tests/fdicClient.test.ts`, `npm run typecheck`, and `npm run build`.

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -34,6 +34,7 @@ import {
   formatToolError,
   queryEndpoint,
   truncateIfNeeded,
+  validateFdicResponseShape,
 } from "../src/services/fdicClient.js";
 import packageJson from "../package.json";
 
@@ -73,6 +74,26 @@ describe("fdicClient", () => {
       },
     });
     expect(response.meta.total).toBe(1);
+  });
+
+  it("rejects malformed top-level FDIC response payloads", async () => {
+    getMock.mockResolvedValueOnce({
+      data: { records: [], meta: { total: 0 } },
+    });
+
+    await expect(queryEndpoint("institutions", {})).rejects.toThrow(
+      "Unexpected FDIC API response shape for endpoint institutions: expected 'data' to be an array.",
+    );
+  });
+
+  it("rejects malformed FDIC record wrappers", async () => {
+    getMock.mockResolvedValueOnce({
+      data: { data: [{ CERT: 3511 }], meta: { total: 1 } },
+    });
+
+    await expect(queryEndpoint("institutions", {})).rejects.toThrow(
+      "Unexpected FDIC API response shape for endpoint institutions: expected data[0] to contain an object 'data' property.",
+    );
   });
 
   it("includes optional query parameters when provided", async () => {
@@ -190,6 +211,29 @@ describe("fdicClient", () => {
         meta: { total: 2 },
       }),
     ).toEqual([{ CERT: 1 }, { CERT: 2 }]);
+  });
+
+  it("throws a clear error when extractRecords receives malformed entries", () => {
+    expect(() =>
+      extractRecords({
+        data: [{ CERT: 1 } as unknown as { data: Record<string, unknown> }],
+        meta: { total: 1 },
+      }),
+    ).toThrow(
+      "Unexpected FDIC API response shape: expected data[0] to contain an object 'data' property.",
+    );
+  });
+
+  it("validates a well-formed FDIC response payload", () => {
+    expect(
+      validateFdicResponseShape("institutions", {
+        data: [{ data: { CERT: 1 } }],
+        meta: { total: 1 },
+      }),
+    ).toEqual({
+      data: [{ data: { CERT: 1 } }],
+      meta: { total: 1 },
+    });
   });
 
   it("builds pagination metadata with next_offset when more results exist", () => {


### PR DESCRIPTION
Closes #47

## Summary
- validate FDIC API response shapes centrally in the client layer
- replace low-level shape errors with explicit endpoint-aware errors
- add malformed-response tests for top-level payloads and record wrappers

## Changes
- add `validateFdicResponseShape()` in `src/services/fdicClient.ts`
- validate top-level `data` and `meta.total` before returning from `queryEndpoint()`
- validate per-record `{ data: ... }` wrappers with clear error messages
- keep malformed responses from being treated as valid cached results
- extend `tests/fdicClient.test.ts` with malformed payload coverage

## Validation
- `npm test -- tests/fdicClient.test.ts`
- `npm run typecheck`
- `npm run build`
