### PR TITLE
fix: correct analysis progress and insight summaries

### DIFF
--- a/src/tools/analysis.ts
+++ b/src/tools/analysis.ts
@@ -603,6 +603,7 @@ function buildAnalysisOutput(params: {
   sortOrder: "ASC" | "DESC";
   warnings: string[];
   comparisons: ComparisonRecord[];
+  insightComparisons?: ComparisonRecord[];
   offset?: number;
   limitCount?: number;
 }) {
@@ -618,7 +619,9 @@ function buildAnalysisOutput(params: {
     sort_by: params.sortBy,
     sort_order: params.sortOrder,
     warnings: params.warnings,
-    insights: buildTopLevelInsights(params.comparisons),
+    insights: buildTopLevelInsights(
+      params.insightComparisons ?? params.comparisons,
+    ),
     ...buildPaginationInfo(params.analyzedCount, offset, count),
     comparisons: params.comparisons,
   };
@@ -982,7 +985,9 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             server.server,
             progressToken,
             0.3,
-            "Fetching financial time series",
+            include_demographics
+              ? "Fetching financial and demographic time series"
+              : "Fetching financial time series",
           );
 
           const [financialSeriesResult, demographicsSeriesResult] = await Promise.all([
@@ -1013,15 +1018,6 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             ...demographicsSeriesResult.warnings,
           );
 
-          if (include_demographics) {
-            await sendProgressNotification(
-              server.server,
-              progressToken,
-              0.7,
-              "Fetching demographics time series",
-            );
-          }
-
           await sendProgressNotification(
             server.server,
             progressToken,
@@ -1051,7 +1047,9 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             server.server,
             progressToken,
             0.3,
-            "Fetching financial snapshots",
+            include_demographics
+              ? "Fetching financial and demographic snapshots"
+              : "Fetching financial snapshots",
           );
 
           const [financialSnapshotsResult, demographicSnapshotsResult] = await Promise.all([
@@ -1079,15 +1077,6 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
             ...financialSnapshotsResult.warnings,
             ...demographicSnapshotsResult.warnings,
           );
-
-          if (include_demographics) {
-            await sendProgressNotification(
-              server.server,
-              progressToken,
-              0.7,
-              "Fetching demographic snapshots",
-            );
-          }
 
           await sendProgressNotification(
             server.server,
@@ -1147,6 +1136,7 @@ Returns concise comparison text plus structured deltas, derived metrics, and ins
           sortOrder: sort_order,
           warnings,
           comparisons: ranked,
+          insightComparisons: sortedComparisons,
           limitCount: ranked.length,
         });
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -13,3 +13,4 @@
 - For non-trivial repo work, avoid standalone plan markdown files; prefer grouping related issues in the implementation PR description so the reasoning lands in repo history, and use an umbrella issue only when PR-based grouping is not the better fit.
 - When a user asks to follow the repo workflow, complete the full change-management path rather than stopping at local edits: open or reference the issue, use a dedicated branch, commit the change, open the PR, watch checks, fix failures, and merge when green.
 - When the repository has standing SOPs, document them explicitly in `AGENTS.md` instead of relying on adjacent bullets or implied behavior.
+- When running `/issue-batch-run` or another repo workflow shortcut, do not stop at isolated validated worktrees; finish the documented change-management path on branches rooted at `origin/main`, then open PRs, watch checks, and merge unless the user explicitly asks to pause.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Bug Batch 1: Analysis And Ranking Bugs
+
+Reference: bugs #141 and #146 from the `bug` issue batch generated on 2026-03-16.
+
+## Goals
+
+- [x] Make analysis progress notifications describe work before it happens, especially when financial and demographic fetches run in parallel.
+- [x] Ensure top-level analysis insights are computed from the full analyzed population, not only the returned ranked slice.
+- [x] Add or update tests that fail on the current misleading progress sequence and sliced-insight behavior.
+- [x] Validate the batch with targeted tests plus repo-standard type/build checks.
+
+## Acceptance Criteria
+
+- [x] Snapshot and timeseries analysis progress notifications are semantically accurate for both `include_demographics: false` and `include_demographics: true`.
+- [x] `structuredContent.comparisons` remains limited by `limit`, but `structuredContent.insights` reflects the full sorted comparison population.
+- [x] Existing MCP tool contracts remain unchanged apart from the corrected progress messages and insight population semantics.
+- [x] `npm test -- tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build` pass after the changes.
+
+## Review / Results
+
+- [x] Branch created for Batch 1 work: `fix/bug-batch-1-analysis-ranking-pr`.
+- [x] Replaced misleading post-fetch demographic progress notifications with combined pre-fetch progress messages in [analysis.ts](/Users/jlamb/Projects/bankfind-mcp/src/tools/analysis.ts).
+- [x] Decoupled top-level insight generation from the returned `limit` slice so the insight summary reflects the full sorted analysis population.
+- [x] Added MCP HTTP regression coverage for combined demographic progress messaging and full-population top-level insights in [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp/tests/mcp-http.test.ts).
+- [x] Verified `npm test -- tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.
+
 # Hosted Onboarding And Registry Publication
 
 Reference: issue #35 and user request to update the docs around the live hosted endpoint and automate publication to a public MCP registry.
@@ -699,3 +725,29 @@ Reference: issue #131.
 - [x] Identified the root cause as a protocol mismatch: the smoke test posted `tools/list` without first creating an MCP session, but the server correctly requires `initialize` and a valid `MCP-Session-Id`.
 - [x] Updated [deploy-cloud-run.yml](/Users/jlamb/Projects/bankfind-mcp/.github/workflows/deploy-cloud-run.yml) to run `initialize`, capture the `MCP-Session-Id`, send `notifications/initialized`, and only then call `tools/list`.
 - [x] Verified `npm ci`, `npm run typecheck`, `npm test`, `npm run build`, and a YAML parse check for [deploy-cloud-run.yml](/Users/jlamb/Projects/bankfind-mcp/.github/workflows/deploy-cloud-run.yml).
+
+# Label-Driven Issue Batch Helper
+
+Reference: user request to add a shortcut for reviewing issues by label and grouping them into logical execution batches.
+
+## Goals
+
+- [x] Add a repo-local shortcut that fetches GitHub issues by label and emits grouped batches for maintainer review.
+- [x] Make the output align with the repository working norms so each batch can be executed with the expected branch, validation, and PR flow.
+- [x] Add regression coverage for the batching heuristics and markdown brief rendering.
+- [x] Document the shortcut in agent-facing repo guidance.
+
+## Acceptance Criteria
+
+- [x] `npm run issues:batch -- --label bug` produces a markdown brief for the current repository.
+- [x] The brief groups matching issues into logical categories and limits each recommended batch to a configurable size.
+- [x] The brief includes the key execution norms for branch, validation, testing, and PR handling.
+- [x] Automated tests cover category classification, batch splitting, and markdown rendering.
+
+## Review / Results
+
+- [x] Added [prepare-issue-batches.mjs](/Users/jlamb/Projects/bankfind-mcp/scripts/prepare-issue-batches.mjs) plus [issue-batching.mjs](/Users/jlamb/Projects/bankfind-mcp/scripts/lib/issue-batching.mjs) to fetch labeled issues through `gh`, group them by subsystem heuristics, and render a Codex-ready markdown brief.
+- [x] Added the `npm run issues:batch` shortcut in [package.json](/Users/jlamb/Projects/bankfind-mcp/package.json).
+- [x] Documented the helper in [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md) so label-driven maintenance passes start from an explicit batch review step.
+- [x] Added the prompt shorthand `/issue-batch <label>` to [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md) and [prompting-guide.md](/Users/jlamb/Projects/bankfind-mcp/docs/prompting-guide.md) for AI-driven orchestration.
+- [x] Run `npm run typecheck`, `npm test -- tests/issue-batching.test.ts`, and `npm run build`.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -472,6 +472,127 @@ describe("HTTP MCP server", () => {
     ]);
   });
 
+  it("uses combined fetch progress messages when snapshot analysis includes demographics", async () => {
+    const app = createApp();
+    const { sessionId } = await initializeSession(app);
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Example Bank",
+                REPDTE: "20240331",
+                ASSET: 1000,
+                DEP: 800,
+                NETINC: 10,
+                ROA: 1,
+                ROE: 10,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Example Bank",
+                REPDTE: "20241231",
+                ASSET: 1200,
+                DEP: 900,
+                NETINC: 12,
+                ROA: 1.1,
+                ROE: 10.5,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                REPDTE: "20240331",
+                OFFTOT: 5,
+                CBSANAME: "Austin",
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                REPDTE: "20241231",
+                OFFTOT: 6,
+                CBSANAME: "Austin",
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const progress = await collectProgressNotifications(app, sessionId, () =>
+      mcpRequest(app, sessionId, {
+        jsonrpc: "2.0",
+        id: 71,
+        method: "tools/call",
+        params: {
+          name: "fdic_compare_bank_snapshots",
+          arguments: {
+            certs: [3511],
+            start_repdte: "20240331",
+            end_repdte: "20241231",
+            include_demographics: true,
+          },
+          _meta: {
+            progressToken: "analysis-progress-with-demographics",
+          },
+        },
+      }),
+    );
+
+    expect(progress).toEqual([
+      {
+        progressToken: "analysis-progress-with-demographics",
+        progress: 0.1,
+        total: 1,
+        message: "Fetching institution roster",
+      },
+      {
+        progressToken: "analysis-progress-with-demographics",
+        progress: 0.3,
+        total: 1,
+        message: "Fetching financial and demographic snapshots",
+      },
+      {
+        progressToken: "analysis-progress-with-demographics",
+        progress: 0.9,
+        total: 1,
+        message: "Computing metrics and insights",
+      },
+      {
+        progressToken: "analysis-progress-with-demographics",
+        progress: 1,
+        total: 1,
+        message: "Analysis complete",
+      },
+    ]);
+  });
+
   it("streams progress notifications for peer group analysis when the client provides a progress token", async () => {
     const app = createApp();
     const { sessionId } = await initializeSession(app);
@@ -2022,6 +2143,70 @@ describe("HTTP MCP server", () => {
       deposit_mix_softening: ["Trend Bank", "Funding Bank"],
       sustained_asset_growth: ["Trend Bank", "Funding Bank"],
       multi_quarter_roa_decline: ["Trend Bank"],
+    });
+  });
+
+  it("builds top-level insights from the full sorted population instead of the returned slice", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Slice Bank", CITY: "Raleigh", STALP: "NC" } },
+            { data: { CERT: 2222, NAME: "Hidden Insight Bank", CITY: "Durham", STALP: "NC" } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Slice Bank", ASSET: 100, DEP: 90, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+            { data: { CERT: 2222, NAME: "Hidden Insight Bank", ASSET: 100, DEP: 90, NETINC: 10, ROA: 1.0, ROE: 8.0 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 1111, NAME: "Slice Bank", ASSET: 160, DEP: 130, NETINC: 15, ROA: 1.3, ROE: 9.0 } },
+            { data: { CERT: 2222, NAME: "Hidden Insight Bank", ASSET: 125, DEP: 80, NETINC: 9, ROA: 0.8, ROE: 7.5 } },
+          ],
+          meta: { total: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      })
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 1202,
+      method: "tools/call",
+      params: {
+        name: "fdic_compare_bank_snapshots",
+        arguments: {
+          state: "North Carolina",
+          start_repdte: "20211231",
+          end_repdte: "20250630",
+          include_demographics: true,
+          limit: 1,
+          sort_by: "asset_growth",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent.comparisons).toHaveLength(1);
+    expect(
+      response.body.result.structuredContent.comparisons[0].name,
+    ).toBe("Slice Bank");
+    expect(response.body.result.structuredContent.insights).toMatchObject({
+      growth_with_better_profitability: ["Slice Bank"],
+      balance_sheet_growth_without_profitability: ["Hidden Insight Bank"],
     });
   });
 


### PR DESCRIPTION
## Summary
- make analysis progress notifications reflect the actual pre-fetch phase when demographics are requested in parallel
- compute top-level analysis insights from the full sorted comparison set while still returning the requested ranked slice
- add MCP HTTP regressions for combined snapshot progress messaging and full-population insight summaries
- record the workflow lesson from this user correction in `tasks/lessons.md`

## Why
Closes #141
Closes #146

The analysis tool was emitting demographic fetch progress after the data had already been fetched, and the top-level `insights` summary only reflected the returned `limit` slice instead of the full analyzed population.

## Validation
- `npm test -- tests/mcp-http.test.ts`
- `npm run typecheck`
- `npm run build`

## Release impact
- patch
