### PR TITLE
fix: add docker healthcheck and runtime parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,34 @@ jobs:
       - name: Validate npm package contents
         run: npm run pack:check
 
+  docker-build:
+    name: Build Docker image (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "20.20.1"
+          - "22.22.1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg NODE_VERSION=${{ matrix.node }} \
+            --tag fdic-mcp-server:test-${{ matrix.node }} \
+            .
+
+      - name: Verify image healthcheck metadata
+        run: |
+          healthcheck="$(docker image inspect fdic-mcp-server:test-${{ matrix.node }} \
+            --format '{{json .Config.Healthcheck}}')"
+          test "$healthcheck" != "null"
+          echo "$healthcheck"
+
   ci-required:
     name: CI required
     runs-on: ubuntu-latest
@@ -82,6 +110,7 @@ jobs:
       - actionlint
       - commitlint
       - validate
+      - docker-build
     if: ${{ always() }}
 
     steps:
@@ -94,6 +123,11 @@ jobs:
 
           if [ "${{ needs.validate.result }}" != "success" ]; then
             echo "validate result: ${{ needs.validate.result }}"
+            exit 1
+          fi
+
+          if [ "${{ needs.docker-build.result }}" != "success" ]; then
+            echo "docker-build result: ${{ needs.docker-build.result }}"
             exit 1
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-bookworm-slim AS build
+ARG NODE_VERSION=22.22.1
+
+FROM node:${NODE_VERSION}-bookworm-slim AS build
 
 WORKDIR /app
 
@@ -10,7 +12,7 @@ COPY scripts ./scripts
 COPY tsconfig.json ./
 RUN npm run build && npm prune --omit=dev
 
-FROM node:22-bookworm-slim
+FROM node:${NODE_VERSION}-bookworm-slim
 
 ENV NODE_ENV=production
 ENV TRANSPORT=http
@@ -27,6 +29,9 @@ COPY --chown=fdicmcp:fdicmcp --from=build /app/node_modules ./node_modules
 COPY --chown=fdicmcp:fdicmcp --from=build /app/dist ./dist
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["node", "-e", "fetch('http://localhost:8080/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"]
 
 USER fdicmcp
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# Docker Healthcheck And Runtime Parity
+
+Reference: issues #139 and #147.
+
+## Goals
+
+- [x] Add a container `HEALTHCHECK` that exercises the existing `/health` endpoint.
+- [x] Make the Dockerfile runtime version explicit and reproducible instead of relying on a mutable major tag.
+- [x] Add CI coverage that actually builds the Docker image across the supported container runtime matrix.
+- [x] Validate the batch with repo-standard checks plus Dockerfile/workflow verification.
+
+## Acceptance Criteria
+
+- [x] `Dockerfile` includes a non-shell `HEALTHCHECK` that fails when `http://localhost:8080/health` is unavailable or non-OK.
+- [x] The Docker base image is pinned to a specific published Node 22 patch version by default.
+- [x] CI adds a Docker build job that builds the container with both Node 20 and Node 22 image args so Dockerfile regressions are caught in the same matrix CI claims to support.
+- [x] Repo-standard validation passes after the changes.
+
+## Validation
+
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run build`
+- [x] Parse the updated workflow YAML successfully.
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/issues-139-147-docker-runtime-parity`.
+- [x] Pinned the Docker build and runtime stages to `node:22.22.1-bookworm-slim` by default while keeping `NODE_VERSION` overrideable for CI matrix builds.
+- [x] Added a JSON-array `HEALTHCHECK` that probes the existing HTTP `/health` endpoint.
+- [x] Added CI Docker image builds for `20.20.1` and `22.22.1`, then asserted that the built images carry `Healthcheck` metadata.
+
 # Bug Batch 4: CI, Release, And Deployment Bugs
 
 Reference: bug #144 from the `bug` issue batch generated on 2026-03-16.


### PR DESCRIPTION
Closes #139
Closes #147

## Summary
- pin the Docker build/runtime stages to `node:22.22.1-bookworm-slim` by default and keep `NODE_VERSION` overrideable for CI
- add a container `HEALTHCHECK` that probes the existing `/health` endpoint
- add CI Docker image builds for Node `20.20.1` and `22.22.1`, and fail CI if the built image has no healthcheck metadata

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |path| YAML.load_file(path); puts path }'`\n\n## Notes\n- Docker is not installed in the local workspace, so container-build execution is delegated to GitHub Actions via the new `docker-build` job.