### PR TITLE
fix: stop semantic-release from pushing release commits to main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,12 +16,6 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
       "@semantic-release/npm",
       {
         "npmPublish": true
@@ -33,18 +27,6 @@
         "prepareCmd": "node scripts/sync-server-json.mjs ${nextRelease.version}"
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md",
-          "package.json",
-          "package-lock.json",
-          "server.json"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip release]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Follow this sequence for substantive repo work unless the user explicitly asks f
 - Commit in logical chunks with clear, concise commit messages.
 - Use conventional commit messages for any commit that may land on `main`, because release automation derives versions from commit semantics. Use `fix:` for patch-level behavior fixes, `feat:` for new user-facing capability, and `!` or `BREAKING CHANGE:` for breaking changes. Do not hide behavior changes under `docs:` or `chore:` just to avoid a release bump.
 - Ensure the final commit message that reaches `main` remains conventional. If the repo uses squash merges, make the PR title conventional as well so the squashed mainline commit keeps the correct release signal.
-- Do not manually bump `package.json` versions or create release tags by hand. `semantic-release` owns version calculation, tagging, changelog updates, and downstream publishing.
+- Do not manually bump `package.json` versions or create release tags by hand. `semantic-release` owns version calculation, tagging, GitHub Release publication, and downstream publishing.
 - When the work is ready for review, open a pull request that explains what changed, why it changed, how it was validated, and any follow-up risk or context.
 - After opening the PR, monitor the required checks rather than assuming they passed. If validation fails, investigate the root cause, fix it on the same branch, and iterate until checks pass.
 - If validation passes, merge the PR and clean up local and remote working branches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
-All notable changes to this project are tracked here by semantic-release.
+Published release notes now live on the GitHub Releases page.
+
+This file is retained only as a compatibility stub and is not updated by release automation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Container note:
   - `fix:` creates a patch release
   - `feat:` creates a minor release
   - `BREAKING CHANGE:` or `!` creates a major release
-- Release automation publishes npm, GitHub Releases, GitHub Packages, and MCP Registry metadata from the same computed version.
+- Release automation publishes npm, GitHub Releases, GitHub Packages, and MCP Registry metadata from the same computed version without pushing release commits back to `main`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The FDIC BankFind Suite API is public and useful, but it is not packaged for MCP
 - Technical specification: [docs/technical/specification.md](./docs/technical/specification.md)
 - Architecture: [docs/technical/architecture.md](./docs/technical/architecture.md)
 - Key decisions: [docs/technical/decisions.md](./docs/technical/decisions.md)
-- Release history: [CHANGELOG.md](./CHANGELOG.md)
+- Release history: [GitHub Releases](https://github.com/jflamb/fdic-mcp-server/releases)
 - Archived release notes: [docs/release-notes/index.md](./docs/release-notes/index.md)
 - Security policy: [SECURITY.md](./SECURITY.md)
 
@@ -242,7 +242,7 @@ npm test
 npm run build
 ```
 
-Releases are published automatically from validated `main` commits by `semantic-release`. Do not manually edit the package version or create release tags by hand.
+Releases are published automatically from validated `main` commits by `semantic-release`. Do not manually edit the package version or create release tags by hand. GitHub Releases is the authoritative release record for published versions.
 
 ## License
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,7 +9,7 @@ breadcrumbs:
   - title: Project Info
     url: /project-information/
 ---
-Current releases are generated automatically by `semantic-release` and recorded in [CHANGELOG.md]({{ '/CHANGELOG.md' | relative_url }}) and the GitHub Releases page.
+Current releases are generated automatically by `semantic-release` and recorded on the GitHub Releases page.
 
 Historical manually curated notes remain here for earlier releases:
 

--- a/docs/technical/cloud-run-deployment.md
+++ b/docs/technical/cloud-run-deployment.md
@@ -138,7 +138,7 @@ Relevant repo assets:
 
 - `server.json` contains the MCP Registry metadata for this server
 - `.github/workflows/publish.yml` runs after successful `CI` on `main`, uses `semantic-release` to calculate the next version, and then runs `mcp-publisher login github-oidc` and `mcp-publisher publish`
-- `scripts/sync-server-json.mjs` keeps `server.json` version fields aligned with the semantic-release version written into `package.json`
+- `scripts/sync-server-json.mjs` keeps `server.json` version fields aligned with the semantic-release version in the release workspace before the MCP Registry publish step
 
 Registry references:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,8 @@
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^20.0.0",
-        "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/commit-analyzer": "^12.0.0",
         "@semantic-release/exec": "^6.0.3",
-        "@semantic-release/git": "^10.0.0",
         "@semantic-release/github": "^11.0.6",
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^13.0.0",
@@ -1535,25 +1533,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
@@ -1794,144 +1773,6 @@
       "license": "ISC"
     },
     "node_modules/@semantic-release/exec/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@semantic-release/git/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@semantic-release/git/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
@@ -7798,16 +7639,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-timeout": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,8 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^20.0.0",
-    "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/commit-analyzer": "^12.0.0",
     "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/git": "^10.0.0",
     "@semantic-release/github": "^11.0.6",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^13.0.0",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -624,3 +624,27 @@ Reference: umbrella issue #115 and issues #109, #110, #111, #112, #113, and #114
 - [x] Verified `npm run typecheck`, `npm test -- tests/mcp-http.test.ts tests/analysis.test.ts tests/peerGroup.test.ts`, `npm test`, and `npm run build`.
 - [x] Expanded [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp-mcp-http/tests/mcp-http.test.ts) to cover session initialization requirements, GET/DELETE handling, protocol-version validation, and origin enforcement.
 - [x] Verified `npm run typecheck`, `npm test -- tests/mcp-http.test.ts`, `npm test`, and `npm run build`.
+
+# Protected Main Release Flow
+
+Reference: issue #128.
+
+## Goals
+
+- [x] Keep semantic-release fully automatic for version calculation, tagging, npm publishing, GitHub Releases, GitHub Packages, and MCP Registry publication.
+- [x] Remove release-time writes back to protected `main`.
+- [x] Update repo docs so they point to the correct published release source of truth.
+
+## Acceptance Criteria
+
+- [x] semantic-release no longer attempts to push release commits directly to `main`.
+- [x] Automated versioning and downstream publish steps still use the semantic-release-computed version.
+- [x] Repo documentation no longer claims `CHANGELOG.md` on `main` is the authoritative published release record.
+- [x] Repo-standard validation passes.
+
+## Review / Results
+
+- [x] Removed `@semantic-release/changelog` and `@semantic-release/git` from the release path so the workflow no longer needs to mutate `main` after tagging and publishing.
+- [x] Kept `@semantic-release/npm`, `@semantic-release/exec`, and the downstream publish workflow intact so package and MCP Registry artifacts still use the computed release version inside the release workspace.
+- [x] Updated [README.md](/Users/jlamb/Projects/bankfind-mcp/README.md), [CONTRIBUTING.md](/Users/jlamb/Projects/bankfind-mcp/CONTRIBUTING.md), [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md), [docs/release-notes/index.md](/Users/jlamb/Projects/bankfind-mcp/docs/release-notes/index.md), and [docs/technical/cloud-run-deployment.md](/Users/jlamb/Projects/bankfind-mcp/docs/technical/cloud-run-deployment.md) to point at GitHub Releases rather than a committed changelog on `main`.
+- [x] Verified `npm run typecheck`, `npm test`, and `npm run build`.


### PR DESCRIPTION
## Summary
- remove semantic-release plugins that mutate tracked files and push release commits back to `main`
- keep semantic-release version calculation, npm publish, GitHub Releases, GitHub Packages, and MCP Registry publish flow intact
- update repo docs so GitHub Releases is the authoritative published release record

## Why
`main` is protected and requires PR-based changes plus required checks. The old release flow tried to push `chore(release)` commits directly to `main`, which caused the publish workflow to fail even though trusted npm publishing was working.

Closes #128.

## Validation
- npm run typecheck
- npm test
- npm run build
