### PR TITLE
fix: fully hide skip link until focused

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -66,7 +66,7 @@ img {
 
 .skip-link {
   position: absolute;
-  top: -3rem;
+  top: 1rem;
   left: 1rem;
   z-index: 50;
   padding: 0.75rem 1rem;
@@ -74,11 +74,12 @@ img {
   background: var(--ink);
   color: var(--surface-strong);
   text-decoration: none;
-  transition: top 160ms ease;
+  transform: translateY(-200%);
+  transition: transform 160ms ease;
 }
 
 .skip-link:focus {
-  top: 1rem;
+  transform: translateY(0);
 }
 
 .site-shell {


### PR DESCRIPTION
## Summary
- switch the docs skip link from negative top positioning to transform-based hiding
- keep the link at its visible focused position while ensuring it is fully off-screen by default
- preserve keyboard accessibility without the clipped sliver at the top-left of the viewport

## Validation
- npm run build
- ~/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site
- local browser check confirming the skip link is fully above the viewport by default and appears on first Tab focus
