### PR TITLE
feat: animate docs primary navigation indicator

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -82,6 +82,16 @@ img {
   transform: translateY(0);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .top-nav__indicator {
+    transition: none;
+  }
+}
+
 .site-shell {
   min-height: 100vh;
 }
@@ -135,12 +145,16 @@ img {
 }
 
 .top-nav {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 0.45rem;
+  isolation: isolate;
 }
 
 .top-nav a {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   min-height: 2.5rem;
@@ -157,8 +171,36 @@ img {
   background: var(--accent-soft);
 }
 
+.top-nav--animated a:hover,
+.top-nav--animated a.is-active {
+  background: transparent;
+}
+
 .top-nav a.is-active {
   box-shadow: inset 0 0 0 1px rgba(13, 122, 102, 0.12);
+}
+
+.top-nav--animated a.is-active {
+  box-shadow: none;
+}
+
+.top-nav__indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg, rgba(216, 239, 232, 0.96), rgba(207, 154, 53, 0.12));
+  box-shadow:
+    inset 0 0 0 1px rgba(13, 122, 102, 0.12),
+    0 12px 24px rgba(10, 37, 31, 0.08);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 160ms ease;
 }
 
 .search-button,
@@ -1331,6 +1373,15 @@ img {
   .mobile-nav__panel {
     background: rgba(13, 24, 21, 0.97);
   }
+
+  .top-nav__indicator {
+    background:
+      linear-gradient(135deg, rgba(17, 33, 29, 0.96), rgba(31, 62, 54, 0.94));
+    box-shadow:
+      inset 0 0 0 1px rgba(111, 208, 184, 0.16),
+      0 12px 24px rgba(0, 0, 0, 0.24);
+  }
+
   .search-dialog__input {
     background: rgba(9, 19, 16, 0.96);
     color: var(--ink);

--- a/docs/assets/js/docs.js
+++ b/docs/assets/js/docs.js
@@ -91,6 +91,78 @@ const ensureHeadingIds = (headings) => {
   });
 };
 
+const initPrimaryNavIndicator = () => {
+  const navs = Array.from(document.querySelectorAll(".top-nav")).filter(
+    (nav) => !nav.closest(".mobile-nav__panel"),
+  );
+
+  navs.forEach((nav) => {
+    const links = Array.from(nav.querySelectorAll("a"));
+    const activeLink = links.find((link) => link.classList.contains("is-active"));
+
+    if (!activeLink) {
+      return;
+    }
+
+    nav.classList.add("top-nav--animated");
+
+    const indicator = document.createElement("span");
+    indicator.className = "top-nav__indicator";
+    indicator.setAttribute("aria-hidden", "true");
+    nav.appendChild(indicator);
+
+    let pinnedLink = activeLink;
+
+    const moveIndicator = (link, immediate = false) => {
+      if (!link) {
+        return;
+      }
+
+      const navRect = nav.getBoundingClientRect();
+      const linkRect = link.getBoundingClientRect();
+
+      if (immediate) {
+        indicator.style.transition = "none";
+      }
+
+      indicator.style.width = `${linkRect.width}px`;
+      indicator.style.height = `${linkRect.height}px`;
+      indicator.style.transform = `translate(${linkRect.left - navRect.left}px, ${linkRect.top - navRect.top}px)`;
+      indicator.style.opacity = "1";
+
+      if (immediate) {
+        window.requestAnimationFrame(() => {
+          indicator.style.transition = "";
+        });
+      }
+    };
+
+    moveIndicator(pinnedLink, true);
+
+    links.forEach((link) => {
+      link.addEventListener("pointerenter", () => moveIndicator(link));
+      link.addEventListener("focus", () => moveIndicator(link));
+      link.addEventListener("click", () => {
+        pinnedLink = link;
+        links.forEach((item) => {
+          item.classList.toggle("is-active", item === link);
+        });
+        moveIndicator(link);
+      });
+    });
+
+    nav.addEventListener("pointerleave", () => moveIndicator(pinnedLink));
+    nav.addEventListener("focusout", (event) => {
+      if (!nav.contains(event.relatedTarget)) {
+        moveIndicator(pinnedLink);
+      }
+    });
+
+    window.addEventListener("resize", () => moveIndicator(pinnedLink, true));
+    window.addEventListener("load", () => moveIndicator(pinnedLink, true), { once: true });
+  });
+};
+
 const renderToc = (target, headings) => {
   target.innerHTML = "";
 
@@ -425,6 +497,7 @@ const initSearch = () => {
 document.addEventListener("DOMContentLoaded", () => {
   enhanceCodeBlocks();
   enhanceTables();
+  initPrimaryNavIndicator();
   initPageToc();
   initMobileNav();
   initSearch();


### PR DESCRIPTION
## Summary
- add an animated indicator pill behind the active docs primary-nav item
- move the indicator on hover and focus while preserving the active destination as the pinned state
- add reduced-motion handling and dark-theme styling for the indicator

## Validation
- npm run typecheck
- npm test
- npm run build

## Risk
- low; scoped to the docs site primary navigation UI in CSS and static JS