### PR TITLE
fix: sync docs release metadata with GitHub releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:
@@ -22,6 +25,17 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Generate docs release data
+        run: node scripts/generate-docs-release-data.mjs
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 dist/
+.tmp/
+.jekyll-cache/
+.jekyll-metadata
+docs/.jekyll-cache/
 .DS_Store
 *.tsbuildinfo
 .envrc

--- a/docs/_data/latest_release.json
+++ b/docs/_data/latest_release.json
@@ -1,0 +1,10 @@
+{
+  "source": "github",
+  "tag_name": "v1.2.2",
+  "version": "1.2.2",
+  "display_name": "Version 1.2.2",
+  "release_name": "v1.2.2",
+  "url": "https://github.com/jflamb/fdic-mcp-server/releases/tag/v1.2.2",
+  "published_at": "2026-03-16T17:55:57Z",
+  "summary": "bug fixes in the latest published release, including initialize MCP session in Cloud Run smoke test (132)."
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ kicker: Documentation Home
 summary: A starting point for users, maintainers, and evaluators who need to understand what the project solves and where to go next.
 body_class: overview-page
 ---
+{% assign latest_release = site.data.latest_release %}
 
 <div class="hero-grid">
   <section class="hero-panel hero-panel--accent">
@@ -33,10 +34,10 @@ body_class: overview-page
     <h3>Connect to the live endpoint</h3>
     <p>Start with the hosted MCP URL when your host accepts remote servers. Use the local install path only when your host requires stdio.</p>
   </a>
-  <a class="card" href="{{ '/release-notes/v1.1.3/' | relative_url }}">
+  <a class="card" href="{{ latest_release.url }}">
     <span class="card__eyebrow">Latest Release</span>
-    <h3>Version 1.1.3</h3>
-    <p>Fixes empty listed parameter schemas for the analysis tools in MCP clients.</p>
+    <h3>{{ latest_release.display_name }}</h3>
+    <p>{{ latest_release.summary }}</p>
   </a>
   <a class="card" href="{{ '/prompting-guide/' | relative_url }}">
     <span class="card__eyebrow">Best Next Read</span>

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,7 +9,11 @@ breadcrumbs:
   - title: Project Info
     url: /project-information/
 ---
+{% assign latest_release = site.data.latest_release %}
+
 Current releases are generated automatically by `semantic-release` and recorded on the GitHub Releases page.
+
+Latest published release: [{{ latest_release.tag_name }}]({{ latest_release.url }}){% if latest_release.published_at %}, published {{ latest_release.published_at | date: "%B %-d, %Y" }}{% endif %}.
 
 Historical manually curated notes remain here for earlier releases:
 

--- a/scripts/generate-docs-release-data.mjs
+++ b/scripts/generate-docs-release-data.mjs
@@ -1,0 +1,215 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const packageJsonPath = path.join(repoRoot, "package.json");
+const outputPath = process.env.DOCS_LATEST_RELEASE_OUTPUT
+  ? path.resolve(process.env.DOCS_LATEST_RELEASE_OUTPUT)
+  : path.join(repoRoot, "docs", "_data", "latest_release.json");
+
+async function main() {
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  const repo = getRepositorySlug(packageJson);
+  const latestRelease =
+    (await fetchLatestRelease(repo)) ??
+    getLatestReleaseFromGit(repo) ??
+    getLatestReleaseFromPackage(repo, packageJson.version);
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(latestRelease, null, 2)}\n`);
+
+  console.log(
+    `Wrote docs latest release data for ${latestRelease.tag_name} to ${outputPath}`,
+  );
+}
+
+function getRepositorySlug(packageJson) {
+  const repositoryUrl =
+    typeof packageJson.repository === "string"
+      ? packageJson.repository
+      : packageJson.repository?.url;
+
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+
+  if (!repositoryUrl) {
+    throw new Error("Unable to determine repository slug for docs release data.");
+  }
+
+  const normalized = repositoryUrl
+    .replace(/^git\+/, "")
+    .replace(/^git@github\.com:/, "https://github.com/")
+    .replace(/\.git$/, "");
+
+  const match = normalized.match(/github\.com\/([^/]+\/[^/]+)$/);
+
+  if (!match) {
+    throw new Error(`Unsupported repository URL: ${repositoryUrl}`);
+  }
+
+  return match[1];
+}
+
+async function fetchLatestRelease(repo) {
+  const apiBaseUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const url = `${apiBaseUrl}/repos/${repo}/releases/latest`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "fdic-mcp-server-docs-release-data",
+        ...(process.env.GITHUB_TOKEN
+          ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+          : {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API responded with ${response.status}`);
+    }
+
+    const release = await response.json();
+
+    return mapRelease({
+      source: "github",
+      tagName: release.tag_name,
+      url: release.html_url,
+      publishedAt: release.published_at,
+      summary: summarizeReleaseBody(release.body),
+      releaseName: release.name,
+    });
+  } catch (error) {
+    console.warn(`Falling back from GitHub release API: ${error.message}`);
+    return null;
+  }
+}
+
+function getLatestReleaseFromGit(repo) {
+  try {
+    const output = execFileSync(
+      "git",
+      ["tag", "--list", "v*", "--sort=-version:refname"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    const tagName = output
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+
+    if (!tagName) {
+      return null;
+    }
+
+    return mapRelease({
+      source: "git",
+      tagName,
+      url: `https://github.com/${repo}/releases/tag/${tagName}`,
+      summary: `Published release ${tagName} from the repository tags.`,
+    });
+  } catch (error) {
+    console.warn(`Falling back from git tags: ${error.message}`);
+    return null;
+  }
+}
+
+function getLatestReleaseFromPackage(repo, version) {
+  const tagName = version.startsWith("v") ? version : `v${version}`;
+
+  return mapRelease({
+    source: "package",
+    tagName,
+    url: `https://github.com/${repo}/releases/latest`,
+    summary: `Latest release data was unavailable during the docs build. See GitHub Releases for ${tagName}.`,
+  });
+}
+
+function mapRelease({ source, tagName, url, publishedAt = null, summary, releaseName = null }) {
+  const version = tagName.replace(/^v/, "");
+
+  return {
+    source,
+    tag_name: tagName,
+    version,
+    display_name: `Version ${version}`,
+    release_name: releaseName || tagName,
+    url,
+    published_at: publishedAt,
+    summary,
+  };
+}
+
+function summarizeReleaseBody(body) {
+  if (!body) {
+    return "See the GitHub release notes for the latest published changes.";
+  }
+
+  const sectionSummary = summarizeReleaseSections(body);
+
+  if (sectionSummary) {
+    return sectionSummary;
+  }
+
+  const firstParagraph = body
+    .split(/\n\s*\n/)
+    .map((part) => part.replace(/\s+/g, " ").trim())
+    .find((part) => part && !part.startsWith("#"));
+
+  if (!firstParagraph) {
+    return "See the GitHub release notes for the latest published changes.";
+  }
+
+  return stripMarkdown(firstParagraph).slice(0, 220);
+}
+
+function summarizeReleaseSections(body) {
+  const lines = body.split("\n");
+  let currentHeading = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("### ")) {
+      currentHeading = stripMarkdown(line.slice(4));
+      continue;
+    }
+
+    if (!currentHeading || !line.startsWith("* ")) {
+      continue;
+    }
+
+    const bullet = stripMarkdown(line.slice(2))
+      .replace(/\(\[[^)]+\]\)\s*$/, "")
+      .replace(/\s+\([a-f0-9]{7,}\)\s*$/, "")
+      .trim();
+
+    if (!bullet) {
+      continue;
+    }
+
+    const headingPrefix = (
+      currentHeading.endsWith("s") ? currentHeading : `${currentHeading}s`
+    ).toLowerCase();
+
+    return `${headingPrefix} in the latest published release, including ${bullet}.`
+      .replace(/\s+/g, " ")
+      .slice(0, 220);
+  }
+
+  return null;
+}
+
+function stripMarkdown(text) {
+  return text
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[*_>#-]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+await main();

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -219,6 +219,35 @@ Reference: issue #54.
 
 # AGENTS File Guide Cleanup
 
+# Docs Release Sync Automation
+
+Reference: issue #133 and user report that the GitHub Pages site still advertises `1.1.3` while GitHub Releases shows `v1.2.2`.
+
+## Goals
+
+- [x] Identify why the docs site release card drifted behind the actual published releases.
+- [x] Remove the hardcoded latest-release version from the docs homepage.
+- [x] Generate latest-release metadata for Jekyll automatically from GitHub Releases during the Pages build.
+- [x] Ensure the Pages workflow rebuilds when a GitHub release is published, not only when `main` receives a push.
+- [x] Validate the automation with targeted checks.
+
+## Acceptance Criteria
+
+- [x] The docs homepage latest-release card renders from generated data instead of a manually edited version string.
+- [x] A newly published GitHub release is sufficient to refresh the GitHub Pages site.
+- [x] If release metadata is unavailable, the docs build still succeeds with a safe fallback.
+- [x] Targeted validation passes for the generation script and Jekyll build.
+
+## Review / Results
+
+- [x] Root cause documented.
+- [x] Automation implemented and validated.
+- [x] Issue created and linked: #133.
+- [x] Verified `node scripts/generate-docs-release-data.mjs`.
+- [x] Verified fallback generation with `GITHUB_API_URL=http://127.0.0.1:9 DOCS_LATEST_RELEASE_OUTPUT=.tmp/latest_release_fallback.json node scripts/generate-docs-release-data.mjs`.
+- [x] Parsed `.github/workflows/pages.yml` successfully with Ruby `YAML.load_file`.
+- [x] Verified `PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH" jekyll build --source docs --destination .tmp/jekyll-site`.
+
 Reference: issue #60.
 
 ## Goals


### PR DESCRIPTION
## Summary
- generate docs latest-release data from GitHub Releases with git/package fallbacks
- replace the hardcoded `1.1.3` docs card with Jekyll data-driven release metadata
- rebuild GitHub Pages when a release is published and ignore local Jekyll/temp output

## Why
The docs site still advertised `1.1.3` because the release card was hardcoded in the docs content and the Pages workflow only rebuilt on pushes to `main`. GitHub Releases had advanced independently to `v1.2.2`.

Closes #133.

## Validation
- `node scripts/generate-docs-release-data.mjs`
- `GITHUB_API_URL=http://127.0.0.1:9 DOCS_LATEST_RELEASE_OUTPUT=.tmp/latest_release_fallback.json node scripts/generate-docs-release-data.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pages.yml'); puts 'pages.yml ok'"`
- `PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH" jekyll build --source docs --destination .tmp/jekyll-site`

## Residual Risk
- The local Jekyll build emits a pre-existing YAML warning for `docs/technical/specification.md` front matter, but the build completes successfully.
