### PR TITLE
fix: align lone docs next link to the right

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -789,6 +789,10 @@ img {
   text-align: right;
 }
 
+.prev-next > .prev-next__link--next:only-child {
+  grid-column: 2;
+}
+
 .prev-next__direction {
   font-size: 0.76rem;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- move a lone docs prev/next "Next" card into the second grid column
- keep the footer pagination visually aligned when there is no previous link

## Validation
- npx vitest run tests/docs-site.test.ts

## Risk
- low; CSS-only change scoped to the docs prev/next component