### PR TITLE
Expose FDIC schema resources over MCP

### DIFF
--- a/docs/technical/specification.md
+++ b/docs/technical/specification.md
@@ -39,6 +39,15 @@ Server-side analysis tools:
 - `fdic_compare_bank_snapshots`
 - `fdic_peer_group_analysis`
 
+## Resource Surface
+
+The server also exposes MCP `resources` for endpoint field discovery:
+
+- `fdic://schemas/index` for the schema index
+- `fdic://schemas/{endpoint}` for one machine-readable field catalog per FDIC endpoint
+
+Clients and agents should use these resources to discover valid endpoint-specific `fields` and `sort_by` values before composing search requests.
+
 ## Data Contracts
 
 All tools return:

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { registerSodTools } from "./tools/sod.js";
 import { registerDemographicsTools } from "./tools/demographics.js";
 import { registerAnalysisTools } from "./tools/analysis.js";
 import { registerPeerGroupTools } from "./tools/peerGroup.js";
+import { registerSchemaResources } from "./resources/schemaResources.js";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -30,6 +31,7 @@ export function createServer(): McpServer {
   registerDemographicsTools(server);
   registerAnalysisTools(server);
   registerPeerGroupTools(server);
+  registerSchemaResources(server);
 
   return server;
 }

--- a/src/resources/schemaResources.ts
+++ b/src/resources/schemaResources.ts
@@ -1,0 +1,92 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  getEndpointMetadata,
+  listEndpointMetadata,
+} from "../services/fdicSchema.js";
+
+const RESOURCE_SCHEME = "fdic";
+const INDEX_URI = `${RESOURCE_SCHEME}://schemas/index`;
+
+function getEndpointResourceUri(endpoint: string): string {
+  return `${RESOURCE_SCHEME}://schemas/${endpoint}`;
+}
+
+export function registerSchemaResources(server: McpServer): void {
+  const endpointMetadata = listEndpointMetadata();
+
+  server.registerResource(
+    "fdic-schema-index",
+    INDEX_URI,
+    {
+      title: "FDIC Endpoint Schema Index",
+      description:
+        "Machine-readable index of endpoint field catalogs exposed by this MCP server.",
+      mimeType: "application/json",
+    },
+    async () => ({
+      contents: [
+        {
+          uri: INDEX_URI,
+          text: JSON.stringify(
+            {
+              resources: endpointMetadata.map((metadata) => ({
+                endpoint: metadata.endpoint,
+                title: metadata.title,
+                uri: getEndpointResourceUri(metadata.endpoint),
+                field_count: Object.keys(metadata.fields).length,
+                source: metadata.source,
+              })),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    }),
+  );
+
+  for (const metadata of endpointMetadata) {
+    const uri = getEndpointResourceUri(metadata.endpoint);
+
+    server.registerResource(
+      `fdic-schema-${metadata.endpoint}`,
+      uri,
+      {
+        title: `${metadata.endpoint} field catalog`,
+        description:
+          `Machine-readable FDIC field metadata for the ${metadata.endpoint} endpoint.`,
+        mimeType: "application/json",
+      },
+      async () => ({
+        contents: [
+          {
+            uri,
+            text: JSON.stringify(
+              {
+                endpoint: metadata.endpoint,
+                title: metadata.title,
+                description: metadata.description,
+                source: metadata.source,
+                sort_fields: metadata.sortFields,
+                fields: metadata.fields,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      }),
+    );
+  }
+}
+
+export function getSchemaResourceUri(endpoint: string): string {
+  if (!getEndpointMetadata(endpoint)) {
+    throw new Error(`No schema metadata found for endpoint ${endpoint}.`);
+  }
+
+  return getEndpointResourceUri(endpoint);
+}
+
+export { INDEX_URI as FDIC_SCHEMA_INDEX_URI };

--- a/src/services/fdicSchema.ts
+++ b/src/services/fdicSchema.ts
@@ -49,6 +49,13 @@ export function getEndpointMetadata(endpoint: string) {
   };
 }
 
+export function listEndpointMetadata() {
+  return Object.keys(FDIC_ENDPOINT_METADATA)
+    .sort()
+    .map((endpoint) => getEndpointMetadata(endpoint))
+    .filter((metadata): metadata is NonNullable<typeof metadata> => metadata !== undefined);
+}
+
 export function validateEndpointQueryParams(
   endpoint: string,
   params: { fields?: string; sort_by?: string },

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -113,6 +113,52 @@ describe("HTTP MCP server", () => {
     expect(peerGroupTool.inputSchema.properties.asset_min.type).toBe("number");
   });
 
+  it("lists schema resources for each supported FDIC endpoint", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 101,
+      method: "resources/list",
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.result.resources.map(
+        (resource: { uri: string }) => resource.uri,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "fdic://schemas/index",
+        "fdic://schemas/institutions",
+        "fdic://schemas/financials",
+        "fdic://schemas/summary",
+        "fdic://schemas/sod",
+        "fdic://schemas/demographics",
+      ]),
+    );
+  });
+
+  it("reads an endpoint schema resource over HTTP", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 102,
+      method: "resources/read",
+      params: {
+        uri: "fdic://schemas/financials",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const resource = response.body.result.contents[0];
+    const parsed = JSON.parse(resource.text);
+
+    expect(resource.uri).toBe("fdic://schemas/financials");
+    expect(parsed.endpoint).toBe("financials");
+    expect(parsed.fields.CERT).toBeDefined();
+    expect(parsed.fields.NETNIM).toBeDefined();
+    expect(parsed.sort_fields).toContain("CERT");
+  });
+
   it("reuses cached FDIC responses across sequential HTTP requests", async () => {
     const app = createApp();
     getMock.mockResolvedValueOnce({

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createServer } from "../src/index.js";
+
+async function connectClientAndServer() {
+  const client = new Client({
+    name: "fdic-mcp-server-test-client",
+    version: "0.0.0-test",
+  });
+  const server = createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return { client, server };
+}
+
+describe("schema resources", () => {
+  let current:
+    | {
+        client: Client;
+        server: ReturnType<typeof createServer>;
+      }
+    | undefined;
+
+  afterEach(async () => {
+    await current?.client.close();
+    await current?.server.close();
+    current = undefined;
+  });
+
+  it("lists schema resources over an in-memory MCP connection", async () => {
+    current = await connectClientAndServer();
+
+    const result = await current.client.listResources();
+    const uris = result.resources.map((resource) => resource.uri);
+
+    expect(uris).toContain("fdic://schemas/index");
+    expect(uris).toContain("fdic://schemas/history");
+    expect(uris).toContain("fdic://schemas/failures");
+  });
+
+  it("reads the schema index resource over an in-memory MCP connection", async () => {
+    current = await connectClientAndServer();
+
+    const result = await current.client.readResource({
+      uri: "fdic://schemas/index",
+    });
+    const parsed = JSON.parse(result.contents[0].text ?? "{}");
+
+    expect(parsed.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          endpoint: "institutions",
+          uri: "fdic://schemas/institutions",
+        }),
+        expect.objectContaining({
+          endpoint: "demographics",
+          uri: "fdic://schemas/demographics",
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- register MCP `resources` for the FDIC schema index plus one field catalog per supported endpoint
- expose the same endpoint metadata source of truth introduced in #94 over both HTTP and in-memory MCP clients
- document the new resource surface for clients and agents composing endpoint-aware queries

Closes #95

## Validation
- `npm run typecheck`
- `npm test -- tests/mcp-http.test.ts tests/resources.test.ts`
- `npm run build`
