### PR TITLE
Make GitHub Packages publish idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,21 @@ jobs:
           registry-url: https://npm.pkg.github.com
           scope: "@jflamb"
 
+      - name: Check for existing GitHub Packages version
+        id: gpr
+        working-directory: .tmp/github-package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view @jflamb/fdic-mcp-server@"$VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to GitHub Packages
+        if: steps.gpr.outputs.exists != 'true'
         working-directory: .tmp/github-package
         run: npm publish
         env:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -429,19 +429,42 @@ Reference: issue #80 and PR #81.
 
 - [x] Bump the package and registry metadata version for the schema-listing fix release.
 - [x] Add matching GitHub and docs release notes for the new version.
-- [ ] Merge the fix branch to `main`.
-- [ ] Tag the merged `main` commit so the publish workflow runs.
+- [x] Merge the fix branch to `main`.
+- [x] Tag the merged `main` commit so the publish workflow runs.
 
 ## Acceptance Criteria
 
 - [x] `package.json`, `package-lock.json`, and `server.json` all point to the new patch version.
 - [x] The docs site points to the new latest release notes entry.
-- [ ] The release tag references a commit already on `main`.
+- [x] The release tag references a commit already on `main`.
 - [x] Validation passes after the release-prep changes.
 
 ## Review / Results
 
 - [x] Release version selected: `1.1.3`.
+- [x] Merged PR #81 to `main`.
+- [x] Tagged merged `main` commit as `v1.1.3`.
 - [x] Verified `npm test -- tests/mcp-http.test.ts`.
 - [x] Verified `npm run typecheck`.
 - [x] Verified `npm run build`.
+
+# Idempotent GitHub Packages Publish
+
+Reference: issue #82.
+
+## Goals
+
+- [ ] Prevent the tagged publish workflow from failing when GitHub Packages already has the target version.
+- [ ] Allow later release steps to continue when GitHub Packages publish is skipped.
+- [ ] Open a PR for the workflow fix.
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/publish.yml` checks whether the GitHub Packages version already exists before publishing.
+- [ ] The GitHub Packages publish step is skipped instead of failing when the version is already present.
+- [ ] The GitHub Release step can still run after a skipped GitHub Packages publish.
+- [ ] Workflow YAML remains valid after the change.
+
+## Review / Results
+
+- [x] Opened issue #82.


### PR DESCRIPTION
## Summary
- add a GitHub Packages version-exists check to the tagged publish workflow
- skip the GitHub Packages publish step when that version is already present
- keep the later GitHub Release step reachable after a skipped package publish

## Validation
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/publish.yml\"); YAML.load_file(\".github/workflows/sync-release-and-gpr.yml\"); puts \"ok\"'`\n\nCloses #82\n