### PR TITLE
fix: align release workflow with npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          registry-url: https://registry.npmjs.org
           cache: npm
 
       - name: Install dependencies
@@ -81,7 +80,6 @@ jobs:
         if: github.event_name != 'workflow_run' || steps.release_target.outputs.current == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/run-semantic-release.mjs
 
       - name: Install MCP Registry publisher

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -469,6 +469,31 @@ Reference: issue #82.
 
 - [x] Opened issue #82.
 
+# Trusted Publishing Release Recovery
+
+Reference: issue #122.
+
+## Goals
+
+- [x] Trace why the `Release` workflow on `main` is failing before it can publish a new version.
+- [x] Verify whether npm trusted publishing is still the supported path for this repo.
+- [x] Update the release workflow to use the supported trusted-publishing configuration instead of the broken token-oriented path.
+- [x] Validate the workflow change before merge.
+
+## Acceptance Criteria
+
+- [x] The repo captures evidence for the current `Release` workflow failure mode.
+- [x] The release workflow no longer configures `setup-node` with npm `registry-url` in the semantic-release job.
+- [x] The semantic-release step no longer requires `NPM_TOKEN` when the repo is using npm trusted publishing from GitHub Actions.
+- [x] Validation covers workflow syntax and the repo-standard PR checks.
+
+## Review / Results
+
+- [x] Confirmed failed `Release` runs on March 16, 2026 were stopping in semantic-release with `EINVALIDNPMTOKEN` during `@semantic-release/npm` `verifyConditions`.
+- [x] Verified the workflow was still setting `registry-url` in `setup-node` and passing `NPM_TOKEN`, which conflicts with the semantic-release trusted-publishing guidance.
+- [x] Validated `.github/workflows/publish.yml` parses cleanly with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "YAML OK"'`.
+- [x] Verified `npm run typecheck`, `npm test`, and `npm run build`.
+
 # Semantic Release Automation
 
 Reference: issue #105.


### PR DESCRIPTION
## Summary
- remove the npm `registry-url` setup from the semantic-release job so npm trusted publishing can use OIDC instead of a generated token-based `.npmrc`
- stop passing `NPM_TOKEN` into semantic-release, since the current repo release path is configured to use npm trusted publishing rather than a long-lived publish token
- capture the traced failure mode and validation in `tasks/todo.md`

Closes #122.

## Evidence
- `Release` workflow runs on March 16, 2026 were failing in `@semantic-release/npm` `verifyConditions` with `EINVALIDNPMTOKEN` and `401 Unauthorized` against `https://registry.npmjs.org/-/whoami`

## Validation
- npm run typecheck
- npm test
- npm run build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "YAML OK"'