### PR TITLE
fix: simplify extractRecords for validated responses

### DIFF
--- a/src/services/fdicClient.ts
+++ b/src/services/fdicClient.ts
@@ -241,14 +241,7 @@ export async function queryEndpoint(
 export function extractRecords(
   response: FdicResponse,
 ): Array<Record<string, unknown>> {
-  return response.data.map((item, index) => {
-    if (!isRecord(item) || !isRecord(item.data)) {
-      throw new Error(
-        `Unexpected FDIC API response shape: expected data[${index}] to contain an object 'data' property.`,
-      );
-    }
-    return item.data;
-  });
+  return response.data.map((item) => item.data);
 }
 
 export function buildPaginationInfo(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -939,3 +939,33 @@ Reference: issue #149.
 - [x] Branch created for this work: `fix/issue-149-map-with-concurrency-tests`.
 - [x] Added direct `mapWithConcurrency()` regression coverage in [queryUtils.test.ts](/Users/jlamb/Projects/bankfind-mcp/tests/queryUtils.test.ts) for out-of-order async completion and in-flight concurrency limits.
 - [x] Verified `npm test -- tests/queryUtils.test.ts`, `npm run typecheck`, and `npm run build`.
+
+# Issue #136: extractRecords Dead Validation
+
+Reference: issue #136.
+
+## Goals
+
+- [x] Remove the unreachable `extractRecords()` record-wrapper validation that duplicates `validateFdicResponseShape()`.
+- [x] Keep the public FDIC client contract unchanged for validated responses.
+- [x] Update tests to assert the real invariant boundary instead of direct misuse of `extractRecords()`.
+- [x] Validate with repo-standard commands and record the result.
+
+## Acceptance Criteria
+
+- [x] `extractRecords()` is a plain projection from validated response wrappers to record payloads.
+- [x] Malformed FDIC record wrappers are still rejected before callers receive an `FdicResponse`.
+- [x] `npm run typecheck`, `npm test`, and `npm run build` pass after the change.
+
+## Validation
+
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run build`
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/issue-136-extract-records`.
+- [x] Simplified [fdicClient.ts](/Users/jlamb/Projects/bankfind-mcp/src/services/fdicClient.ts) so `extractRecords()` now trusts the validated `FdicResponse` shape guaranteed by `validateFdicResponseShape()`.
+- [x] Updated [fdicClient.test.ts](/Users/jlamb/Projects/bankfind-mcp/tests/fdicClient.test.ts) to cover extracting records from a validated response instead of expecting unreachable dead-code errors from `extractRecords()`.
+- [x] Verified `npm run typecheck`, `npm test`, and `npm run build`.

--- a/tests/fdicClient.test.ts
+++ b/tests/fdicClient.test.ts
@@ -312,24 +312,13 @@ describe("fdicClient", () => {
     );
   });
 
-  it("extracts data records from the FDIC response", () => {
-    expect(
-      extractRecords({
-        data: [{ data: { CERT: 1 } }, { data: { CERT: 2 } }],
-        meta: { total: 2 },
-      }),
-    ).toEqual([{ CERT: 1 }, { CERT: 2 }]);
-  });
+  it("extracts records from a validated FDIC response", () => {
+    const response = validateFdicResponseShape("institutions", {
+      data: [{ data: { CERT: 1 } }, { data: { CERT: 2 } }],
+      meta: { total: 2 },
+    });
 
-  it("throws a clear error when extractRecords receives malformed entries", () => {
-    expect(() =>
-      extractRecords({
-        data: [{ CERT: 1 } as unknown as { data: Record<string, unknown> }],
-        meta: { total: 1 },
-      }),
-    ).toThrow(
-      "Unexpected FDIC API response shape: expected data[0] to contain an object 'data' property.",
-    );
+    expect(extractRecords(response)).toEqual([{ CERT: 1 }, { CERT: 2 }]);
   });
 
   it("validates a well-formed FDIC response payload", () => {


### PR DESCRIPTION
## Summary
- remove the unreachable record-wrapper validation from extractRecords()
- keep malformed wrapper rejection at validateFdicResponseShape() where the FDIC response boundary is enforced
- align fdic client tests and task tracking with the validated-response invariant

## Testing
- npm run typecheck
- npm test
- npm run build

Closes #136
