### PR TITLE
fix: expire idle HTTP MCP sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,12 +82,18 @@ export function parseAllowedOrigins(
 interface HttpAppOptions {
   port?: number;
   allowedOrigins?: string[];
+  sessionIdleTimeoutMs?: number;
+  sessionSweepIntervalMs?: number;
 }
 
 interface SessionContext {
   server: McpServer;
   transport: StreamableHTTPServerTransport;
+  lastActivityAt: number;
 }
+
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 async function closeSession(
   sessions: Map<string, SessionContext>,
@@ -101,6 +107,28 @@ async function closeSession(
   sessions.delete(sessionId);
   await session.server.close().catch(() => {});
   await session.transport.close().catch(() => {});
+}
+
+function touchSession(session: SessionContext, now: number): void {
+  session.lastActivityAt = now;
+}
+
+async function sweepIdleSessions(
+  sessions: Map<string, SessionContext>,
+  idleTimeoutMs: number,
+  now: number,
+): Promise<void> {
+  const expiredSessionIds: string[] = [];
+
+  for (const [sessionId, session] of sessions.entries()) {
+    if (now - session.lastActivityAt >= idleTimeoutMs) {
+      expiredSessionIds.push(sessionId);
+    }
+  }
+
+  await Promise.all(
+    expiredSessionIds.map((sessionId) => closeSession(sessions, sessionId)),
+  );
 }
 
 function sendInvalidSessionResponse(res: express.Response): void {
@@ -120,7 +148,16 @@ export function createApp(options: HttpAppOptions = {}): Express {
   const allowedOrigins =
     options.allowedOrigins ?? parseAllowedOrigins(undefined, port);
   const sessions = new Map<string, SessionContext>();
+  const sessionIdleTimeoutMs =
+    options.sessionIdleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS;
+  const sessionSweepIntervalMs =
+    options.sessionSweepIntervalMs ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
   app.use(express.json());
+
+  const sessionSweepTimer = setInterval(() => {
+    void sweepIdleSessions(sessions, sessionIdleTimeoutMs, Date.now());
+  }, sessionSweepIntervalMs);
+  sessionSweepTimer.unref?.();
 
   app.get("/health", (_req, res) => {
     res.json({ status: "ok", server: "fdic-mcp-server", version: VERSION });
@@ -146,6 +183,7 @@ export function createApp(options: HttpAppOptions = {}): Express {
           return;
         }
 
+        touchSession(session, Date.now());
         await session.transport.handleRequest(req, res, req.body);
         if (req.method === "DELETE") {
           await closeSession(sessions, sessionId);
@@ -165,7 +203,11 @@ export function createApp(options: HttpAppOptions = {}): Express {
         enableDnsRebindingProtection: true,
         allowedOrigins,
         onsessioninitialized: (newSessionId) => {
-          sessions.set(newSessionId, { server, transport });
+          sessions.set(newSessionId, {
+            server,
+            transport,
+            lastActivityAt: Date.now(),
+          });
         },
       });
 

--- a/src/tools/shared/queryUtils.ts
+++ b/src/tools/shared/queryUtils.ts
@@ -61,6 +61,8 @@ export async function mapWithConcurrency<T, R>(
 
   async function worker(): Promise<void> {
     while (true) {
+      // Safe under JS async concurrency: no `await` occurs between reading and
+      // incrementing `nextIndex`, so workers cannot interleave during assignment.
       const currentIndex = nextIndex;
       nextIndex += 1;
       if (currentIndex >= values.length) return;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Bug Batch 2: HTTP Transport And Protocol Bugs
+
+Reference: bugs #143 and #149 from the `bug` issue batch generated on 2026-03-16.
+
+## Goals
+
+- [x] Add idle-session cleanup for HTTP MCP sessions so abandoned sessions do not accumulate indefinitely.
+- [x] Make the `mapWithConcurrency()` safety invariant explicit in code.
+- [x] Add regression coverage for idle-session expiration.
+- [x] Validate the batch with targeted tests plus repo-standard type/build checks.
+
+## Acceptance Criteria
+
+- [x] HTTP sessions expire after a configurable idle timeout even if the client never sends `DELETE`.
+- [x] Session activity refreshes the idle deadline for active clients.
+- [x] `mapWithConcurrency()` documents why its shared `nextIndex` access is safe under JavaScript’s execution model.
+- [x] `npm test -- tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build` pass after the changes.
+
+## Review / Results
+
+- [x] Branch created for Batch 2 work: `fix/bug-batch-2-http-transport-pr`.
+- [x] Added configurable idle-session sweeping plus per-request activity refresh in [index.ts](/Users/jlamb/Projects/bankfind-mcp-batch2/src/index.ts).
+- [x] Added MCP HTTP regression coverage for session expiration and keep-alive behavior in [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp-batch2/tests/mcp-http.test.ts).
+- [x] Documented the `mapWithConcurrency()` safety invariant inline in [queryUtils.ts](/Users/jlamb/Projects/bankfind-mcp-batch2/src/tools/shared/queryUtils.ts).
+- [x] Verified `npm test -- tests/mcp-http.test.ts`, `npm run typecheck`, and `npm run build`.
+
 # Bug Batch 1: Analysis And Ranking Bugs
 
 Reference: bugs #141 and #146 from the `bug` issue batch generated on 2026-03-16.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -302,6 +302,94 @@ describe("HTTP MCP server", () => {
     expect(postDeleteResponse.body.error.message).toBe("Session not found");
   });
 
+  it("expires idle HTTP sessions even when the client never sends DELETE", async () => {
+    vi.useFakeTimers();
+    const app = createApp({
+      sessionIdleTimeoutMs: 1000,
+      sessionSweepIntervalMs: 250,
+    });
+
+    const { sessionId } = await initializeSession(app);
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("mcp-session-id", sessionId)
+      .send({
+        jsonrpc: "2.0",
+        id: 22,
+        method: "tools/list",
+        params: {},
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error.message).toBe("Session not found");
+    vi.useRealTimers();
+  });
+
+  it("refreshes the idle deadline when an HTTP session stays active", async () => {
+    vi.useFakeTimers();
+    const app = createApp({
+      sessionIdleTimeoutMs: 1000,
+      sessionSweepIntervalMs: 250,
+    });
+
+    const { sessionId } = await initializeSession(app);
+
+    await vi.advanceTimersByTimeAsync(600);
+
+    const keepAliveResponse = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("mcp-session-id", sessionId)
+      .send({
+        jsonrpc: "2.0",
+        id: 23,
+        method: "tools/list",
+        params: {},
+      });
+
+    expect(keepAliveResponse.status).toBe(200);
+
+    await vi.advanceTimersByTimeAsync(600);
+
+    const stillActiveResponse = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("mcp-session-id", sessionId)
+      .send({
+        jsonrpc: "2.0",
+        id: 24,
+        method: "tools/list",
+        params: {},
+      });
+
+    expect(stillActiveResponse.status).toBe(200);
+
+    await vi.advanceTimersByTimeAsync(1200);
+
+    const expiredResponse = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("mcp-session-id", sessionId)
+      .send({
+        jsonrpc: "2.0",
+        id: 25,
+        method: "tools/list",
+        params: {},
+      });
+
+    expect(expiredResponse.status).toBe(404);
+    expect(expiredResponse.body.error.message).toBe("Session not found");
+    vi.useRealTimers();
+  });
+
   it("accepts missing MCP-Protocol-Version after initialization and rejects unsupported versions", async () => {
     const { app, sessionId } = await initializeSession(createApp());
 


### PR DESCRIPTION
## Summary
- add idle-session expiration and sweeping for HTTP MCP sessions so abandoned sessions do not accumulate indefinitely
- refresh session activity on each request so active clients are not expired prematurely
- document why `mapWithConcurrency()` is safe under JavaScript async concurrency
- add HTTP regressions for session expiration and keep-alive behavior

## Why
Closes #143
Refs #149

The HTTP transport only cleaned up sessions on explicit DELETE, transport close, or request errors. Long-running deployments could leak sessions if clients disappeared without closing cleanly. Issue #149 is documentation-oriented rather than a functional bug, so this PR addresses it with an explicit code comment.

## Validation
- `npm test -- tests/mcp-http.test.ts`
- `npm run typecheck`
- `npm run build`

## Release impact
- patch
