### PR TITLE
test: cover mapWithConcurrency scheduling

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -857,3 +857,24 @@ Reference: user request to add a shortcut for reviewing issues by label and grou
 - [x] Documented the helper in [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md) so label-driven maintenance passes start from an explicit batch review step.
 - [x] Added the prompt shorthand `/issue-batch <label>` to [AGENTS.md](/Users/jlamb/Projects/bankfind-mcp/AGENTS.md) and [prompting-guide.md](/Users/jlamb/Projects/bankfind-mcp/docs/prompting-guide.md) for AI-driven orchestration.
 - [x] Run `npm run typecheck`, `npm test -- tests/issue-batching.test.ts`, and `npm run build`.
+# Issue #149: mapWithConcurrency Safety Follow-Up
+
+Reference: issue #149.
+
+## Goals
+
+- [x] Add direct regression coverage for `mapWithConcurrency()` so its async work distribution contract is exercised, not just documented.
+- [x] Keep the current implementation and safety comment intact unless testing exposes a real behavioral defect.
+- [x] Validate with targeted tests plus repo-standard type/build checks.
+
+## Acceptance Criteria
+
+- [x] `mapWithConcurrency()` maps every input exactly once under interleaved async completion and preserves result ordering.
+- [x] `mapWithConcurrency()` does not exceed the requested concurrency limit while work is in flight.
+- [x] `npm test -- tests/queryUtils.test.ts`, `npm run typecheck`, and `npm run build` pass after the change.
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/issue-149-map-with-concurrency-tests`.
+- [x] Added direct `mapWithConcurrency()` regression coverage in [queryUtils.test.ts](/Users/jlamb/Projects/bankfind-mcp/tests/queryUtils.test.ts) for out-of-order async completion and in-flight concurrency limits.
+- [x] Verified `npm test -- tests/queryUtils.test.ts`, `npm run typecheck`, and `npm run build`.

--- a/tests/queryUtils.test.ts
+++ b/tests/queryUtils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildFilterString } from "../src/tools/shared/queryUtils.js";
+import {
+  buildFilterString,
+  mapWithConcurrency,
+} from "../src/tools/shared/queryUtils.js";
 
 describe("buildFilterString", () => {
   it("returns undefined when no filters are provided", () => {
@@ -42,5 +45,42 @@ describe("buildFilterString", () => {
         rawFiltersPosition: "last",
       }),
     ).toBe('CERT:3511 AND (CITY:"Austin")');
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("processes each input exactly once and preserves result ordering", async () => {
+    const values = [10, 20, 30, 40, 50];
+    const startedIndices: number[] = [];
+    const completedIndices: number[] = [];
+
+    const results = await mapWithConcurrency(values, 3, async (value, index) => {
+      startedIndices.push(index);
+      await new Promise((resolve) => setTimeout(resolve, values.length - index));
+      completedIndices.push(index);
+      return `${index}:${value}`;
+    });
+
+    expect(startedIndices.sort((left, right) => left - right)).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    expect(completedIndices).not.toEqual([0, 1, 2, 3, 4]);
+    expect(results).toEqual(["0:10", "1:20", "2:30", "3:40", "4:50"]);
+  });
+
+  it("does not exceed the configured concurrency limit", async () => {
+    const values = Array.from({ length: 8 }, (_, index) => index);
+    let active = 0;
+    let maxActive = 0;
+
+    await mapWithConcurrency(values, 3, async (value) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return value;
+    });
+
+    expect(maxActive).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- add direct regression coverage for \
- verify every index is processed exactly once with stable result ordering
- assert the helper does not exceed the configured in-flight concurrency limit

## Validation
- npm test -- tests/queryUtils.test.ts
- npm run typecheck
- npm run build

Closes #149