### PR TITLE
Refactor shared search filters and truncation guidance

### DIFF
--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -250,11 +250,15 @@ export function buildTruncationWarning(
   );
 }
 
-export function truncateIfNeeded(text: string, charLimit: number): string {
+export function truncateIfNeeded(
+  text: string,
+  charLimit: number,
+  guidance = "Request fewer fields, narrow your filters, or paginate with limit/offset.",
+): string {
   if (text.length <= charLimit) return text;
   return (
     text.slice(0, charLimit) +
-    `\n\n[Response truncated at ${charLimit} characters. Use limit/offset parameters to paginate or narrow your query with filters.]`
+    `\n\n[Response truncated at ${charLimit} characters. ${guidance}]`
   );
 }
 

--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -1027,6 +1027,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             .filter((value): value is string => value !== null)
             .join("\n\n"),
           CHARACTER_LIMIT,
+          "Reduce the number of certs, narrow institution_filters, request fewer fields, or shorten the date range.",
         );
 
         return {

--- a/src/tools/demographics.ts
+++ b/src/tools/demographics.ts
@@ -10,6 +10,7 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import { CommonQuerySchema } from "../schemas/common.js";
+import { buildFilterString } from "./shared/queryUtils.js";
 
 const DemographicsQuerySchema = CommonQuerySchema.extend({
   cert: z
@@ -77,14 +78,14 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, repdte, ...params }) => {
       try {
-        const filterParts: string[] = [];
-        if (params.filters) filterParts.push(`(${params.filters})`);
-        if (cert !== undefined) filterParts.push(`CERT:${cert}`);
-        if (repdte) filterParts.push(`REPDTE:${repdte}`);
         const response = await queryEndpoint(ENDPOINTS.DEMOGRAPHICS, {
           ...params,
-          filters:
-            filterParts.length > 0 ? filterParts.join(" AND ") : undefined,
+          filters: buildFilterString({
+            cert,
+            dateField: "REPDTE",
+            dateValue: repdte,
+            rawFilters: params.filters,
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -103,6 +104,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "CBSANAME",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/failures.ts
+++ b/src/tools/failures.ts
@@ -76,6 +76,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "RESTYPE",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/financials.ts
+++ b/src/tools/financials.ts
@@ -10,6 +10,7 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import { CommonQuerySchema } from "../schemas/common.js";
+import { buildFilterString } from "./shared/queryUtils.js";
 
 const FinancialQuerySchema = CommonQuerySchema.extend({
   sort_order: z
@@ -99,14 +100,14 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, repdte, ...params }) => {
       try {
-        const filterParts: string[] = [];
-        if (params.filters) filterParts.push(`(${params.filters})`);
-        if (cert !== undefined) filterParts.push(`CERT:${cert}`);
-        if (repdte) filterParts.push(`REPDTE:${repdte}`);
         const response = await queryEndpoint(ENDPOINTS.FINANCIALS, {
           ...params,
-          filters:
-            filterParts.length > 0 ? filterParts.join(" AND ") : undefined,
+          filters: buildFilterString({
+            cert,
+            dateField: "REPDTE",
+            dateValue: repdte,
+            rawFilters: params.filters,
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -125,6 +126,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "NETINC",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],
@@ -183,14 +185,14 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, year, ...params }) => {
       try {
-        const filterParts: string[] = [];
-        if (params.filters) filterParts.push(`(${params.filters})`);
-        if (cert !== undefined) filterParts.push(`CERT:${cert}`);
-        if (year !== undefined) filterParts.push(`YEAR:${year}`);
         const response = await queryEndpoint(ENDPOINTS.SUMMARY, {
           ...params,
-          filters:
-            filterParts.length > 0 ? filterParts.join(" AND ") : undefined,
+          filters: buildFilterString({
+            cert,
+            dateField: "YEAR",
+            dateValue: year,
+            rawFilters: params.filters,
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -209,6 +211,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "ROA",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/history.ts
+++ b/src/tools/history.ts
@@ -10,6 +10,7 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import { CommonQuerySchema } from "../schemas/common.js";
+import { buildFilterString } from "./shared/queryUtils.js";
 
 const HistoryQuerySchema = CommonQuerySchema.extend({
   cert: z
@@ -73,15 +74,13 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, ...params }) => {
       try {
-        let filters = params.filters ?? "";
-        if (cert !== undefined) {
-          filters = filters
-            ? `CERT:${cert} AND (${filters})`
-            : `CERT:${cert}`;
-        }
         const response = await queryEndpoint(ENDPOINTS.HISTORY, {
           ...params,
-          filters: filters || undefined,
+          filters: buildFilterString({
+            cert,
+            rawFilters: params.filters,
+            rawFiltersPosition: "last",
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -100,6 +99,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "PSTALP",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/institutions.ts
+++ b/src/tools/institutions.ts
@@ -80,6 +80,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "ACTIVE",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/locations.ts
+++ b/src/tools/locations.ts
@@ -10,6 +10,7 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import { CommonQuerySchema } from "../schemas/common.js";
+import { buildFilterString } from "./shared/queryUtils.js";
 
 const LocationQuerySchema = CommonQuerySchema.extend({
   cert: z
@@ -72,15 +73,13 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, ...params }) => {
       try {
-        let filters = params.filters ?? "";
-        if (cert !== undefined) {
-          filters = filters
-            ? `CERT:${cert} AND (${filters})`
-            : `CERT:${cert}`;
-        }
         const response = await queryEndpoint(ENDPOINTS.LOCATIONS, {
           ...params,
-          filters: filters || undefined,
+          filters: buildFilterString({
+            cert,
+            rawFilters: params.filters,
+            rawFiltersPosition: "last",
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -99,6 +98,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "BRNUM",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -718,6 +718,7 @@ Override precedence: cert derives defaults, then explicit params override them.`
             warnings,
           ),
           CHARACTER_LIMIT,
+          "Reduce the number of peers, narrow the peer-group criteria, request fewer fields, or shorten the analysis scope.",
         );
 
         return {

--- a/src/tools/shared/queryUtils.ts
+++ b/src/tools/shared/queryUtils.ts
@@ -6,6 +6,40 @@ export function asNumber(value: unknown): number | null {
   return typeof value === "number" ? value : null;
 }
 
+interface BuildFilterStringOptions {
+  cert?: number;
+  dateField?: string;
+  dateValue?: string | number;
+  rawFilters?: string;
+  rawFiltersPosition?: "first" | "last";
+}
+
+export function buildFilterString({
+  cert,
+  dateField,
+  dateValue,
+  rawFilters,
+  rawFiltersPosition = "first",
+}: BuildFilterStringOptions): string | undefined {
+  const filterParts: string[] = [];
+  const rawFilter = rawFilters ? `(${rawFilters})` : undefined;
+
+  if (rawFiltersPosition === "first" && rawFilter) {
+    filterParts.push(rawFilter);
+  }
+  if (cert !== undefined) {
+    filterParts.push(`CERT:${cert}`);
+  }
+  if (dateField && dateValue !== undefined) {
+    filterParts.push(`${dateField}:${dateValue}`);
+  }
+  if (rawFiltersPosition === "last" && rawFilter) {
+    filterParts.push(rawFilter);
+  }
+
+  return filterParts.length > 0 ? filterParts.join(" AND ") : undefined;
+}
+
 export function buildCertFilters(certs: number[]): string[] {
   const filters: string[] = [];
 

--- a/src/tools/sod.ts
+++ b/src/tools/sod.ts
@@ -10,6 +10,7 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import { CommonQuerySchema } from "../schemas/common.js";
+import { buildFilterString } from "./shared/queryUtils.js";
 
 const SodQuerySchema = CommonQuerySchema.extend({
   cert: z
@@ -79,14 +80,14 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     },
     async ({ cert, year, ...params }) => {
       try {
-        const filterParts: string[] = [];
-        if (params.filters) filterParts.push(`(${params.filters})`);
-        if (cert !== undefined) filterParts.push(`CERT:${cert}`);
-        if (year !== undefined) filterParts.push(`YEAR:${year}`);
         const response = await queryEndpoint(ENDPOINTS.SOD, {
           ...params,
-          filters:
-            filterParts.length > 0 ? filterParts.join(" AND ") : undefined,
+          filters: buildFilterString({
+            cert,
+            dateField: "YEAR",
+            dateValue: year,
+            rawFilters: params.filters,
+          }),
         });
         const records = extractRecords(response);
         const pagination = buildPaginationInfo(
@@ -105,6 +106,7 @@ Prefer concise human-readable summaries or tables when answering users. Structur
             "DEPSUMBR",
           ]),
           CHARACTER_LIMIT,
+          "Request fewer fields, narrow your filters, or paginate with limit/offset.",
         );
         return {
           content: [{ type: "text", text }],

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -294,6 +294,15 @@ describe("fdicClient", () => {
     expect(truncateIfNeeded("abcdef", 3)).toContain(
       "[Response truncated at 3 characters.",
     );
+    expect(truncateIfNeeded("abcdef", 3)).toContain(
+      "Request fewer fields, narrow your filters, or paginate with limit/offset.",
+    );
+  });
+
+  it("allows context-specific truncation guidance", () => {
+    expect(
+      truncateIfNeeded("abcdef", 3, "Shorten the date range or reduce the cert list."),
+    ).toContain("Shorten the date range or reduce the cert list.");
   });
 
   it("formats tool errors with MCP-compatible shape", () => {

--- a/tests/queryUtils.test.ts
+++ b/tests/queryUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFilterString } from "../src/tools/shared/queryUtils.js";
+
+describe("buildFilterString", () => {
+  it("returns undefined when no filters are provided", () => {
+    expect(buildFilterString({})).toBeUndefined();
+  });
+
+  it("builds a cert-only filter", () => {
+    expect(buildFilterString({ cert: 3511 })).toBe("CERT:3511");
+  });
+
+  it("builds a date-only filter", () => {
+    expect(
+      buildFilterString({ dateField: "REPDTE", dateValue: "20241231" }),
+    ).toBe("REPDTE:20241231");
+  });
+
+  it("builds a raw-filters-only clause", () => {
+    expect(buildFilterString({ rawFilters: 'CITY:"Austin"' })).toBe(
+      '(CITY:"Austin")',
+    );
+  });
+
+  it("builds all filter parts with raw filters first by default", () => {
+    expect(
+      buildFilterString({
+        cert: 3511,
+        dateField: "REPDTE",
+        dateValue: "20241231",
+        rawFilters: 'CITY:"Austin"',
+      }),
+    ).toBe('(CITY:"Austin") AND CERT:3511 AND REPDTE:20241231');
+  });
+
+  it("can place raw filters after cert/date clauses to preserve existing tool behavior", () => {
+    expect(
+      buildFilterString({
+        cert: 3511,
+        rawFilters: 'CITY:"Austin"',
+        rawFiltersPosition: "last",
+      }),
+    ).toBe('CERT:3511 AND (CITY:"Austin")');
+  });
+});


### PR DESCRIPTION
## Summary
- extract a shared `buildFilterString` helper for the duplicated cert/date/raw filter composition paths
- preserve existing search-tool filter ordering while removing repeated query-building code
- replace the misleading truncation hint with context-aware guidance for search and analysis responses

Closes #86
Closes #93

## Validation
- `npm run typecheck`
- `npm test -- tests/queryUtils.test.ts tests/fdicClient.test.ts tests/mcp-http.test.ts`
- `npm run build`
