### PR TITLE
fix: validate peer group extra fields

### DIFF
--- a/src/services/fdicSchema.ts
+++ b/src/services/fdicSchema.ts
@@ -26,6 +26,28 @@ function quoteFieldList(fields: string[]): string {
   return fields.map((field) => `'${field}'`).join(", ");
 }
 
+export function findInvalidEndpointFields(
+  endpoint: string,
+  fields: string[],
+): string[] {
+  const metadata = getEndpointMetadata(endpoint);
+  if (!metadata) {
+    return [];
+  }
+
+  return fields.filter((field) => metadata.fields[field] === undefined);
+}
+
+export function buildInvalidFieldError(
+  endpoint: string,
+  invalidFields: string[],
+): Error {
+  return new Error(
+    `Invalid field ${quoteFieldList(invalidFields)} for endpoint ${endpoint}. ` +
+      `Use the endpoint-specific field catalog for ${endpoint}.`,
+  );
+}
+
 export function getEndpointMetadata(endpoint: string) {
   const baseMetadata = FDIC_ENDPOINT_METADATA[endpoint];
   if (!baseMetadata) {
@@ -67,15 +89,10 @@ export function validateEndpointQueryParams(
 
   if (params.fields) {
     const requestedFields = parseCommaSeparatedFields(params.fields);
-    const invalidFields = requestedFields.filter(
-      (field) => metadata.fields[field] === undefined,
-    );
+    const invalidFields = findInvalidEndpointFields(endpoint, requestedFields);
 
     if (invalidFields.length > 0) {
-      throw new Error(
-        `Invalid field ${quoteFieldList(invalidFields)} for endpoint ${endpoint}. ` +
-          `Use the endpoint-specific field catalog for ${endpoint}.`,
-      );
+      throw buildInvalidFieldError(endpoint, invalidFields);
     }
   }
 

--- a/src/tools/peerGroup.ts
+++ b/src/tools/peerGroup.ts
@@ -14,6 +14,10 @@ import {
   formatToolError,
 } from "../services/fdicClient.js";
 import {
+  buildInvalidFieldError,
+  findInvalidEndpointFields,
+} from "../services/fdicSchema.js";
+import {
   ANALYSIS_TIMEOUT_MS,
   MAX_CONCURRENCY,
   asNumber,
@@ -245,6 +249,24 @@ function validatePeerGroupParams(value: PeerGroupParams): string | null {
   return null;
 }
 
+function validateExtraFields(
+  extraFields: string[] | undefined,
+): Error | null {
+  if (!extraFields || extraFields.length === 0) {
+    return null;
+  }
+
+  const invalidFields = findInvalidEndpointFields(
+    ENDPOINTS.FINANCIALS,
+    extraFields,
+  );
+  if (invalidFields.length === 0) {
+    return null;
+  }
+
+  return buildInvalidFieldError(ENDPOINTS.FINANCIALS, invalidFields);
+}
+
 const FINANCIAL_FIELDS =
   "CERT,ASSET,DEP,NETINC,ROA,ROE,NETNIM,EQTOT,LNLSNET,INTINC,EINTEXP,NONII,NONIX";
 
@@ -403,6 +425,11 @@ Override precedence: cert derives defaults, then explicit params override them.`
         const validationError = validatePeerGroupParams(params);
         if (validationError) {
           return formatToolError(new Error(validationError));
+        }
+
+        const extraFieldsError = validateExtraFields(params.extra_fields);
+        if (extraFieldsError) {
+          return formatToolError(extraFieldsError);
         }
 
         await sendProgressNotification(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Issue #148: Peer Group extra_fields Validation
+
+Reference: issue #148.
+
+## Goals
+
+- [x] Validate `fdic_peer_group_analysis.extra_fields` against the financials endpoint field catalog before any FDIC API call.
+- [x] Return a clear error that lists invalid field names while preserving the existing tool contract for valid requests.
+- [x] Add regression coverage for both invalid and valid `extra_fields` behavior.
+- [x] Validate with repo-standard commands and record the final review outcome.
+
+## Acceptance Criteria
+
+- [x] Invalid `extra_fields` entries are rejected before any upstream FDIC request is attempted.
+- [x] The error message clearly lists the invalid field names.
+- [x] Valid `extra_fields` values are still included as raw values in peer-group output.
+- [x] `npm run typecheck`, `npm test`, and `npm run build` pass after the change.
+
+## Validation
+
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run build`
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/issue-148-peer-group-extra-fields-validation`.
+- [x] Reused the shared endpoint metadata catalog in [fdicSchema.ts](/Users/jlamb/Projects/bankfind-mcp/src/services/fdicSchema.ts) so peer-group validation and low-level query validation use the same invalid-field detection and error wording.
+- [x] Added an early `extra_fields` guard in [peerGroup.ts](/Users/jlamb/Projects/bankfind-mcp/src/tools/peerGroup.ts) so invalid requests fail before progress or FDIC API calls begin.
+- [x] Added MCP HTTP regression coverage for invalid and valid `extra_fields` requests in [mcp-http.test.ts](/Users/jlamb/Projects/bankfind-mcp/tests/mcp-http.test.ts).
+
 # Docker Healthcheck And Runtime Parity
 
 Reference: issues #139 and #147.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -2619,6 +2619,29 @@ describe("HTTP MCP server", () => {
     );
   });
 
+  it("rejects invalid peer-group extra_fields before calling the FDIC API", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 1023,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: {
+          repdte: "20241231",
+          asset_min: 5000000,
+          extra_fields: ["CERT", "FAILDATE"],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.isError).toBe(true);
+    expect(response.body.result.content[0].text).toContain(
+      "Invalid field 'FAILDATE' for endpoint financials.",
+    );
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
   it("warns when a peer-group financial batch is truncated by the FDIC API limit", async () => {
     getMock
       .mockResolvedValueOnce({
@@ -2750,5 +2773,51 @@ describe("HTTP MCP server", () => {
         (peer: { cert: number }) => peer.cert,
       ),
     ).toEqual([200, 300]);
+  });
+
+  it("includes valid peer-group extra_fields as raw values in structured output", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, NAME: "Peer A", CITY: "Raleigh", STALP: "NC", BKCLASS: "N" } },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            { data: { CERT: 200, ASSET: 5000000, DEPDOM: 3500000, DEP: 4000000, NETINC: 100000, ROA: 1.0, ROE: 9.0, NETNIM: 3.0, EQTOT: 500000, LNLSNET: 3000000, INTINC: 200000, EINTEXP: 80000, NONII: 30000, NONIX: 100000 } },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 106,
+      method: "tools/call",
+      params: {
+        name: "fdic_peer_group_analysis",
+        arguments: {
+          repdte: "20241231",
+          asset_min: 5000000,
+          asset_max: 6000000,
+          charter_classes: ["N"],
+          state: "NC",
+          extra_fields: ["DEPDOM"],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.isError).not.toBe(true);
+    expect(response.body.result.structuredContent.peers).toEqual([
+      expect.objectContaining({
+        cert: 200,
+        DEPDOM: 3500000,
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
Closes #148.

## Summary
- validate `fdic_peer_group_analysis.extra_fields` against the financials endpoint metadata before any FDIC API calls
- reuse shared invalid-field detection and error construction so peer-group and low-level query validation stay aligned
- add MCP HTTP regression coverage for invalid and valid `extra_fields` requests

## Validation
- npm run typecheck
- npm test
- npm run build

## Risk
- low; valid `extra_fields` behavior is preserved and now covered by regression tests
