### PR TITLE
fix: initialize MCP session in Cloud Run smoke test

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -118,8 +118,11 @@ jobs:
           set -euo pipefail
 
           health_response="$(mktemp)"
+          init_headers="$(mktemp)"
+          init_response="$(mktemp)"
+          initialized_response="$(mktemp)"
           mcp_response="$(mktemp)"
-          trap 'rm -f "$health_response" "$mcp_response"' EXIT
+          trap 'rm -f "$health_response" "$init_headers" "$init_response" "$initialized_response" "$mcp_response"' EXIT
 
           curl --fail --silent --show-error \
             "$PUBLIC_HEALTH_URL" \
@@ -141,18 +144,59 @@ jobs:
             "$PUBLIC_MCP_URL" \
             -H 'content-type: application/json' \
             -H 'accept: application/json, text/event-stream' \
-            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
-            --output "$mcp_response"
+            -D "$init_headers" \
+            -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"github-actions-smoke-test","version":"1.0.0"}}}' \
+            --output "$init_response"
 
-          python3 - "$mcp_response" <<'PY'
+          session_id="$(python3 - "$init_headers" "$init_response" <<'PY'
           import json
           import pathlib
           import sys
 
-          payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          headers = pathlib.Path(sys.argv[1]).read_text().splitlines()
+          payload = json.loads(pathlib.Path(sys.argv[2]).read_text())
+
+          session_id = None
+          for header in headers:
+            name, sep, value = header.partition(":")
+            if sep and name.lower() == "mcp-session-id":
+              session_id = value.strip()
+              break
+
+          assert session_id, headers
+          assert payload["jsonrpc"] == "2.0", payload
+          assert payload["id"] == 0, payload
+          print(session_id)
+          PY
+          )"
+
+          curl --fail --silent --show-error \
+            "$PUBLIC_MCP_URL" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -H "mcp-session-id: $session_id" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+            --output "$initialized_response"
+
+          curl --fail --silent --show-error \
+            "$PUBLIC_MCP_URL" \
+            -H 'content-type: application/json' \
+            -H 'accept: application/json, text/event-stream' \
+            -H "mcp-session-id: $session_id" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+            --output "$mcp_response"
+
+          python3 - "$initialized_response" "$mcp_response" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          initialized_payload = pathlib.Path(sys.argv[1]).read_text().strip()
+          payload = json.loads(pathlib.Path(sys.argv[2]).read_text())
           result = payload["result"]
           tools = result["tools"]
 
+          assert initialized_payload == "", initialized_payload
           assert payload["jsonrpc"] == "2.0", payload
           assert payload["id"] == 1, payload
           assert isinstance(tools, list) and tools, payload

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -648,3 +648,25 @@ Reference: issue #128.
 - [x] Kept `@semantic-release/npm`, `@semantic-release/exec`, and the downstream publish workflow intact so package and MCP Registry artifacts still use the computed release version inside the release workspace.
 - [x] Updated [README.md](/Users/jlamb/Projects/bankfind-mcp/README.md), [CONTRIBUTING.md](/Users/jlamb/Projects/bankfind-mcp/CONTRIBUTING.md), [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md), [docs/release-notes/index.md](/Users/jlamb/Projects/bankfind-mcp/docs/release-notes/index.md), and [docs/technical/cloud-run-deployment.md](/Users/jlamb/Projects/bankfind-mcp/docs/technical/cloud-run-deployment.md) to point at GitHub Releases rather than a committed changelog on `main`.
 - [x] Verified `npm run typecheck`, `npm test`, and `npm run build`.
+
+# Cloud Run MCP Session Smoke Test
+
+Reference: issue #131.
+
+## Goals
+
+- [x] Fix the Deploy Cloud Run smoke check so it validates the deployed session-based MCP HTTP endpoint correctly.
+- [x] Keep the health probe and tool-list verification in the workflow.
+
+## Acceptance Criteria
+
+- [x] The smoke test performs MCP session initialization before any session-bound method call.
+- [x] The smoke test reuses the returned `MCP-Session-Id` for follow-up requests.
+- [x] Repo-standard validation passes.
+
+## Review / Results
+
+- [x] Confirmed the latest `Deploy Cloud Run` failure was no longer startup-related; the deployment itself succeeded and the workflow failed in `Run post-deploy smoke checks` with HTTP 400 from `/mcp`.
+- [x] Identified the root cause as a protocol mismatch: the smoke test posted `tools/list` without first creating an MCP session, but the server correctly requires `initialize` and a valid `MCP-Session-Id`.
+- [x] Updated [deploy-cloud-run.yml](/Users/jlamb/Projects/bankfind-mcp/.github/workflows/deploy-cloud-run.yml) to run `initialize`, capture the `MCP-Session-Id`, send `notifications/initialized`, and only then call `tools/list`.
+- [x] Verified `npm ci`, `npm run typecheck`, `npm test`, `npm run build`, and a YAML parse check for [deploy-cloud-run.yml](/Users/jlamb/Projects/bankfind-mcp/.github/workflows/deploy-cloud-run.yml).


### PR DESCRIPTION
## Summary
- update the Deploy Cloud Run smoke test to follow the session-based MCP HTTP protocol
- initialize the session, capture `MCP-Session-Id`, send `notifications/initialized`, then call `tools/list`
- keep the existing health check and tool-list validation intact

## Root cause
The deployed service now uses a session-based MCP HTTP transport. The previous smoke test posted `tools/list` directly to `/mcp` without a valid session, so the server correctly returned HTTP 400 and the workflow failed even when deployment itself succeeded.

Closes #131.

## Validation
- npm ci
- npm run typecheck
- npm test
- npm run build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-cloud-run.yml"); puts "YAML OK"'
