### PR TITLE
fix: address docs-site review v2 follow-up

### DIFF
--- a/docs/_includes/mobile-page-toc.html
+++ b/docs/_includes/mobile-page-toc.html
@@ -1,4 +1,6 @@
-<details class="mobile-page-toc" data-mobile-page-toc-root hidden>
-  <summary>On this page</summary>
-  <nav aria-label="On this page" data-mobile-page-toc></nav>
-</details>
+<nav class="mobile-page-toc" aria-label="On this page" data-mobile-page-toc-root hidden>
+  <details>
+    <summary>On this page</summary>
+    <div data-mobile-page-toc></div>
+  </details>
+</nav>

--- a/docs/_includes/page-toc.html
+++ b/docs/_includes/page-toc.html
@@ -1,6 +1,6 @@
-<section class="page-toc" data-page-toc-root hidden>
+<nav class="page-toc" aria-label="On this page" data-page-toc-root hidden>
   <div class="page-toc__card">
     <p class="page-toc__eyebrow">On this page</p>
-    <nav aria-label="On this page" data-page-toc></nav>
+    <div data-page-toc></div>
   </div>
-</section>
+</nav>

--- a/docs/_includes/search-dialog.html
+++ b/docs/_includes/search-dialog.html
@@ -21,7 +21,7 @@
       data-search-input
     >
 
-    <p class="search-dialog__status" data-search-status>Start typing to search the documentation.</p>
-    <div class="search-results" data-search-results></div>
+    <p class="search-dialog__status" data-search-status role="status" aria-live="polite">Start typing to search the documentation.</p>
+    <div class="search-results" data-search-results aria-live="polite"></div>
   </div>
 </div>

--- a/docs/_includes/section-nav.html
+++ b/docs/_includes/section-nav.html
@@ -15,17 +15,19 @@
 <section class="section-nav" aria-label="{{ current_section.title }}">
   <div class="section-nav__header">
     <p class="section-nav__eyebrow">In this section</p>
-    <h2>{{ current_section.title }}</h2>
+    <p class="section-nav__title">{{ current_section.title }}</p>
     {% if current_section.description %}
     <p>{{ current_section.description }}</p>
     {% endif %}
   </div>
-  <div class="section-nav__links">
-    {% for item in current_section.items %}
-    <a href="{{ item.url | relative_url }}"{% if item.url == page.url %} class="is-active" aria-current="page"{% endif %}>
-      {{ item.short_title | default: item.title }}
-    </a>
-    {% endfor %}
+  <div class="section-nav__links-wrap">
+    <div class="section-nav__links">
+      {% for item in current_section.items %}
+      <a href="{{ item.url | relative_url }}"{% if item.url == page.url %} class="is-active" aria-current="page"{% endif %}>
+        {{ item.short_title | default: item.title }}
+      </a>
+      {% endfor %}
+    </div>
   </div>
 </section>
 {% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,7 +26,7 @@
               <span aria-hidden="true">Search</span>
               <span class="search-button__hint">/</span>
             </button>
-            <button type="button" class="nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav" aria-label="Site navigation">
               <span>Menu</span>
             </button>
           </div>

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -284,15 +284,20 @@ img {
   color: var(--accent);
 }
 
-.section-nav__header h2 {
+.section-nav__title {
   margin: 0;
   font-size: 1.1rem;
+  font-weight: 700;
 }
 
 .section-nav__header p:last-child {
   margin: 0.35rem 0 0;
   color: var(--muted);
   font-size: 0.95rem;
+}
+
+.section-nav__links-wrap {
+  position: relative;
 }
 
 .section-nav__links {
@@ -706,8 +711,8 @@ img {
   box-shadow: var(--shadow-sm);
 }
 
-.page-toc nav,
-.mobile-page-toc nav {
+.page-toc [data-page-toc],
+.mobile-page-toc [data-mobile-page-toc] {
   display: grid;
   gap: 0.32rem;
 }
@@ -749,7 +754,7 @@ img {
   color: var(--ink-soft);
 }
 
-.mobile-page-toc[open] nav {
+.mobile-page-toc details[open] [data-mobile-page-toc] {
   margin-top: 0.8rem;
 }
 
@@ -895,6 +900,14 @@ img {
   display: grid;
   gap: 0.8rem;
   margin-top: 1rem;
+  min-height: 1.5rem;
+}
+
+.search-results[data-loading="true"]::before {
+  content: "Searching...";
+  color: var(--muted);
+  font-weight: 600;
+  animation: search-pulse 1s ease-in-out infinite;
 }
 
 .search-result {
@@ -928,6 +941,17 @@ img {
 .search-result p {
   margin: 0;
   color: var(--muted);
+}
+
+@keyframes search-pulse {
+  0%,
+  100% {
+    opacity: 0.52;
+  }
+
+  50% {
+    opacity: 1;
+  }
 }
 
 .search-result mark {
@@ -1051,6 +1075,29 @@ img {
   .hero-grid {
     grid-template-columns: minmax(0, 1fr);
   }
+
+  .section-nav__links-wrap::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0.15rem;
+    width: 2.5rem;
+    pointer-events: none;
+    background: linear-gradient(90deg, rgba(244, 247, 241, 0), rgba(244, 247, 241, 0.96));
+  }
+
+  .section-nav__links {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    padding-bottom: 0.15rem;
+  }
+
+  .section-nav__links a {
+    flex: 0 0 auto;
+  }
 }
 
 @media (max-width: 760px) {
@@ -1089,16 +1136,6 @@ img {
 
   .section-nav {
     padding: 0.95rem;
-  }
-
-  .section-nav__links {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 0.15rem;
-  }
-
-  .section-nav__links a {
-    flex: 0 0 auto;
   }
 
   .card-grid {
@@ -1170,6 +1207,59 @@ img {
   }
 }
 
+@media print {
+  body {
+    background: #ffffff;
+    color: #000000;
+  }
+
+  .skip-link,
+  .site-header,
+  .section-nav,
+  .page-toc,
+  .mobile-page-toc,
+  .prev-next,
+  .site-footer,
+  .search-dialog {
+    display: none !important;
+  }
+
+  .page-shell {
+    padding: 0;
+  }
+
+  .page-frame {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: #ffffff;
+    box-shadow: none;
+  }
+
+  .page-layout {
+    display: block;
+  }
+
+  .page-header {
+    padding: 0 0 1rem;
+    background: none;
+    border: 0;
+  }
+
+  a,
+  a:visited {
+    color: #000000;
+  }
+}
+
+@media (prefers-color-scheme: dark) and (max-width: 960px) {
+  .section-nav__links-wrap::after {
+    background: linear-gradient(90deg, rgba(13, 24, 21, 0), rgba(13, 24, 21, 0.96));
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
@@ -1224,7 +1314,6 @@ img {
   .mobile-nav__panel {
     background: rgba(13, 24, 21, 0.97);
   }
-
   .search-dialog__input {
     background: rgba(9, 19, 16, 0.96);
     color: var(--ink);

--- a/docs/assets/js/docs.js
+++ b/docs/assets/js/docs.js
@@ -241,24 +241,41 @@ const getSectionLabel = (meta) => {
 
 const initSearch = () => {
   const dialog = document.querySelector("[data-search-dialog]");
+  const panel = dialog?.querySelector(".search-dialog__panel");
   const input = document.querySelector("[data-search-input]");
   const status = document.querySelector("[data-search-status]");
   const results = document.querySelector("[data-search-results]");
   const openButtons = document.querySelectorAll("[data-search-open]");
   const closeButtons = document.querySelectorAll("[data-search-close]");
 
-  if (!dialog || !input || !status || !results) {
+  if (!dialog || !panel || !input || !status || !results) {
     return;
   }
 
   let currentQuery = "";
+  let activeTrigger = null;
+
+  const getFocusableElements = () =>
+    Array.from(
+      panel.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true");
+
+  const setSearchLoading = (isLoading) => {
+    results.dataset.loading = isLoading ? "true" : "false";
+    results.setAttribute("aria-busy", String(isLoading));
+  };
 
   const close = () => {
     dialog.hidden = true;
     document.body.style.overflow = "";
+    setSearchLoading(false);
+    activeTrigger?.focus();
   };
 
-  const open = async () => {
+  const open = async (trigger = null) => {
+    activeTrigger = trigger;
     const mobileNav = document.querySelector("[data-mobile-nav]");
     const navToggle = document.querySelector("[data-nav-toggle]");
     if (mobileNav && !mobileNav.hidden) {
@@ -288,13 +305,15 @@ const initSearch = () => {
     results.innerHTML = "";
 
     if (!query.trim()) {
+      setSearchLoading(false);
       status.textContent = "Start typing to search the documentation.";
       return;
     }
 
     try {
-      const pagefind = await loadPagefind();
       status.textContent = "Searching...";
+      setSearchLoading(true);
+      const pagefind = await loadPagefind();
       const response = await pagefind.search(query);
 
       if (query !== currentQuery) {
@@ -302,6 +321,7 @@ const initSearch = () => {
       }
 
       if (!response.results.length) {
+        setSearchLoading(false);
         status.textContent = `No results for "${query}".`;
         return;
       }
@@ -332,7 +352,10 @@ const initSearch = () => {
         link.append(meta, title, excerpt);
         results.appendChild(link);
       });
+
+      setSearchLoading(false);
     } catch {
+      setSearchLoading(false);
       status.textContent = "Search is unavailable in this build.";
     }
   };
@@ -342,12 +365,41 @@ const initSearch = () => {
   }, 120);
 
   input.addEventListener("input", debouncedSearch);
-  openButtons.forEach((button) => button.addEventListener("click", open));
+  openButtons.forEach((button) =>
+    button.addEventListener("click", () => {
+      open(button);
+    }),
+  );
   closeButtons.forEach((button) => button.addEventListener("click", close));
 
   dialog.addEventListener("click", (event) => {
     if (event.target === dialog) {
       close();
+    }
+  });
+
+  panel.addEventListener("keydown", (event) => {
+    if (event.key !== "Tab" || dialog.hidden) {
+      return;
+    }
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
   });
 
@@ -360,7 +412,7 @@ const initSearch = () => {
 
       if (!isTyping) {
         event.preventDefault();
-        open();
+        open(document.activeElement instanceof HTMLElement ? document.activeElement : null);
       }
     }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,9 +126,3 @@ Expected behavior:
 - the model should call `fdic_search_institutions`
 - filters should include `STNAME:"North Carolina"`, `ACTIVE:1`, and `ASSET:[1000000 TO *]`
 - results should come back with both human-readable output and machine-readable `structuredContent`
-
-## What To Read Next
-
-- [Prompting Guide]({{ '/prompting-guide/' | relative_url }})
-- [Usage Examples]({{ '/usage-examples/' | relative_url }})
-- [Technical Specification]({{ '/technical/specification/' | relative_url }})

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1071,3 +1071,49 @@ Reference: issue #165 and the `Deploy Docs` warning emitted on 2026-03-17 for No
 - [x] Added workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` in [pages.yml](/Users/jlamb/Projects/bankfind-mcp-pagesfix/.github/workflows/pages.yml) so the existing Pages action chain runs on Node 24 without changing action contracts.
 - [x] Reopened issue #165 after confirming the previous merged fix did not clear the warning on the next `Deploy Docs` run.
 - [x] Added explicit job-level Node 24 opt-in env blocks to both jobs in [pages.yml](/Users/jlamb/Projects/bankfind-mcp-pagesfix/.github/workflows/pages.yml).
+
+# Issue #168: Docs-Site Review V2 Follow-Up
+
+Reference: issue #168 and the findings captured in `docs-site-review-v2.html`.
+
+## Goals
+
+- [x] Fix the docs front-end accessibility and semantics gaps called out in the v2 review.
+- [x] Apply the remaining UX polish items without regressing the existing docs-site navigation system.
+- [x] Validate with repo-standard commands plus a local docs-site build and search index generation.
+- [ ] Carry the change through PR, merge, and GitHub Pages deployment verification.
+
+## Acceptance Criteria
+
+- [x] Inner pages no longer render a section-nav `<h2>` ahead of the page `<h1>`.
+- [x] Desktop and mobile TOC components expose explicit `On this page` navigation landmarks.
+- [x] The mobile nav toggle has a stable explicit accessible label.
+- [x] The search dialog traps focus while open and retains Escape-to-close behavior.
+- [x] Redundant manual `What To Read Next` content is removed where auto-generated prev/next navigation already exists.
+- [x] Section-nav pills stay compact and horizontally scrollable on narrow desktop and tablet widths.
+- [x] Search shows an in-dialog loading state while results are being resolved.
+- [x] Print styles hide docs chrome and render the page content cleanly.
+- [x] `npm run typecheck`, `npm test`, `npm run build`, local Jekyll build, and `npm run docs:search` succeed.
+- [ ] The merged branch produces a successful `Deploy Docs` run on `main`.
+
+## Validation
+
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run build`
+- [x] `~/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site`
+- [x] `npm run docs:search`
+- [ ] PR checks pass
+- [ ] Post-merge `Deploy Docs` run succeeds
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/docs-site-review-v2`.
+- [x] Issue opened for this work: #168.
+- [x] Reworked [section-nav.html](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/_includes/section-nav.html), [page-toc.html](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/_includes/page-toc.html), [mobile-page-toc.html](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/_includes/mobile-page-toc.html), and [default.html](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/_layouts/default.html) so the docs shell now uses cleaner heading order, explicit TOC navigation landmarks, and a labeled mobile nav toggle.
+- [x] Updated [docs.js](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/assets/js/docs.js) and [search-dialog.html](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/_includes/search-dialog.html) to add an in-dialog loading state, focus trapping, and focus restoration for the search modal.
+- [x] Extended [docs.css](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/assets/css/docs.css) with narrow-width section-nav overflow handling and print-only cleanup for docs chrome.
+- [x] Removed the redundant manual read-next block from [getting-started.md](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/docs/getting-started.md).
+- [x] Added lightweight docs-shell regression coverage in [docs-site.test.ts](/Users/jlamb/Projects/bankfind-mcp-docs-review-v2/tests/docs-site.test.ts).
+- [x] Verified `npm run typecheck`, `npm test`, `npm run build`, `~/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site`, and `npm run docs:search`.
+- [x] Verified locally in a browser against the built `_site` that the section nav no longer precedes the page H1 semantically, the TOC landmarks render correctly, the search dialog traps Tab focus, Escape closes it, and focus returns to the opener.

--- a/tests/docs-site.test.ts
+++ b/tests/docs-site.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+
+const readRepoFile = (relativePath: string) =>
+  readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+describe("docs site review v2 follow-up", () => {
+  it("keeps section navigation descriptive without introducing a heading before the page h1", () => {
+    const sectionNav = readRepoFile("docs/_includes/section-nav.html");
+
+    expect(sectionNav).toContain('<p class="section-nav__title">');
+    expect(sectionNav).not.toContain("<h2>");
+  });
+
+  it("marks desktop and mobile page toc containers as navigation landmarks", () => {
+    const pageToc = readRepoFile("docs/_includes/page-toc.html");
+    const mobilePageToc = readRepoFile("docs/_includes/mobile-page-toc.html");
+
+    expect(pageToc).toContain('<nav class="page-toc" aria-label="On this page"');
+    expect(mobilePageToc).toContain('<nav class="mobile-page-toc" aria-label="On this page"');
+  });
+
+  it("keeps the mobile nav toggle labeled and the search dialog focus-managed", () => {
+    const layout = readRepoFile("docs/_layouts/default.html");
+    const docsScript = readRepoFile("docs/assets/js/docs.js");
+
+    expect(layout).toContain('aria-label="Site navigation"');
+    expect(docsScript).toContain('panel.addEventListener("keydown"');
+    expect(docsScript).toContain('results.dataset.loading = isLoading ? "true" : "false"');
+  });
+
+  it("removes the redundant getting started read-next block and keeps print cleanup styles", () => {
+    const gettingStarted = readRepoFile("docs/getting-started.md");
+    const docsCss = readRepoFile("docs/assets/css/docs.css");
+
+    expect(gettingStarted).not.toContain("## What To Read Next");
+    expect(docsCss).toContain("@media print");
+    expect(docsCss).toContain(".prev-next");
+    expect(docsCss).toContain(".site-footer");
+  });
+});


### PR DESCRIPTION
## Summary
- fix the remaining docs-site review v2 accessibility and polish issues in the Jekyll front-end
- add search-dialog focus trapping/loading feedback plus TOC/section-nav semantic cleanup
- remove the redundant Getting Started read-next block and add lightweight docs-shell regression coverage

Closes #168.

## Validation
- npm run typecheck
- npm test
- npm run build
- ~/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site
- npm run docs:search
- local browser smoke test against built `_site` for heading order, TOC landmarks, and search modal focus behavior
