### PR TITLE
fix: make peer group report dates deterministic

### DIFF
--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -28,6 +28,21 @@ export interface RankResult {
   percentile: number;
 }
 
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
 export function computeCompetitionRank(
   subjectValue: number,
   peerValues: number[],
@@ -58,17 +73,20 @@ export function computeCompetitionRank(
 
 export function formatRepdteHuman(repdte: string): string {
   if (repdte.length !== 8) return repdte;
-  const year = repdte.slice(0, 4);
-  const month = repdte.slice(4, 6);
-  const day = repdte.slice(6, 8);
-  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
+  const year = Number.parseInt(repdte.slice(0, 4), 10);
+  const month = Number.parseInt(repdte.slice(4, 6), 10);
+  const day = Number.parseInt(repdte.slice(6, 8), 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
   if (Number.isNaN(date.getTime())) return repdte;
-  return date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return repdte;
+  }
+
+  return `${MONTH_NAMES[month - 1]} ${day}, ${year}`;
 }
 
 interface MetricDefinition {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,26 @@
+# Bug Batch 4: CI, Release, And Deployment Bugs
+
+Reference: bug #144 from the `bug` issue batch generated on 2026-03-16.
+
+## Goals
+
+- [x] Replace locale-dependent report-date formatting with deterministic manual formatting.
+- [x] Add regression coverage for valid and invalid formatted dates.
+- [x] Validate the batch with targeted tests plus repo-standard type/build checks.
+
+## Acceptance Criteria
+
+- [x] `formatRepdteHuman()` returns stable `Month D, YYYY` output without relying on runtime ICU locale data.
+- [x] Invalid report dates still round-trip as the original string.
+- [x] `npm test -- tests/peerGroup.test.ts`, `npm run typecheck`, and `npm run build` pass after the changes.
+
+## Review / Results
+
+- [x] Branch created for Batch 4 work: `fix/bug-batch-4-date-format-pr`.
+- [x] Replaced locale-dependent formatting with explicit UTC validation plus month-name formatting in [peerGroup.ts](/Users/jlamb/Projects/bankfind-mcp-batch4/src/tools/peerGroup.ts).
+- [x] Added deterministic date-format regression coverage, including impossible calendar dates, in [peerGroup.test.ts](/Users/jlamb/Projects/bankfind-mcp-batch4/tests/peerGroup.test.ts).
+- [x] Verified `npm test -- tests/peerGroup.test.ts`, `npm run typecheck`, and `npm run build`.
+
 # Bug Batch 3: FDIC Data And Query Contract Bugs
 
 Reference: bug #135 from the `bug` issue batch generated on 2026-03-16.

--- a/tests/peerGroup.test.ts
+++ b/tests/peerGroup.test.ts
@@ -161,6 +161,10 @@ describe("formatRepdteHuman", () => {
   it("returns the raw string for invalid dates", () => {
     expect(formatRepdteHuman("bad")).toBe("bad");
   });
+
+  it("returns the raw string for impossible calendar dates", () => {
+    expect(formatRepdteHuman("20240230")).toBe("20240230");
+  });
 });
 
 describe("PeerGroupInputSchema", () => {


### PR DESCRIPTION
## Summary
- replace locale-dependent `toLocaleDateString()` formatting with deterministic UTC validation and explicit month-name formatting
- add regression coverage for impossible calendar dates

## Why
Closes #144

`formatRepdteHuman()` relied on runtime ICU locale data, which can vary across Node.js environments and container images. The manual formatter keeps human-readable output stable across environments.

## Validation
- `npm test -- tests/peerGroup.test.ts`
- `npm run typecheck`
- `npm run build`

## Release impact
- patch
