### PR TITLE
fix: prune expired query cache entries safely

### DIFF
--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -44,10 +44,9 @@ const queryCache = new Map<string, CacheEntry>();
 
 function pruneExpiredQueryCache(now: number): void {
   for (const [key, entry] of queryCache.entries()) {
-    if (entry.expiresAt > now) {
-      break;
+    if (entry.expiresAt <= now) {
+      queryCache.delete(key);
     }
-    queryCache.delete(key);
   }
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,26 @@
+# Bug Batch 3: FDIC Data And Query Contract Bugs
+
+Reference: bug #135 from the `bug` issue batch generated on 2026-03-16.
+
+## Goals
+
+- [x] Remove the insertion-order assumption from query-cache expiration pruning.
+- [x] Add regression coverage for mixed expired and live cache entries.
+- [x] Validate the batch with targeted tests plus repo-standard type/build checks.
+
+## Acceptance Criteria
+
+- [x] Expired query-cache entries are pruned wherever they appear in the cache map.
+- [x] Live cache entries are preserved while stale entries are removed.
+- [x] `npm test -- tests/fdicClient.test.ts`, `npm run typecheck`, and `npm run build` pass after the changes.
+
+## Review / Results
+
+- [x] Branch created for Batch 3 work: `fix/bug-batch-3-cache-pr`.
+- [x] Removed the early `break` from cache pruning in [fdicClient.ts](/Users/jlamb/Projects/bankfind-mcp-batch3/src/services/fdicClient.ts) so expiration cleanup no longer depends on map iteration order.
+- [x] Added a cache-regression scenario in [fdicClient.test.ts](/Users/jlamb/Projects/bankfind-mcp-batch3/tests/fdicClient.test.ts) that exercises stale-entry cleanup alongside live cache entries.
+- [x] Verified `npm test -- tests/fdicClient.test.ts`, `npm run typecheck`, and `npm run build`.
+
 # Bug Batch 2: HTTP Transport And Protocol Bugs
 
 Reference: bugs #143 and #149 from the `bug` issue batch generated on 2026-03-16.

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -214,7 +214,7 @@ describe("fdicClient", () => {
     nowSpy.mockRestore();
   });
 
-  it("keeps expired-entry pruning bounded to the oldest cache entries", async () => {
+  it("prunes expired cache entries without relying on insertion order", async () => {
     const nowSpy = vi.spyOn(Date, "now");
     getMock.mockResolvedValue({
       data: { data: [{ data: { CERT: 3511 } }], meta: { total: 1 } },
@@ -226,7 +226,10 @@ describe("fdicClient", () => {
     nowSpy.mockReturnValue(1_500);
     await queryEndpoint("institutions", { filters: "CERT:2" });
 
-    nowSpy.mockReturnValue(61_000);
+    nowSpy.mockReturnValue(61_250);
+    await queryEndpoint("institutions", { filters: "CERT:1" });
+
+    nowSpy.mockReturnValue(62_000);
     await queryEndpoint("institutions", { filters: "CERT:3" });
 
     expect(getQueryCacheSize()).toBe(2);


### PR DESCRIPTION
## Summary
- remove the insertion-order assumption from query-cache expiration pruning
- add a regression that exercises stale-entry cleanup with mixed live and expired cache entries

## Why
Closes #135

`pruneExpiredQueryCache()` was breaking at the first live entry even though `Map` iteration order is insertion-based, not expiration-based. That left stale entries behind when keys were refreshed out of order.

## Validation
- `npm test -- tests/fdicClient.test.ts`
- `npm run typecheck`
- `npm run build`

## Release impact
- patch
