### PR TITLE
Add Cloud Run post-deploy smoke checks

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -28,6 +28,7 @@ env:
   GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
   CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT }}
   PUBLIC_MCP_URL: https://bankfind.jflamb.com/mcp
+  PUBLIC_HEALTH_URL: https://bankfind.jflamb.com/health
 
 jobs:
   deploy:
@@ -109,6 +110,52 @@ jobs:
             --allow-unauthenticated
             --port=8080
             --service-account=${{ env.CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT }}
+
+      - name: Run post-deploy smoke checks
+        run: |
+          set -euo pipefail
+
+          health_response="$(mktemp)"
+          mcp_response="$(mktemp)"
+          trap 'rm -f "$health_response" "$mcp_response"' EXIT
+
+          curl --fail --silent --show-error \
+            "$PUBLIC_HEALTH_URL" \
+            --output "$health_response"
+
+          python3 - "$health_response" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+
+          assert payload["status"] == "ok", payload
+          assert payload["server"] == "fdic-mcp-server", payload
+          assert isinstance(payload["version"], str) and payload["version"], payload
+          PY
+
+          curl --fail --silent --show-error \
+            "$PUBLIC_MCP_URL" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+            --output "$mcp_response"
+
+          python3 - "$mcp_response" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          result = payload["result"]
+          tools = result["tools"]
+
+          assert payload["jsonrpc"] == "2.0", payload
+          assert payload["id"] == 1, payload
+          assert isinstance(tools, list) and tools, payload
+          assert any(tool.get("name") == "fdic_search_institutions" for tool in tools), payload
+          PY
 
       - name: Show deployed URL
         run: |

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -10,3 +10,5 @@
 - When documenting onboarding, lead with the least-friction path that is genuinely available and position local terminal-based setup as the fallback.
 - In end-user docs, do not imply that users must speak in API-native field formats like `YYYYMMDD` unless that is truly required; distinguish user-facing prompt style from tool-level parameter formats.
 - When documenting MCP onboarding, distinguish clearly between hosted-URL connection flows and agentic local-install flows; do not imply that plain chat products can install a local npm package just because coding agents can.
+- For non-trivial repo work, avoid standalone plan markdown files; prefer grouping related issues in the implementation PR description so the reasoning lands in repo history, and use an umbrella issue only when PR-based grouping is not the better fit.
+- When a user asks to follow the repo workflow, complete the full change-management path rather than stopping at local edits: open or reference the issue, use a dedicated branch, commit the change, open the PR, watch checks, fix failures, and merge when green.


### PR DESCRIPTION
## Summary
- add a post-deploy smoke-test step to the Cloud Run workflow
- verify the live `/health` contract after rollout
- verify the live `/mcp` endpoint accepts a JSON-RPC `tools/list` request after rollout

Closes #118.

## Validation
- npm run typecheck
- npm test
- npm run build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-cloud-run.yml"); puts "YAML OK"'