### PR TITLE
fix: harden analysis date parsing and empty envelopes

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -170,6 +170,13 @@ function compareComparisonTieBreakers(
 }
 
 export function yearsBetween(startRepdte: string, endRepdte: string): number {
+  const start = parseRepdteDate(startRepdte);
+  const end = parseRepdteDate(endRepdte);
+
+  if (!start || !end) {
+    return 0;
+  }
+
   const startQuarterIndex = getQuarterIndex(startRepdte);
   const endQuarterIndex = getQuarterIndex(endRepdte);
 
@@ -177,21 +184,54 @@ export function yearsBetween(startRepdte: string, endRepdte: string): number {
     return Math.max((endQuarterIndex - startQuarterIndex) / 4, 0);
   }
 
-  const start = new Date(
-    `${startRepdte.slice(0, 4)}-${startRepdte.slice(4, 6)}-${startRepdte.slice(6, 8)}T00:00:00Z`,
-  );
-  const end = new Date(
-    `${endRepdte.slice(0, 4)}-${endRepdte.slice(4, 6)}-${endRepdte.slice(6, 8)}T00:00:00Z`,
-  );
-
   return Math.max(
     (end.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000),
     0,
   );
 }
 
-function cagr(start: number | null, end: number | null, years: number): number | null {
-  if (start === null || end === null || start <= 0 || end <= 0 || years <= 0) {
+function parseRepdteDate(repdte: string): Date | null {
+  const year = Number.parseInt(repdte.slice(0, 4), 10);
+  const month = Number.parseInt(repdte.slice(4, 6), 10);
+  const day = Number.parseInt(repdte.slice(6, 8), 10);
+
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day)
+  ) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+export function cagr(
+  start: number | null,
+  end: number | null,
+  years: number,
+): number | null {
+  if (
+    start === null ||
+    end === null ||
+    start <= 0 ||
+    end <= 0 ||
+    !Number.isFinite(years) ||
+    years <= 0
+  ) {
     return null;
   }
   return (Math.pow(end / start, 1 / years) - 1) * 100;
@@ -552,6 +592,37 @@ function formatComparisonText(output: {
   return insights ? `${header}\n${rows.join("\n")}\nInsights\n${insights}` : `${header}\n${rows.join("\n")}`;
 }
 
+function buildAnalysisOutput(params: {
+  totalCandidates: number;
+  analyzedCount: number;
+  startRepdte: string;
+  endRepdte: string;
+  analysisMode: "snapshot" | "timeseries";
+  sortBy: z.infer<typeof SortFieldSchema>;
+  sortOrder: "ASC" | "DESC";
+  warnings: string[];
+  comparisons: ComparisonRecord[];
+  offset?: number;
+  limitCount?: number;
+}) {
+  const offset = params.offset ?? 0;
+  const count = params.limitCount ?? params.comparisons.length;
+
+  return {
+    total_candidates: params.totalCandidates,
+    analyzed_count: params.analyzedCount,
+    start_repdte: params.startRepdte,
+    end_repdte: params.endRepdte,
+    analysis_mode: params.analysisMode,
+    sort_by: params.sortBy,
+    sort_order: params.sortOrder,
+    warnings: params.warnings,
+    insights: buildTopLevelInsights(params.comparisons),
+    ...buildPaginationInfo(params.analyzedCount, offset, count),
+    comparisons: params.comparisons,
+  };
+}
+
 async function fetchInstitutionRoster(
   state: string | undefined,
   institutionFilters: string | undefined,
@@ -855,22 +926,25 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
                 controller.signal,
               );
         const roster = rosterResult.records;
+        const warnings = rosterResult.warning ? [rosterResult.warning] : [];
 
         const candidateCerts = roster
           .map((record) => asNumber(record.CERT))
           .filter((cert): cert is number => cert !== null);
 
         if (candidateCerts.length === 0) {
-          const output = {
-            total_candidates: 0,
-            analyzed_count: 0,
-            start_repdte,
-            end_repdte,
-            analysis_mode,
-            sort_by,
-            sort_order,
+          const output = buildAnalysisOutput({
+            totalCandidates: 0,
+            analyzedCount: 0,
+            startRepdte: start_repdte,
+            endRepdte: end_repdte,
+            analysisMode: analysis_mode,
+            sortBy: sort_by,
+            sortOrder: sort_order,
+            warnings,
             comparisons: [],
-          };
+            limitCount: 0,
+          });
 
           return {
             content: [
@@ -890,7 +964,6 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
         );
 
         let comparisons: ComparisonRecord[] = [];
-        const warnings = rosterResult.warning ? [rosterResult.warning] : [];
 
         if (analysis_mode === "timeseries") {
           const [financialSeriesResult, demographicsSeriesResult] = await Promise.all([
@@ -1004,20 +1077,18 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
           sort_order,
         );
         const ranked = sortedComparisons.slice(0, limit);
-        const pagination = buildPaginationInfo(comparisons.length, 0, ranked.length);
-        const output = {
-          total_candidates: candidateCerts.length,
-          analyzed_count: comparisons.length,
-          start_repdte,
-          end_repdte,
-          analysis_mode,
-          sort_by,
-          sort_order,
+        const output = buildAnalysisOutput({
+          totalCandidates: candidateCerts.length,
+          analyzedCount: comparisons.length,
+          startRepdte: start_repdte,
+          endRepdte: end_repdte,
+          analysisMode: analysis_mode,
+          sortBy: sort_by,
+          sortOrder: sort_order,
           warnings,
-          insights: buildTopLevelInsights(sortedComparisons),
-          ...pagination,
           comparisons: ranked,
-        };
+          limitCount: ranked.length,
+        });
 
         const text = truncateIfNeeded(
           [

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -492,3 +492,32 @@ Reference: issue #105.
 - [x] Replaced the manual tag-triggered publish workflow with an automated release workflow that runs after successful CI on the latest `main` commit.
 - [x] Added commit-message linting in CI so semantic versioning stays reliable under the current merge workflow.
 - [x] Removed the one-off backfill workflow and updated contributor and deployment docs to describe the automated release process.
+
+# Analysis Bug Batch: Issues #103 And #104
+
+Reference: issues #103 and #104.
+
+## Goals
+
+- [x] Fix invalid `REPDTE` handling in the analysis date-span helpers so impossible calendar dates cannot leak `NaN` into `asset_cagr` or related structured output.
+- [x] Make `fdic_compare_bank_snapshots` return one stable `structuredContent` shape for both empty and populated comparison sets.
+- [x] Add targeted regression coverage for both bugs in the analysis helper tests and MCP HTTP contract tests.
+- [x] Execute the work on a dedicated branch from fresh `main`. Branch: `fix/analysis-batch-103-104`.
+
+## Acceptance Criteria
+
+- [x] `yearsBetween()` returns `0` when either fallback parsed date is invalid, including impossible month/day combinations.
+- [x] `cagr()` returns `null` when `years` is non-finite, so `asset_cagr` never becomes `NaN`.
+- [x] The empty-result path for `fdic_compare_bank_snapshots` includes the same top-level keys as the success path: `warnings`, `insights`, `total`, `offset`, `count`, `has_more`, and `comparisons`.
+- [x] Roster-level warnings remain visible even when the analyzed set is empty.
+- [x] Regression tests cover invalid-date helper inputs and the empty-analysis `structuredContent` contract.
+- [x] Validation passes with `npm run typecheck`, `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`, and `npm run build`.
+
+## Review / Results
+
+- [x] Created a dedicated worktree and branch from `main` to keep this bug batch isolated from unrelated local publish work.
+- [x] Replaced permissive `Date` fallback parsing in [analysis.ts](/Users/jlamb/Projects/bankfind-mcp-analysis-103-104/src/tools/analysis.ts) with strict UTC round-trip validation so values such as `20240230` are rejected instead of normalized.
+- [x] Tightened `cagr()` in [analysis.ts](/Users/jlamb/Projects/bankfind-mcp-analysis-103-104/src/tools/analysis.ts) to return `null` for non-finite year spans.
+- [x] Centralized the analysis output envelope in [analysis.ts](/Users/jlamb/Projects/bankfind-mcp-analysis-103-104/src/tools/analysis.ts) so empty and populated responses share the same `structuredContent` shape.
+- [x] Added regression coverage in [analysis.test.ts](/Users/jlamb/Projects/bankfind-mcp-analysis-103-104/tests/analysis.test.ts) and [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp-analysis-103-104/tests/mcp-http.test.ts) for invalid dates, non-finite CAGR inputs, empty envelopes, and preserved warnings on empty analyzed results.
+- [x] Verified `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.

--- a/tests/analysis.test.ts
+++ b/tests/analysis.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  cagr,
   getQuarterIndex,
   maxOrNull,
   yearsBetween,
@@ -41,6 +42,20 @@ describe("yearsBetween", () => {
 
   it("clamps reversed ranges to zero", () => {
     expect(yearsBetween("20250630", "20211231")).toBe(0);
+  });
+
+  it("returns zero for impossible calendar dates on the fallback path", () => {
+    expect(yearsBetween("20241301", "20250331")).toBe(0);
+    expect(yearsBetween("20240015", "20250331")).toBe(0);
+    expect(yearsBetween("20240230", "20250331")).toBe(0);
+    expect(yearsBetween("20240229", "20250331")).toBe(1);
+  });
+});
+
+describe("cagr", () => {
+  it("returns null for non-finite year spans", () => {
+    expect(cagr(100, 120, Number.NaN)).toBeNull();
+    expect(cagr(100, 120, Number.POSITIVE_INFINITY)).toBeNull();
   });
 });
 

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -995,6 +995,77 @@ describe("HTTP MCP server", () => {
     );
   });
 
+  it("returns a stable empty structuredContent envelope when no institutions match", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [],
+        meta: { total: 0 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 803,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          limit: 2,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.content[0].text).toBe(
+      "No institutions matched the comparison set.",
+    );
+
+    const sc = response.body.result.structuredContent;
+    expect(Object.keys(sc).sort()).toEqual([
+      "analysis_mode",
+      "analyzed_count",
+      "comparisons",
+      "count",
+      "end_repdte",
+      "has_more",
+      "insights",
+      "offset",
+      "sort_by",
+      "sort_order",
+      "start_repdte",
+      "total",
+      "total_candidates",
+      "warnings",
+    ]);
+    expect(sc).toMatchObject({
+      total_candidates: 0,
+      analyzed_count: 0,
+      start_repdte: "20211231",
+      end_repdte: "20250630",
+      analysis_mode: "snapshot",
+      sort_by: "asset_growth",
+      sort_order: "DESC",
+      total: 0,
+      offset: 0,
+      count: 0,
+      has_more: false,
+      warnings: [],
+      comparisons: [],
+      insights: {
+        growth_with_better_profitability: [],
+        growth_with_branch_expansion: [],
+        balance_sheet_growth_without_profitability: [],
+        growth_with_branch_consolidation: [],
+        deposit_mix_softening: [],
+        sustained_asset_growth: [],
+        multi_quarter_roa_decline: [],
+      },
+    });
+  });
+
   it("batches snapshot comparisons into financial and demographic date queries", async () => {
     getMock
       .mockResolvedValueOnce({
@@ -1507,6 +1578,65 @@ describe("HTTP MCP server", () => {
     expect(response.body.result.content[0].text).toContain(
       "Warning: Institution roster truncated to 10,000 records out of 10,500 matched institutions.",
     );
+  });
+
+  it("preserves roster warnings when candidates exist but no comparisons can be built", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ data: { CERT: 3510, NAME: "Bank A", CITY: "Charlotte", STALP: "NC" } }],
+          meta: { total: 10001 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [],
+          meta: { total: 0 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [],
+          meta: { total: 0 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 1201,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          include_demographics: false,
+          limit: 2,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const sc = response.body.result.structuredContent;
+    expect(sc.total_candidates).toBe(1);
+    expect(sc.analyzed_count).toBe(0);
+    expect(sc.total).toBe(0);
+    expect(sc.count).toBe(0);
+    expect(sc.has_more).toBe(false);
+    expect(sc.comparisons).toEqual([]);
+    expect(sc.warnings).toEqual([
+      "Institution roster truncated to 1 records out of 10,001 matched institutions. Narrow the comparison set with institution_filters or certs for complete analysis.",
+    ]);
+    expect(sc.insights).toMatchObject({
+      growth_with_better_profitability: [],
+      growth_with_branch_expansion: [],
+      balance_sheet_growth_without_profitability: [],
+      growth_with_branch_consolidation: [],
+      deposit_mix_softening: [],
+      sustained_asset_growth: [],
+      multi_quarter_roa_decline: [],
+    });
   });
 
   it("warns when a snapshot analysis financial batch is truncated by the FDIC API limit", async () => {


### PR DESCRIPTION
## Summary
- fix `yearsBetween()` so impossible `REPDTE` values return `0` instead of leaking invalid spans into CAGR calculations
- make `cagr()` return `null` for non-finite year spans
- normalize `fdic_compare_bank_snapshots` so empty and populated responses share the same `structuredContent` envelope
- add regression tests for invalid dates, empty envelopes, and warning preservation

## Issues
- Closes #103
- Closes #104

## Validation
- `npm test -- tests/analysis.test.ts tests/mcp-http.test.ts`
- `npm run typecheck`
- `npm run build`
