### PR TITLE
Gate Cloud Run deployment on successful CI

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -1,7 +1,11 @@
 name: Deploy Cloud Run
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:
@@ -11,8 +15,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-cloud-run-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-cloud-run-production
+  cancel-in-progress: false
 
 env:
   GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -28,6 +32,12 @@ env:
 jobs:
   deploy:
     name: Deploy production
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success'
+      )
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -36,6 +46,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Validate required variables
         run: |

--- a/docs/technical/cloud-run-deployment.md
+++ b/docs/technical/cloud-run-deployment.md
@@ -104,12 +104,20 @@ This is why the workflow only needs repository variables such as `GCP_WORKLOAD_I
 
 ## Deployment Behavior
 
-On every push to `main`, the workflow:
+The production deploy workflow runs in two cases:
 
-1. Authenticates to Google Cloud using GitHub OIDC
-2. Builds the container image
-3. Pushes the image to Artifact Registry
-4. Deploys the new revision to Cloud Run
+1. automatically after the `CI` workflow completes successfully for `main`
+2. manually through `workflow_dispatch` when an operator explicitly triggers it
+
+On an automatic production deploy, the workflow:
+
+1. checks out the exact commit SHA that passed CI
+2. authenticates to Google Cloud using GitHub OIDC
+3. builds the container image
+4. pushes the image to Artifact Registry
+5. deploys the new revision to Cloud Run
+
+Production deploy concurrency is serialized. Newer deploy requests wait rather than canceling an in-flight production rollout.
 
 ## Registry Publication
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -136,3 +136,24 @@ Reference: issue #47.
 ## Review / Results
 
 - [x] Verified `npm test -- tests/fdicClient.test.ts`, `npm run typecheck`, and `npm run build`.
+
+# CI-Gated Cloud Run Deployment
+
+Reference: issue #52.
+
+## Goals
+
+- [x] Gate Cloud Run deployment on successful CI rather than raw pushes to `main`.
+- [x] Prevent in-progress production deployments from being canceled by a newer push.
+- [x] Update technical docs to describe the new deploy trigger correctly.
+- [ ] Open a PR for the workflow change.
+
+## Acceptance Criteria
+
+- [x] Cloud Run deploys only after the `CI` workflow completes successfully for `main`.
+- [x] Production deploy concurrency no longer cancels an in-flight deployment.
+- [x] Technical docs describe the CI-gated deploy behavior accurately.
+
+## Review / Results
+
+- [x] Parsed `.github/workflows/deploy-cloud-run.yml` successfully with Ruby `YAML.load_file`.


### PR DESCRIPTION
Closes #52

## Summary
- trigger Cloud Run deployment only after the `CI` workflow completes successfully for `main`
- keep manual deployment via `workflow_dispatch`
- stop canceling in-flight production deployments when newer deploy requests arrive
- update the technical deployment docs to describe the new behavior

## Changes
- change `deploy-cloud-run.yml` from `push` to `workflow_run` on the `CI` workflow for `main`
- gate the deploy job on `workflow_run.conclusion == success`
- check out the exact commit SHA that passed CI during automatic deploys
- change production deploy concurrency to serialized, non-canceling behavior
- update `docs/technical/cloud-run-deployment.md`

## Validation
- parsed `.github/workflows/deploy-cloud-run.yml` successfully with Ruby `YAML.load_file`
- did not run app tests because this PR changes workflow/docs behavior only
