### PR TITLE
Add MCP progress notifications for analysis tools

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -16,6 +16,7 @@ import {
   buildCertFilters,
   mapWithConcurrency,
 } from "./shared/queryUtils.js";
+import { sendProgressNotification } from "./shared/progress.js";
 
 type InstitutionRecord = Record<string, unknown>;
 type ComparisonRecord = Record<string, unknown>;
@@ -879,21 +880,25 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
         openWorldHint: true,
       },
     },
-    async ({
-      state,
-      certs,
-      institution_filters,
-      active_only,
-      start_repdte,
-      end_repdte,
-      analysis_mode,
-      include_demographics,
-      limit,
-      sort_by,
-      sort_order,
-    }) => {
+    async (
+      {
+        state,
+        certs,
+        institution_filters,
+        active_only,
+        start_repdte,
+        end_repdte,
+        analysis_mode,
+        include_demographics,
+        limit,
+        sort_by,
+        sort_order,
+      },
+      extra,
+    ) => {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
+      const progressToken = extra._meta?.progressToken;
 
       try {
         const validationError = validateSnapshotAnalysisParams({
@@ -912,6 +917,13 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
         if (validationError) {
           return formatToolError(new Error(validationError));
         }
+
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          0.1,
+          "Fetching institution roster",
+        );
 
         const rosterResult =
           certs && certs.length > 0
@@ -966,6 +978,13 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
         let comparisons: ComparisonRecord[] = [];
 
         if (analysis_mode === "timeseries") {
+          await sendProgressNotification(
+            server.server,
+            progressToken,
+            0.3,
+            "Fetching financial time series",
+          );
+
           const [financialSeriesResult, demographicsSeriesResult] = await Promise.all([
             fetchSeriesRecords(
               ENDPOINTS.FINANCIALS,
@@ -993,6 +1012,23 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             ...financialSeriesResult.warnings,
             ...demographicsSeriesResult.warnings,
           );
+
+          if (include_demographics) {
+            await sendProgressNotification(
+              server.server,
+              progressToken,
+              0.7,
+              "Fetching demographics time series",
+            );
+          }
+
+          await sendProgressNotification(
+            server.server,
+            progressToken,
+            0.9,
+            "Computing metrics and insights",
+          );
+
           const financialSeries = financialSeriesResult.grouped;
           const demographicsSeries = demographicsSeriesResult.grouped;
 
@@ -1011,6 +1047,13 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             )
             .filter((comparison): comparison is ComparisonRecord => comparison !== null);
         } else {
+          await sendProgressNotification(
+            server.server,
+            progressToken,
+            0.3,
+            "Fetching financial snapshots",
+          );
+
           const [financialSnapshotsResult, demographicSnapshotsResult] = await Promise.all([
             fetchBatchedRecordsForDates(
               ENDPOINTS.FINANCIALS,
@@ -1036,6 +1079,23 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             ...financialSnapshotsResult.warnings,
             ...demographicSnapshotsResult.warnings,
           );
+
+          if (include_demographics) {
+            await sendProgressNotification(
+              server.server,
+              progressToken,
+              0.7,
+              "Fetching demographic snapshots",
+            );
+          }
+
+          await sendProgressNotification(
+            server.server,
+            progressToken,
+            0.9,
+            "Computing metrics and insights",
+          );
+
           const financialSnapshots = financialSnapshotsResult.byDate;
           const demographicSnapshots = demographicSnapshotsResult.byDate;
 
@@ -1099,6 +1159,13 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             .join("\n\n"),
           CHARACTER_LIMIT,
           "Reduce the number of certs, narrow institution_filters, request fewer fields, or shorten the date range.",
+        );
+
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          1,
+          "Analysis complete",
         );
 
         return {

--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -20,6 +20,7 @@ import {
   buildCertFilters,
   mapWithConcurrency,
 } from "./shared/queryUtils.js";
+import { sendProgressNotification } from "./shared/progress.js";
 
 export interface RankResult {
   rank: number;
@@ -375,15 +376,23 @@ Override precedence: cert derives defaults, then explicit params override them.`
         openWorldHint: true,
       },
     },
-    async (params) => {
+    async (params, extra) => {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), ANALYSIS_TIMEOUT_MS);
+      const progressToken = extra._meta?.progressToken;
 
       try {
         const validationError = validatePeerGroupParams(params);
         if (validationError) {
           return formatToolError(new Error(validationError));
         }
+
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          0.1,
+          "Resolving subject and peer criteria",
+        );
 
         const warnings: string[] = [];
         let subjectProfile: Record<string, unknown> | null = null;
@@ -454,6 +463,13 @@ Override precedence: cert derives defaults, then explicit params override them.`
         const { state, active_only, raw_filter } = params;
 
         // --- Phase 2: Build peer roster ---
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          0.4,
+          "Fetching peer roster",
+        );
+
         const filterParts: string[] = [];
         if (assetMin !== undefined || assetMax !== undefined) {
           const min = assetMin ?? 0;
@@ -563,6 +579,13 @@ Override precedence: cert derives defaults, then explicit params override them.`
           .map((r) => asNumber(r.CERT))
           .filter((c): c is number => c !== null);
 
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          0.7,
+          "Fetching peer financials",
+        );
+
         const certFilters = buildCertFilters(peerCerts);
         const extraFieldsCsv =
           params.extra_fields && params.extra_fields.length > 0
@@ -640,6 +663,13 @@ Override precedence: cert derives defaults, then explicit params override them.`
         const peerCount = peers.length;
 
         // --- Phase 4: Rank and assemble ---
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          0.9,
+          "Computing peer rankings",
+        );
+
         const subjectMetrics = subjectFinancials
           ? deriveMetrics(subjectFinancials)
           : null;
@@ -719,6 +749,13 @@ Override precedence: cert derives defaults, then explicit params override them.`
           ),
           CHARACTER_LIMIT,
           "Reduce the number of peers, narrow the peer-group criteria, request fewer fields, or shorten the analysis scope.",
+        );
+
+        await sendProgressNotification(
+          server.server,
+          progressToken,
+          1,
+          "Analysis complete",
         );
 
         return {

--- a/src/tools/shared/progress.ts
+++ b/src/tools/shared/progress.ts
@@ -1,0 +1,43 @@
+export interface ProgressNotificationSender {
+  notification: (notification: {
+    method: "notifications/progress";
+    params: {
+      progressToken: string | number;
+      progress: number;
+      total: number;
+      message: string;
+    };
+  }) => Promise<void>;
+}
+
+export function asProgressToken(
+  value: unknown,
+): string | number | undefined {
+  if (typeof value === "string" || typeof value === "number") {
+    return value;
+  }
+
+  return undefined;
+}
+
+export async function sendProgressNotification(
+  sender: ProgressNotificationSender,
+  progressToken: unknown,
+  progress: number,
+  message: string,
+): Promise<void> {
+  const token = asProgressToken(progressToken);
+  if (token === undefined) {
+    return;
+  }
+
+  await sender.notification({
+    method: "notifications/progress",
+    params: {
+      progressToken: token,
+      progress,
+      total: 1,
+      message,
+    },
+  });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -531,6 +531,7 @@ Reference: umbrella issue #115 and issues #109, #110, #111, #112, #113, and #114
 - [x] Make the HTTP transport session-aware so MCP lifecycle state persists across requests.
 - [x] Implement compliant `GET /mcp` and `DELETE /mcp` behavior for initialized sessions.
 - [x] Default local HTTP binding to localhost and enforce Origin validation with a configurable allowlist.
+- [x] Add progress notifications for the long-running analysis tools without changing tool result contracts.
 - [x] Update user-facing docs for the new HTTP defaults and environment knobs.
 
 ## Acceptance Criteria
@@ -540,6 +541,7 @@ Reference: umbrella issue #115 and issues #109, #110, #111, #112, #113, and #114
 - [x] Unsupported `MCP-Protocol-Version` headers are rejected and missing headers after initialization still use the SDK default behavior.
 - [x] Local HTTP runs bind to `127.0.0.1` by default, with `HOST` available for explicit overrides.
 - [x] Disallowed browser `Origin` headers receive HTTP 403 while non-browser requests without `Origin` continue to work.
+- [x] `fdic_compare_bank_snapshots` and `fdic_peer_group_analysis` emit monotonic progress notifications when the request includes a progress token.
 - [x] Repo-standard validation passes.
 
 ## Review / Results
@@ -548,5 +550,8 @@ Reference: umbrella issue #115 and issues #109, #110, #111, #112, #113, and #114
 - [x] Reworked [index.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/src/index.ts) to manage one `McpServer` plus `StreamableHTTPServerTransport` per HTTP session instead of rebuilding the server on every POST.
 - [x] Reused the SDK's built-in session, method, protocol-version, and origin-validation behavior by routing requests to the correct persistent transport instance.
 - [x] Added `HOST` and `ALLOWED_ORIGINS` runtime support and documented the localhost-default bind behavior in [README.md](/Users/jlamb/Projects/bankfind-mcp-mcp-http/README.md), [getting-started.md](/Users/jlamb/Projects/bankfind-mcp-mcp-http/docs/getting-started.md), and [troubleshooting.md](/Users/jlamb/Projects/bankfind-mcp-mcp-http/docs/troubleshooting.md).
+- [x] Added a shared progress notification helper in [progress.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/src/tools/shared/progress.ts) and wired it into [analysis.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/src/tools/analysis.ts) and [peerGroup.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/src/tools/peerGroup.ts).
+- [x] Expanded [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/tests/mcp-http.test.ts) to cover session initialization requirements, GET/DELETE handling, protocol-version validation, origin enforcement, and end-to-end progress notifications over the standalone SSE stream.
+- [x] Verified `npm run typecheck`, `npm test -- tests/mcp-http.test.ts tests/analysis.test.ts tests/peerGroup.test.ts`, `npm test`, and `npm run build`.
 - [x] Expanded [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/tests/mcp-http.test.ts) to cover session initialization requirements, GET/DELETE handling, protocol-version validation, and origin enforcement.
 - [x] Verified `npm run typecheck`, `npm test -- tests/mcp-http.test.ts`, `npm test`, and `npm run build`.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -111,6 +111,79 @@ async function mcpPost(body: Record<string, unknown>) {
   return mcpRequest(app, sessionId, body);
 }
 
+async function collectProgressNotifications(
+  app: Express,
+  sessionId: string,
+  trigger: () => Promise<unknown>,
+) {
+  const server = app.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP address for test server");
+  }
+
+  const response = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+    headers: {
+      accept: "text/event-stream",
+      "mcp-session-id": sessionId,
+    },
+  });
+
+  if (!response.ok || response.body === null) {
+    throw new Error(`Failed to open SSE stream: ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const progressEvents: Array<{
+    progressToken: string | number;
+    progress: number;
+    total: number;
+    message: string;
+  }> = [];
+
+  const readTask = (async () => {
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
+
+      for (const event of events) {
+        const dataLine = event
+          .split("\n")
+          .find((line) => line.startsWith("data: "));
+        if (!dataLine) {
+          continue;
+        }
+
+        const payload = JSON.parse(dataLine.slice(6));
+        if (payload.method === "notifications/progress") {
+          progressEvents.push(payload.params);
+          if (payload.params.progress === 1) {
+            return;
+          }
+        }
+      }
+    }
+  })();
+
+  await trigger();
+  await readTask;
+  await reader.cancel();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+
+  return progressEvents;
+}
+
 
 describe("HTTP MCP server", () => {
   beforeEach(() => {
@@ -306,6 +379,196 @@ describe("HTTP MCP server", () => {
       });
 
     expect(disallowedInit.status).toBe(403);
+  });
+
+  it("streams progress notifications for snapshot analysis when the client provides a progress token", async () => {
+    const app = createApp();
+    const { sessionId } = await initializeSession(app);
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Example Bank",
+                REPDTE: "20240331",
+                ASSET: 1000,
+                DEP: 800,
+                NETINC: 10,
+                ROA: 1,
+                ROE: 10,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Example Bank",
+                REPDTE: "20241231",
+                ASSET: 1200,
+                DEP: 900,
+                NETINC: 12,
+                ROA: 1.1,
+                ROE: 10.5,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const progress = await collectProgressNotifications(app, sessionId, () =>
+      mcpRequest(app, sessionId, {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: {
+          name: "fdic_compare_bank_snapshots",
+          arguments: {
+            certs: [3511],
+            start_repdte: "20240331",
+            end_repdte: "20241231",
+            include_demographics: false,
+          },
+          _meta: {
+            progressToken: "analysis-progress",
+          },
+        },
+      }),
+    );
+
+    expect(progress).toEqual([
+      {
+        progressToken: "analysis-progress",
+        progress: 0.1,
+        total: 1,
+        message: "Fetching institution roster",
+      },
+      {
+        progressToken: "analysis-progress",
+        progress: 0.3,
+        total: 1,
+        message: "Fetching financial snapshots",
+      },
+      {
+        progressToken: "analysis-progress",
+        progress: 0.9,
+        total: 1,
+        message: "Computing metrics and insights",
+      },
+      {
+        progressToken: "analysis-progress",
+        progress: 1,
+        total: 1,
+        message: "Analysis complete",
+      },
+    ]);
+  });
+
+  it("streams progress notifications for peer group analysis when the client provides a progress token", async () => {
+    const app = createApp();
+    const { sessionId } = await initializeSession(app);
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Example Bank",
+                CITY: "Austin",
+                STALP: "TX",
+                BKCLASS: "N",
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                ASSET: 1000,
+                DEP: 800,
+                NETINC: 10,
+                ROA: 1,
+                ROE: 10,
+                NETNIM: 3,
+                EQTOT: 100,
+                LNLSNET: 700,
+                INTINC: 50,
+                EINTEXP: 10,
+                NONII: 5,
+                NONIX: 4,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const progress = await collectProgressNotifications(app, sessionId, () =>
+      mcpRequest(app, sessionId, {
+        jsonrpc: "2.0",
+        id: 8,
+        method: "tools/call",
+        params: {
+          name: "fdic_peer_group_analysis",
+          arguments: {
+            repdte: "20241231",
+            asset_min: 500,
+            asset_max: 2000,
+            active_only: false,
+          },
+          _meta: {
+            progressToken: "peer-progress",
+          },
+        },
+      }),
+    );
+
+    expect(progress).toEqual([
+      {
+        progressToken: "peer-progress",
+        progress: 0.1,
+        total: 1,
+        message: "Resolving subject and peer criteria",
+      },
+      {
+        progressToken: "peer-progress",
+        progress: 0.4,
+        total: 1,
+        message: "Fetching peer roster",
+      },
+      {
+        progressToken: "peer-progress",
+        progress: 0.7,
+        total: 1,
+        message: "Fetching peer financials",
+      },
+      {
+        progressToken: "peer-progress",
+        progress: 0.9,
+        total: 1,
+        message: "Computing peer rankings",
+      },
+      {
+        progressToken: "peer-progress",
+        progress: 1,
+        total: 1,
+        message: "Analysis complete",
+      },
+    ]);
   });
 
   it("lists all registered tools including demographics", async () => {


### PR DESCRIPTION
## Summary

This PR groups the analysis progress work on top of the HTTP transport compliance branch.

Related issues:
- Related #113
- Related #115
- Depends on #116

## What Changed

- added a shared helper for emitting `notifications/progress`
- wired progress notifications into `fdic_compare_bank_snapshots` at stable analysis phases
- wired progress notifications into `fdic_peer_group_analysis` at stable analysis phases
- extended the HTTP MCP tests to open the standalone SSE stream and assert the end-to-end progress notification sequence

## Validation

- `npm run typecheck`
- `npm test -- tests/mcp-http.test.ts tests/analysis.test.ts tests/peerGroup.test.ts`
- `npm run build`
