### PR TITLE
Fix Batch 1 runtime and workflow consistency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           registry-url: https://registry.npmjs.org
           cache: npm
 
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Node.js for GitHub Packages
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           registry-url: https://npm.pkg.github.com
           scope: "@jflamb"
 

--- a/.github/workflows/sync-release-and-gpr.yml
+++ b/.github/workflows/sync-release-and-gpr.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js for npm
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node.js for GitHub Packages
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           registry-url: https://npm.pkg.github.com
           scope: "@jflamb"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ Prerequisites:
 - Node.js 18 or later
 - npm
 
+Recommended local versions:
+
+- Node.js 20 or 22 for parity with CI
+
 Install and validate:
 
 ```bash
@@ -22,6 +26,12 @@ npm install
 npm run typecheck
 npm test
 npm run build
+```
+
+Run directly from TypeScript during development:
+
+```bash
+npm run dev
 ```
 
 Run locally over stdio:
@@ -35,6 +45,17 @@ Run locally over HTTP:
 ```bash
 TRANSPORT=http PORT=3000 node dist/index.js
 ```
+
+Container note:
+
+- Local HTTP examples default to port `3000`.
+- The production Docker and Cloud Run runtime default to port `8080`.
+
+## Node Version Policy
+
+- CI validates the project on Node.js 20 and 22.
+- Release publishing workflows run on Node.js 22.
+- The production Docker image also uses Node.js 22.
 
 ## Workflow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM node:22-bookworm-slim
 
 ENV NODE_ENV=production
 ENV TRANSPORT=http
+# Cloud Run injects PORT=8080, so the image uses the same container default.
 ENV PORT=8080
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ TRANSPORT=http PORT=3000 node dist/index.js
 
 The HTTP MCP endpoint is `http://localhost:3000/mcp`.
 
+Container builds use `PORT=8080` by default for Cloud Run compatibility.
+
 ### Minimal MCP Configuration
 
 ```json

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,6 +19,7 @@ The full contributor workflow lives in the repository root at `CONTRIBUTING.md`.
 - Update tests for behavior or contract changes.
 - Update the docs when prompts, client setup, or technical behavior changes.
 - Run `npm run typecheck`, `npm test`, and `npm run build` before opening a pull request.
+- Use Node.js 20 or 22 locally when possible to match CI, release publishing, and the production container baseline.
 
 ## Repository Guide
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,8 @@ TRANSPORT=http PORT=3000 node dist/index.js
 
 The HTTP MCP endpoint is available at `http://localhost:3000/mcp`.
 
+The Docker image and Cloud Run deployment use port `8080` by default; `3000` is the local shell example for direct runs outside the container.
+
 ### Connect A Client
 
 Use the client-specific instructions in [Client Setup]({{ '/clients/' | relative_url }}).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,8 @@ TRANSPORT=http PORT=3000 fdic-mcp-server
 
 Then expose it through a reachable HTTPS URL.
 
+If you are running the Docker image or Cloud Run deployment instead of the local binary, use port `8080` rather than `3000`.
+
 ### Why do I get no results for a bank I know exists?
 
 Common causes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,16 @@
         "express": "^4.18.2",
         "zod": "^3.22.4"
       },
+      "bin": {
+        "fdic-mcp-server": "dist/index.js"
+      },
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^20.0.0",
         "@types/supertest": "^6.0.3",
         "esbuild": "^0.27.4",
         "supertest": "^7.1.4",
+        "tsx": "^4.20.6",
         "typescript": "^5.3.0",
         "vitest": "^3.2.4"
       },
@@ -2276,6 +2280,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2776,6 +2793,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -3245,6 +3272,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pack:check": "npm pack --dry-run",
     "registry:sync": "node scripts/sync-server-json.mjs",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts",
+    "dev": "tsx src/cli.ts",
     "deploy:local": "bash scripts/deploy-local.sh"
   },
   "repository": {
@@ -56,6 +56,7 @@
     "@types/supertest": "^6.0.3",
     "esbuild": "^0.27.4",
     "supertest": "^7.1.4",
+    "tsx": "^4.20.6",
     "typescript": "^5.3.0",
     "vitest": "^3.2.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ export function parseHttpPort(rawPort: string | undefined): number {
 
 export function createApp(): Express {
   const app = express();
+  const server = createServer();
+  let requestQueue = Promise.resolve();
   app.use(express.json());
 
   app.get("/health", (_req, res) => {
@@ -61,7 +63,6 @@ export function createApp(): Express {
   });
 
   app.post("/mcp", async (req, res) => {
-    const server = createServer();
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: true,
@@ -69,27 +70,35 @@ export function createApp(): Express {
 
     res.on("close", () => {
       void transport.close().catch(() => {});
-      void server.close().catch(() => {});
     });
 
-    try {
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-    } catch (error: unknown) {
-      console.error("MCP request error:", error);
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32603,
-            message: "Internal server error",
-          },
-          id: null,
-        });
+    // The SDK server can only connect to one transport at a time, so HTTP
+    // requests reuse the same tool-registered server instance sequentially.
+    const runRequest = async () => {
+      try {
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      } catch (error: unknown) {
+        console.error("MCP request error:", error);
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32603,
+              message: "Internal server error",
+            },
+            id: null,
+          });
+        }
+      } finally {
+        await transport.close().catch(() => {});
+        await server.close().catch(() => {});
       }
-      await transport.close().catch(() => {});
-      await server.close().catch(() => {});
-    }
+    };
+
+    const queuedRequest = requestQueue.catch(() => {}).then(runRequest);
+    requestQueue = queuedRequest;
+    await queuedRequest;
   });
 
   return app;

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -113,16 +113,17 @@ describe("HTTP MCP server", () => {
     expect(peerGroupTool.inputSchema.properties.asset_min.type).toBe("number");
   });
 
-  it("handles repeated MCP requests without reusing a connected server", async () => {
-    getMock
-      .mockResolvedValueOnce({
-        data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
-      })
-      .mockResolvedValueOnce({
-        data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
-      });
+  it("reuses cached FDIC responses across sequential HTTP requests", async () => {
+    const app = createApp();
+    getMock.mockResolvedValueOnce({
+      data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
+    });
 
-    const first = await mcpPost({
+    const first = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", "application/json, text/event-stream")
+      .send({
       jsonrpc: "2.0",
       id: 1,
       method: "tools/call",
@@ -132,7 +133,11 @@ describe("HTTP MCP server", () => {
       },
     });
 
-    const second = await mcpPost({
+    const second = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", "application/json, text/event-stream")
+      .send({
       jsonrpc: "2.0",
       id: 2,
       method: "tools/call",
@@ -147,6 +152,7 @@ describe("HTTP MCP server", () => {
     expect(second.body.result.structuredContent.institutions[0].CERT).toBe(
       3511,
     );
+    expect(getMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns structuredContent for search tools", async () => {


### PR DESCRIPTION
## Summary
- reuse one app-scoped MCP server instance for HTTP requests while reconnecting per-request transports sequentially
- fix the development entrypoint by switching `npm run dev` to `tsx src/cli.ts`
- document the local-vs-container port split and align release workflows to the same Node 22 baseline as Docker

Closes #84
Closes #85
Closes #87
Closes #90

## Validation
- `npm run typecheck`
- `npm test -- tests/mcp-http.test.ts tests/fdicClient.test.ts`
- `npm run build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); YAML.load_file(".github/workflows/sync-release-and-gpr.yml"); puts "workflow yaml ok"'`
- `npm run dev` (smoke-tested until stdio startup banner, then stopped)
