### PR TITLE
Fix analysis date validation and deterministic ordering

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -103,6 +103,10 @@ function validateSnapshotAnalysisParams(
     return "Provide either state or certs.";
   }
 
+  if (value.start_repdte >= value.end_repdte) {
+    return "start_repdte must be earlier than end_repdte.";
+  }
+
   return null;
 }
 
@@ -133,16 +137,36 @@ function change(start: number | null, end: number | null): number | null {
   return end - start;
 }
 
-function getQuarterIndex(repdte: string): number | null {
+export function getQuarterIndex(repdte: string): number | null {
   const year = Number.parseInt(repdte.slice(0, 4), 10);
   const month = Number.parseInt(repdte.slice(4, 6), 10);
-  const quarter = month / 3;
-
-  if (!Number.isInteger(quarter) || quarter < 1 || quarter > 4) {
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
     return null;
   }
 
+  if (month < 1 || month > 12) {
+    return null;
+  }
+
+  const quarter = Math.ceil(month / 3);
+
   return year * 4 + quarter;
+}
+
+function compareComparisonTieBreakers(
+  left: ComparisonRecord,
+  right: ComparisonRecord,
+): number {
+  const leftCert = asNumber(left.cert);
+  const rightCert = asNumber(right.cert);
+
+  if (leftCert !== null && rightCert !== null && leftCert !== rightCert) {
+    return leftCert - rightCert;
+  }
+
+  const leftName = String(left.name ?? "");
+  const rightName = String(right.name ?? "");
+  return leftName.localeCompare(rightName);
 }
 
 export function yearsBetween(startRepdte: string, endRepdte: string): number {
@@ -193,10 +217,14 @@ function sortComparisons(
 ): ComparisonRecord[] {
   const direction = sortOrder === "ASC" ? 1 : -1;
 
+  // Tie-break by CERT/name so repeated runs keep the same ranked order.
   return [...comparisons].sort((left, right) => {
     const leftValue = asNumber(left[sortBy]) ?? Number.NEGATIVE_INFINITY;
     const rightValue = asNumber(right[sortBy]) ?? Number.NEGATIVE_INFINITY;
-    return (leftValue - rightValue) * direction;
+    const primary = (leftValue - rightValue) * direction;
+    return primary !== 0
+      ? primary
+      : compareComparisonTieBreakers(left, right);
   });
 }
 
@@ -357,7 +385,10 @@ function summarizeTimeSeries(
   if (records.length < 2) return null;
 
   const sorted = [...records].sort((left, right) =>
-    String(left.REPDTE).localeCompare(String(right.REPDTE)),
+    String(left.REPDTE).localeCompare(String(right.REPDTE)) ||
+    String(left.NAME ?? institution.NAME ?? "").localeCompare(
+      String(right.NAME ?? institution.NAME ?? ""),
+    ),
   );
   const start = sorted[0];
   const end = sorted[sorted.length - 1];

--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -239,6 +239,20 @@ interface PeerEntry {
   extraFields: Record<string, unknown>;
 }
 
+function comparePeerEntriesByAsset(left: PeerEntry, right: PeerEntry): number {
+  const primary = (right.metrics.asset ?? 0) - (left.metrics.asset ?? 0);
+  if (primary !== 0) {
+    return primary;
+  }
+
+  // Tie-break by CERT/name so peer ordering is deterministic across runs.
+  if (left.cert !== right.cert) {
+    return left.cert - right.cert;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
 function formatMetricValue(key: MetricKey, value: number | null): string {
   if (value === null) return "n/a";
   const def = METRIC_DEFINITIONS[key];
@@ -651,8 +665,8 @@ Override precedence: cert derives defaults, then explicit params override them.`
           }
         }
 
-        // Sort peers by asset descending, truncate
-        peers.sort((a, b) => (b.metrics.asset ?? 0) - (a.metrics.asset ?? 0));
+        // Sort peers by asset descending with a deterministic tie-breaker.
+        peers.sort(comparePeerEntriesByAsset);
         const returnedPeers = peers.slice(0, params.limit);
         const returnedCount = returnedPeers.length;
         const hasMore = peerCount > returnedCount;

--- a/tests/analysis.test.ts
+++ b/tests/analysis.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it } from "vitest";
 
-import { maxOrNull, yearsBetween } from "../src/tools/analysis.js";
+import {
+  getQuarterIndex,
+  maxOrNull,
+  yearsBetween,
+} from "../src/tools/analysis.js";
+
+describe("getQuarterIndex", () => {
+  it("maps every month to its containing quarter", () => {
+    expect(getQuarterIndex("20240115")).toBe(2024 * 4 + 1);
+    expect(getQuarterIndex("20240215")).toBe(2024 * 4 + 1);
+    expect(getQuarterIndex("20240315")).toBe(2024 * 4 + 1);
+    expect(getQuarterIndex("20240415")).toBe(2024 * 4 + 2);
+    expect(getQuarterIndex("20240515")).toBe(2024 * 4 + 2);
+    expect(getQuarterIndex("20240615")).toBe(2024 * 4 + 2);
+    expect(getQuarterIndex("20240715")).toBe(2024 * 4 + 3);
+    expect(getQuarterIndex("20240815")).toBe(2024 * 4 + 3);
+    expect(getQuarterIndex("20240915")).toBe(2024 * 4 + 3);
+    expect(getQuarterIndex("20241015")).toBe(2024 * 4 + 4);
+    expect(getQuarterIndex("20241115")).toBe(2024 * 4 + 4);
+    expect(getQuarterIndex("20241215")).toBe(2024 * 4 + 4);
+  });
+
+  it("returns null for invalid months", () => {
+    expect(getQuarterIndex("20240015")).toBeNull();
+    expect(getQuarterIndex("20241315")).toBeNull();
+  });
+});
 
 describe("yearsBetween", () => {
   it("returns exact quarter-based year spans for FDIC reporting dates", () => {
     expect(yearsBetween("20211231", "20250630")).toBe(3.5);
     expect(yearsBetween("20240331", "20240630")).toBe(0.25);
+  });
+
+  it("uses quarter math for non-quarter-end dates in the same quarter cadence", () => {
+    expect(yearsBetween("20240115", "20240415")).toBe(0.25);
+    expect(yearsBetween("20240115", "20250115")).toBe(1);
   });
 
   it("clamps reversed ranges to zero", () => {

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -625,6 +625,48 @@ describe("HTTP MCP server", () => {
     );
   });
 
+  it("rejects snapshot analysis requests when start_repdte is not earlier than end_repdte", async () => {
+    const reversed = await mcpPost({
+      jsonrpc: "2.0",
+      id: 801,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20241231",
+          end_repdte: "20211231",
+        },
+      },
+    });
+
+    const equal = await mcpPost({
+      jsonrpc: "2.0",
+      id: 802,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20241231",
+          end_repdte: "20241231",
+        },
+      },
+    });
+
+    expect(reversed.status).toBe(200);
+    expect(reversed.body.result.isError).toBe(true);
+    expect(reversed.body.result.content[0].text).toContain(
+      "start_repdte must be earlier than end_repdte.",
+    );
+
+    expect(equal.status).toBe(200);
+    expect(equal.body.result.isError).toBe(true);
+    expect(equal.body.result.content[0].text).toContain(
+      "start_repdte must be earlier than end_repdte.",
+    );
+  });
+
   it("batches snapshot comparisons into financial and demographic date queries", async () => {
     getMock
       .mockResolvedValueOnce({
@@ -931,6 +973,66 @@ describe("HTTP MCP server", () => {
     expect(
       response.body.result.structuredContent.insights.growth_with_branch_expansion,
     ).toEqual(["Bank Fast", "Bank Slow"]);
+  });
+
+  it("uses cert as a deterministic tie-breaker for equal analysis sort values", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank One", CITY: "Raleigh", STALP: "NC" } },
+            { data: { CERT: 2222, NAME: "Bank Two", CITY: "Durham", STALP: "NC" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank One", ASSET: 100, DEP: 50, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+            { data: { CERT: 2222, NAME: "Bank Two", ASSET: 150, DEP: 70, NETINC: 12, ROA: 1.2, ROE: 8.5 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Bank One", ASSET: 200, DEP: 120, NETINC: 15, ROA: 1.1, ROE: 8.2 } },
+            { data: { CERT: 2222, NAME: "Bank Two", ASSET: 250, DEP: 140, NETINC: 17, ROA: 1.3, ROE: 8.7 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 803,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          sort_by: "asset_growth",
+          limit: 2,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.structuredContent.comparisons.map(
+        (comparison: { cert: number }) => comparison.cert,
+      ),
+    ).toEqual([1111, 2222]);
   });
 
   it("includes all generated insight categories in the top-level summary", async () => {
@@ -1318,5 +1420,50 @@ describe("HTTP MCP server", () => {
     expect(sc.message).toBe("No peers matched the specified criteria.");
     expect(sc.peers).toEqual([]);
     expect(sc.subject.rankings).toBeNull();
+  });
+
+  it("uses cert as a deterministic tie-breaker for equal peer asset values", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "N" } },
+            { data: { CERT: 300, NAME: "Peer B", CITY: "Charlotte", STALP: "NC", BKCLASS: "N" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 300, ASSET: 5000000, DEP: 4000000, NETINC: 100000, ROA: 1.0, ROE: 9.0, NETNIM: 3.0, EQTOT: 500000, LNLSNET: 3000000, INTINC: 200000, EINTEXP: 80000, NONII: 30000, NONIX: 100000 } },
+            { data: { CERT: 200, ASSET: 5000000, DEP: 4100000, NETINC: 110000, ROA: 1.1, ROE: 9.5, NETNIM: 3.1, EQTOT: 520000, LNLSNET: 3050000, INTINC: 210000, EINTEXP: 82000, NONII: 32000, NONIX: 101000 } },
+          ],
+          meta: { total: 2 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 105,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: {
+          repdte: "20241231",
+          asset_min: 5000000,
+          asset_max: 6000000,
+          charter_classes: ["N"],
+          state: "NC",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.structuredContent.peers.map(
+        (peer: { cert: number }) => peer.cert,
+      ),
+    ).toEqual([200, 300]);
   });
 });


### PR DESCRIPTION
## Summary
- reject `fdic_compare_bank_snapshots` requests unless `start_repdte` is earlier than `end_repdte`
- fix quarter indexing for all months and keep analysis/peer ordering deterministic with explicit tie-breakers
- add regression coverage for reversed/equal dates and tied ranking output

Closes #88
Closes #89
Closes #92

## Validation
- `npm run typecheck`
- `npm test -- tests/analysis.test.ts tests/peerGroup.test.ts tests/mcp-http.test.ts`
- `npm run build`
