### PR TITLE
Harden FDIC response limits and close remaining test gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The HTTP MCP endpoint is `http://localhost:3000/mcp`.
 
 Container builds use `PORT=8080` by default for Cloud Run compatibility.
 
+Set `FDIC_MAX_RESPONSE_BYTES` to override the upstream FDIC response-size guard. The default is `5242880` bytes (5 MiB).
+
 ### Minimal MCP Configuration
 
 ```json

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const VERSION =
 export const FDIC_API_BASE_URL = "https://banks.data.fdic.gov/api";
 
 export const CHARACTER_LIMIT = 50_000;
+export const DEFAULT_FDIC_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 
 export const ENDPOINTS = {
   INSTITUTIONS: "institutions",

--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -1,5 +1,9 @@
 import axios, { AxiosError } from "axios";
-import { FDIC_API_BASE_URL, VERSION } from "../constants.js";
+import {
+  DEFAULT_FDIC_MAX_RESPONSE_BYTES,
+  FDIC_API_BASE_URL,
+  VERSION,
+} from "../constants.js";
 import { validateEndpointQueryParams } from "./fdicSchema.js";
 
 const apiClient = axios.create({
@@ -75,6 +79,21 @@ export function clearQueryCache(): void {
 
 export function getQueryCacheSize(): number {
   return queryCache.size;
+}
+
+export function resolveFdicMaxResponseBytes(rawValue: string | undefined): number {
+  if (!rawValue) {
+    return DEFAULT_FDIC_MAX_RESPONSE_BYTES;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error(
+      `Invalid FDIC_MAX_RESPONSE_BYTES value: ${rawValue}. Expected a positive integer.`,
+    );
+  }
+
+  return parsed;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -156,6 +175,9 @@ export async function queryEndpoint(
       const response = await apiClient.get(`/${endpoint}`, {
         params: queryParams,
         signal: options.signal,
+        maxContentLength: resolveFdicMaxResponseBytes(
+          process.env.FDIC_MAX_RESPONSE_BYTES,
+        ),
       });
       return validateFdicResponseShape(endpoint, response.data);
     } catch (err) {
@@ -174,6 +196,11 @@ export async function queryEndpoint(
         const status = err.response?.status;
         const detail =
           (err.response?.data as { message?: string })?.message ?? err.message;
+        if (err.message.includes("maxContentLength size of")) {
+          throw new Error(
+            "FDIC API response exceeded the configured response-size limit before parsing. Narrow your filters, request fewer fields, or lower the result size and try again.",
+          );
+        }
         if (status === 400) {
           throw new Error(
             `Bad request to FDIC API: ${detail}. Check your filter syntax (use ElasticSearch query string syntax, e.g. STNAME:"California" AND ACTIVE:1).`,

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -34,6 +34,7 @@ import {
   formatToolError,
   getQueryCacheSize,
   queryEndpoint,
+  resolveFdicMaxResponseBytes,
   truncateIfNeeded,
   validateFdicResponseShape,
 } from "../src/services/fdicClient.js";
@@ -60,6 +61,16 @@ describe("fdicClient", () => {
     );
   });
 
+  it("uses the default FDIC response-size limit when no env override is set", () => {
+    expect(resolveFdicMaxResponseBytes(undefined)).toBe(5 * 1024 * 1024);
+  });
+
+  it("rejects invalid FDIC_MAX_RESPONSE_BYTES values", () => {
+    expect(() => resolveFdicMaxResponseBytes("0")).toThrow(
+      "Invalid FDIC_MAX_RESPONSE_BYTES value: 0. Expected a positive integer.",
+    );
+  });
+
   it("passes default query parameters through to the FDIC API", async () => {
     getMock.mockResolvedValueOnce({
       data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
@@ -67,13 +78,16 @@ describe("fdicClient", () => {
 
     const response = await queryEndpoint("institutions", {});
 
-    expect(getMock).toHaveBeenCalledWith("/institutions", {
-      params: {
-        limit: 20,
-        offset: 0,
-        output: "json",
-      },
-    });
+    expect(getMock).toHaveBeenCalledWith(
+      "/institutions",
+      expect.objectContaining({
+        params: {
+          limit: 20,
+          offset: 0,
+          output: "json",
+        },
+      }),
+    );
     expect(response.meta.total).toBe(1);
   });
 
@@ -111,17 +125,20 @@ describe("fdicClient", () => {
       sort_order: "DESC",
     });
 
-    expect(getMock).toHaveBeenCalledWith("/financials", {
-      params: {
-        filters: "CERT:3511",
-        fields: "CERT,REPDTE",
-        limit: 5,
-        offset: 10,
-        output: "json",
-        sort_by: "REPDTE",
-        sort_order: "DESC",
-      },
-    });
+    expect(getMock).toHaveBeenCalledWith(
+      "/financials",
+      expect.objectContaining({
+        params: {
+          filters: "CERT:3511",
+          fields: "CERT,REPDTE",
+          limit: 5,
+          offset: 10,
+          output: "json",
+          sort_by: "REPDTE",
+          sort_order: "DESC",
+        },
+      }),
+    );
   });
 
   it("rejects invalid fields locally before calling the FDIC API", async () => {
@@ -241,6 +258,16 @@ describe("fdicClient", () => {
 
     await expect(queryEndpoint("institutions", {})).rejects.toThrow(
       'Bad request to FDIC API: Invalid query string. Check your filter syntax (use ElasticSearch query string syntax, e.g. STNAME:"California" AND ACTIVE:1).',
+    );
+  });
+
+  it("maps oversized upstream responses to a clear narrowing error", async () => {
+    getMock.mockRejectedValueOnce(
+      new AxiosError("maxContentLength size of 5242880 exceeded"),
+    );
+
+    await expect(queryEndpoint("institutions", {})).rejects.toThrow(
+      "FDIC API response exceeded the configured response-size limit before parsing. Narrow your filters, request fewer fields, or lower the result size and try again.",
     );
   });
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -227,15 +227,18 @@ describe("HTTP MCP server", () => {
       has_more: false,
       institutions: [{ CERT: 3511, NAME: "Wells Fargo" }],
     });
-    expect(getMock).toHaveBeenCalledWith("/institutions", {
-      params: {
-        filters: "CERT:3511",
-        limit: 1,
-        offset: 0,
-        output: "json",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenCalledWith(
+      "/institutions",
+      expect.objectContaining({
+        params: {
+          filters: "CERT:3511",
+          limit: 1,
+          offset: 0,
+          output: "json",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("returns structured not-found payloads for single-record tools", async () => {
@@ -261,6 +264,46 @@ describe("HTTP MCP server", () => {
     });
   });
 
+  it("returns structured lookup details for a single institution", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            data: {
+              CERT: 3511,
+              NAME: "Wells Fargo Bank, National Association",
+              CITY: "Sioux Falls",
+              STALP: "SD",
+              ASSET: 1000000,
+              ACTIVE: 1,
+            },
+          },
+        ],
+        meta: { total: 1 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 41,
+      method: "tools/call",
+      params: {
+        name: "fdic_get_institution",
+        arguments: { cert: 3511, fields: "CERT,NAME,CITY,STALP,ASSET,ACTIVE" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent).toEqual({
+      CERT: 3511,
+      NAME: "Wells Fargo Bank, National Association",
+      CITY: "Sioux Falls",
+      STALP: "SD",
+      ASSET: 1000000,
+      ACTIVE: 1,
+    });
+  });
+
   it("builds combined filters for location lookups with cert and user filters", async () => {
     getMock.mockResolvedValueOnce({
       data: { data: [], meta: { total: 0 } },
@@ -276,14 +319,65 @@ describe("HTTP MCP server", () => {
       },
     });
 
-    expect(getMock).toHaveBeenLastCalledWith("/locations", {
-      params: {
-        filters: 'CERT:3511 AND (CITY:"Austin")',
-        limit: 20,
-        offset: 0,
-        output: "json",
-        sort_order: "ASC",
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/locations",
+      expect.objectContaining({
+        params: {
+          filters: 'CERT:3511 AND (CITY:"Austin")',
+          limit: 20,
+          offset: 0,
+          output: "json",
+          sort_order: "ASC",
+        },
+      }),
+    );
+  });
+
+  it("returns structured location search results", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            data: {
+              CERT: 3511,
+              UNINAME: "Wells Fargo Bank, National Association",
+              NAMEFULL: "Downtown Branch",
+              CITY: "Austin",
+              STALP: "TX",
+              BRNUM: 12,
+            },
+          },
+        ],
+        meta: { total: 1 },
       },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 51,
+      method: "tools/call",
+      params: {
+        name: "fdic_search_locations",
+        arguments: { filters: 'CITY:"Austin"', limit: 1 },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent).toEqual({
+      total: 1,
+      offset: 0,
+      count: 1,
+      has_more: false,
+      locations: [
+        {
+          CERT: 3511,
+          UNINAME: "Wells Fargo Bank, National Association",
+          NAMEFULL: "Downtown Branch",
+          CITY: "Austin",
+          STALP: "TX",
+          BRNUM: 12,
+        },
+      ],
     });
   });
 
@@ -310,18 +404,25 @@ describe("HTTP MCP server", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(getMock).toHaveBeenLastCalledWith("/financials", {
-      params: {
-        fields: "CERT,REPDTE",
-        filters: "CERT:3511 AND REPDTE:20251231",
-        limit: 20,
-        offset: 0,
-        output: "json",
-        sort_order: "DESC",
-      },
+    expect(response.body.result.structuredContent).toEqual({
+      total: 1,
+      offset: 0,
+      count: 1,
+      has_more: false,
+      financials: [{ CERT: 3511, REPDTE: "20251231" }],
     });
-    expect(response.body.result.structuredContent.financials[0].REPDTE).toBe(
-      "20251231",
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/financials",
+      expect.objectContaining({
+        params: {
+          fields: "CERT,REPDTE",
+          filters: "CERT:3511 AND REPDTE:20251231",
+          limit: 20,
+          offset: 0,
+          output: "json",
+          sort_order: "DESC",
+        },
+      }),
     );
   });
 
@@ -377,16 +478,19 @@ describe("HTTP MCP server", () => {
         },
       ],
     });
-    expect(getMock).toHaveBeenLastCalledWith("/failures", {
-      params: {
-        filters: "STALP:CA",
-        limit: 1,
-        offset: 0,
-        output: "json",
-        sort_by: "FAILDATE",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/failures",
+      expect.objectContaining({
+        params: {
+          filters: "STALP:CA",
+          limit: 1,
+          offset: 0,
+          output: "json",
+          sort_by: "FAILDATE",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("returns failure lookup details for a certificate number", async () => {
@@ -492,16 +596,19 @@ describe("HTTP MCP server", () => {
         },
       ],
     });
-    expect(getMock).toHaveBeenLastCalledWith("/history", {
-      params: {
-        filters: "CERT:3511 AND (TYPE:merger)",
-        limit: 20,
-        offset: 0,
-        output: "json",
-        sort_by: "PROCDATE",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/history",
+      expect.objectContaining({
+        params: {
+          filters: "CERT:3511 AND (TYPE:merger)",
+          limit: 20,
+          offset: 0,
+          output: "json",
+          sort_by: "PROCDATE",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("composes SOD filters from cert, year, and caller filters", async () => {
@@ -555,16 +662,19 @@ describe("HTTP MCP server", () => {
         },
       ],
     });
-    expect(getMock).toHaveBeenLastCalledWith("/sod", {
-      params: {
-        filters: '(CITYBR:"Austin") AND CERT:3511 AND YEAR:2022',
-        limit: 20,
-        offset: 0,
-        output: "json",
-        sort_by: "DEPSUMBR",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/sod",
+      expect.objectContaining({
+        params: {
+          filters: '(CITYBR:"Austin") AND CERT:3511 AND YEAR:2022',
+          limit: 20,
+          offset: 0,
+          output: "json",
+          sort_by: "DEPSUMBR",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("composes annual summary filters and returns summary records", async () => {
@@ -618,16 +728,19 @@ describe("HTTP MCP server", () => {
         },
       ],
     });
-    expect(getMock).toHaveBeenLastCalledWith("/summary", {
-      params: {
-        filters: "(ASSET:[500000 TO *]) AND CERT:3511 AND YEAR:2023",
-        limit: 20,
-        offset: 0,
-        output: "json",
-        sort_by: "YEAR",
-        sort_order: "ASC",
-      },
-    });
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/summary",
+      expect.objectContaining({
+        params: {
+          filters: "(ASSET:[500000 TO *]) AND CERT:3511 AND YEAR:2023",
+          limit: 20,
+          offset: 0,
+          output: "json",
+          sort_by: "YEAR",
+          sort_order: "ASC",
+        },
+      }),
+    );
   });
 
   it("returns MCP error payloads when the FDIC client throws", async () => {
@@ -648,6 +761,175 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toBe(
       "Error: Unexpected error calling FDIC API: Error: backend unavailable",
     );
+  });
+
+  it("returns structured demographics search results for combined filters", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            data: {
+              CERT: 3511,
+              REPDTE: "20241231",
+              OFFTOT: 12,
+              OFFSTATE: 3,
+              METRO: 1,
+              CBSANAME: "Austin-Round Rock-Georgetown, TX",
+            },
+          },
+        ],
+        meta: { total: 1 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 71,
+      method: "tools/call",
+      params: {
+        name: "fdic_search_demographics",
+        arguments: {
+          cert: 3511,
+          repdte: "20241231",
+          filters: "METRO:1",
+          limit: 1,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent).toEqual({
+      total: 1,
+      offset: 0,
+      count: 1,
+      has_more: false,
+      demographics: [
+        {
+          CERT: 3511,
+          REPDTE: "20241231",
+          OFFTOT: 12,
+          OFFSTATE: 3,
+          METRO: 1,
+          CBSANAME: "Austin-Round Rock-Georgetown, TX",
+        },
+      ],
+    });
+    expect(getMock).toHaveBeenLastCalledWith(
+      "/demographics",
+      expect.objectContaining({
+        params: {
+          filters: "(METRO:1) AND CERT:3511 AND REPDTE:20241231",
+          limit: 1,
+          offset: 0,
+          output: "json",
+          sort_order: "ASC",
+        },
+      }),
+    );
+  });
+
+  it("returns empty demographics results with the expected structured shape", async () => {
+    getMock.mockResolvedValueOnce({
+      data: { data: [], meta: { total: 0 } },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 72,
+      method: "tools/call",
+      params: {
+        name: "fdic_search_demographics",
+        arguments: { cert: 3511 },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent).toEqual({
+      total: 0,
+      offset: 0,
+      count: 0,
+      has_more: false,
+      demographics: [],
+    });
+  });
+
+  it("passes unusual filter strings through all search tools", async () => {
+    const cases = [
+      {
+        name: "fdic_search_institutions",
+        endpoint: "/institutions",
+        filters: `NAME:"O'FALLON"`,
+        expectedFilters: `NAME:"O'FALLON"`,
+      },
+      {
+        name: "fdic_search_failures",
+        endpoint: "/failures",
+        filters: `NAME:"FIRST STATE BANK - ST. CHARLES"`,
+        expectedFilters: `NAME:"FIRST STATE BANK - ST. CHARLES"`,
+      },
+      {
+        name: "fdic_search_locations",
+        endpoint: "/locations",
+        filters: `CITY:"ST. JOHN'S"`,
+        expectedFilters: `(CITY:"ST. JOHN'S")`,
+      },
+      {
+        name: "fdic_search_history",
+        endpoint: "/history",
+        filters: `INSTNAME:"BANK & TRUST"`,
+        expectedFilters: `(INSTNAME:"BANK & TRUST")`,
+      },
+      {
+        name: "fdic_search_financials",
+        endpoint: "/financials",
+        filters: `NAME:"BANK OF THE WEST"`,
+        expectedFilters: `(NAME:"BANK OF THE WEST")`,
+      },
+      {
+        name: "fdic_search_summary",
+        endpoint: "/summary",
+        filters: `NAME:"BANK OF THE WEST"`,
+        expectedFilters: `(NAME:"BANK OF THE WEST")`,
+      },
+      {
+        name: "fdic_search_sod",
+        endpoint: "/sod",
+        filters: `NAMEFULL:"MAIN/OFFICE"`,
+        expectedFilters: `(NAMEFULL:"MAIN/OFFICE")`,
+      },
+      {
+        name: "fdic_search_demographics",
+        endpoint: "/demographics",
+        filters: `CBSANAME:"ST. LOUIS, MO-IL"`,
+        expectedFilters: `(CBSANAME:"ST. LOUIS, MO-IL")`,
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      getMock.mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      });
+
+      const response = await mcpPost({
+        jsonrpc: "2.0",
+        id: 80,
+        method: "tools/call",
+        params: {
+          name: testCase.name,
+          arguments: { filters: testCase.filters },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(getMock).toHaveBeenLastCalledWith(
+        testCase.endpoint,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            filters: testCase.expectedFilters,
+          }),
+        }),
+      );
+    }
   });
 
   it("rejects snapshot analysis requests without state or certs", async () => {
@@ -1079,6 +1361,64 @@ describe("HTTP MCP server", () => {
         (comparison: { cert: number }) => comparison.cert,
       ),
     ).toEqual([1111, 2222]);
+  });
+
+  it("handles partial snapshot data by analyzing only institutions with both dates present", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Complete Bank", CITY: "Raleigh", STALP: "NC" } },
+            { data: { CERT: 2222, NAME: "Missing End Bank", CITY: "Durham", STALP: "NC" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Complete Bank", ASSET: 100, DEP: 50, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+            { data: { CERT: 2222, NAME: "Missing End Bank", ASSET: 200, DEP: 80, NETINC: 12, ROA: 1.2, ROE: 8.5 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Complete Bank", ASSET: 140, DEP: 90, NETINC: 14, ROA: 1.1, ROE: 8.2 } },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 804,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          limit: 2,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.total_candidates).toBe(2);
+    expect(response.body.result.structuredContent.analyzed_count).toBe(1);
+    expect(response.body.result.structuredContent.comparisons).toEqual([
+      expect.objectContaining({ cert: 1111, name: "Complete Bank" }),
+    ]);
   });
 
   it("includes all generated insight categories in the top-level summary", async () => {


### PR DESCRIPTION
## Summary
- enforce an upstream FDIC response-size guard with a configurable `FDIC_MAX_RESPONSE_BYTES` limit and a clearer user-facing error
- add the remaining high-value search and lookup coverage, including a dedicated demographics suite, stronger structured-content assertions, unusual-filter regressions across all search tools, and partial-data analysis coverage
- document the new response-size configuration default in the README

Closes #96
Closes #91

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
