### PR TITLE
fix: clarify docs homepage IA

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,30 +1,30 @@
 primary:
   - key: overview
-    title: Overview
+    title: Home
     url: /
   - key: user
-    title: User Docs
+    title: Use the Server
     url: /user-guide/
   - key: technical
-    title: Technical Docs
+    title: Technical Reference
     url: /technical/
   - key: project
-    title: Project Info
+    title: Project & Support
     url: /project-information/
 
 sections:
   overview:
-    title: Overview
-    description: Documentation home and first-run paths.
+    title: Home
+    description: What this server is, who it is for, and the fastest paths into the docs.
     items:
-      - title: Documentation Overview
+      - title: FDIC BankFind MCP Server
         short_title: Home
         url: /
   user:
-    title: User Docs
-    description: Setup, prompting, examples, and troubleshooting.
+    title: Use the Server
+    description: Setup, prompting, examples, and troubleshooting for people using the MCP server.
     items:
-      - title: User Docs
+      - title: Use the Server
         short_title: Overview
         url: /user-guide/
       - title: Getting Started
@@ -39,10 +39,10 @@ sections:
         short_title: Troubleshooting
         url: /troubleshooting/
   technical:
-    title: Technical Docs
-    description: Contracts, architecture, implementation details, and operations.
+    title: Technical Reference
+    description: Contracts, architecture, implementation details, and deployment operations.
     items:
-      - title: Technical Docs
+      - title: Technical Reference
         short_title: Overview
         url: /technical/
       - title: Technical Specification
@@ -59,10 +59,10 @@ sections:
         short_title: Deployment
         url: /technical/cloud-run-deployment/
   project:
-    title: Project Info
-    description: Operational context, support posture, and contribution workflows.
+    title: Project & Support
+    description: Release history, support posture, compatibility guidance, and contribution workflow.
     items:
-      - title: Project Info
+      - title: Project & Support
         short_title: Overview
         url: /project-information/
       - title: MCP Host Compatibility Matrix

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ summary: Start with a hosted MCP URL when your host supports it, or use the loca
 breadcrumbs:
   - title: Overview
     url: /
-  - title: User Docs
+  - title: Use the Server
     url: /user-guide/
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,15 @@
 ---
-title: Documentation Overview
+title: FDIC BankFind MCP Server
 nav_group: overview
-kicker: Documentation Home
-summary: A starting point for users, maintainers, and evaluators who need to understand what the project solves and where to go next.
+kicker: MCP Documentation
+summary: Connect to the FDIC BankFind MCP Server, use its search and analysis tools, and find the right setup, reference, or support docs.
 body_class: overview-page
 ---
 {% assign latest_release = site.data.latest_release %}
 
 <div class="hero-grid">
   <section class="hero-panel hero-panel--accent">
-    <h3>What problem this project solves</h3>
+    <h3>What this server does</h3>
     <p>
       The FDIC BankFind Suite API is public, but it is not packaged for MCP hosts in a way that is easy to use from prompts.
       This server turns those datasets into MCP tools with stable machine-readable output, then adds analysis helpers for multi-bank comparison and peer benchmarking.
@@ -30,19 +30,19 @@ body_class: overview-page
 
 <div class="card-grid">
   <a class="card" href="{{ '/getting-started/' | relative_url }}">
-    <span class="card__eyebrow">First Step</span>
-    <h3>Connect to the live endpoint</h3>
+    <span class="card__eyebrow">Get Started</span>
+    <h3>Choose the fastest setup path</h3>
     <p>Start with the hosted MCP URL when your host accepts remote servers. Use the local install path only when your host requires stdio.</p>
   </a>
-  <a class="card" href="{{ latest_release.url }}">
-    <span class="card__eyebrow">Latest Release</span>
-    <h3>{{ latest_release.display_name }}</h3>
-    <p>{{ latest_release.summary }}</p>
+  <a class="card" href="{{ '/clients/' | relative_url }}">
+    <span class="card__eyebrow">Connect</span>
+    <h3>Find your MCP host instructions</h3>
+    <p>Use the right setup steps for Claude Desktop, ChatGPT, Gemini CLI, or GitHub Copilot CLI.</p>
   </a>
   <a class="card" href="{{ '/prompting-guide/' | relative_url }}">
-    <span class="card__eyebrow">Best Next Read</span>
-    <h3>Prompting Guide</h3>
-    <p>Use copy-pasteable prompt patterns that are explicit about dates, metrics, and dataset boundaries.</p>
+    <span class="card__eyebrow">Use It Well</span>
+    <h3>Learn the prompting patterns</h3>
+    <p>Use copy-pasteable prompt patterns that stay explicit about dates, metrics, and dataset boundaries.</p>
   </a>
 </div>
 
@@ -57,37 +57,37 @@ body_class: overview-page
   <pre><code>https://bankfind.jflamb.com/mcp</code></pre>
 </div>
 
-## Choose your path
+## Browse by need
 
 <p class="section-intro">
-  The docs are organized by audience so you can start from the right level of detail instead of scanning every page.
+  The site is organized around the jobs people typically need to do: get connected, use the server effectively, inspect the technical contract, or find project and support information.
 </p>
 
 <div class="card-grid">
   <a class="card" href="{{ '/user-guide/' | relative_url }}">
-    <span class="card__eyebrow">For Users</span>
-    <h3>User Docs</h3>
+    <span class="card__eyebrow">Use the Server</span>
+    <h3>Setup, prompting, and examples</h3>
     <p>Installation, client setup, prompting guidance, practical examples, and troubleshooting.</p>
   </a>
   <a class="card" href="{{ '/technical/' | relative_url }}">
-    <span class="card__eyebrow">For Maintainers</span>
-    <h3>Technical Docs</h3>
+    <span class="card__eyebrow">Technical Reference</span>
+    <h3>Architecture, contracts, and tools</h3>
     <p>Architecture, contracts, implementation boundaries, and the reasoning behind key design decisions.</p>
   </a>
   <a class="card" href="{{ '/project-information/' | relative_url }}">
-    <span class="card__eyebrow">For Evaluators</span>
-    <h3>Project Info</h3>
+    <span class="card__eyebrow">Project &amp; Support</span>
+    <h3>Compatibility, releases, and support</h3>
     <p>Release notes, support expectations, compatibility guidance, contribution workflow, and security reporting.</p>
   </a>
 </div>
 
-## Recommended starting points
+## Common next steps
 
 <div class="card-grid">
-  <a class="card" href="{{ '/clients/' | relative_url }}">
-    <span class="card__eyebrow">Connect</span>
-    <h3>Client Setup</h3>
-    <p>Find the right MCP host setup for Claude Desktop, ChatGPT, Gemini CLI, or GitHub Copilot CLI.</p>
+  <a class="card" href="{{ latest_release.url }}">
+    <span class="card__eyebrow">Latest Release</span>
+    <h3>{{ latest_release.display_name }}</h3>
+    <p>{{ latest_release.summary }}</p>
   </a>
   <a class="card" href="{{ '/usage-examples/' | relative_url }}">
     <span class="card__eyebrow">Examples</span>

--- a/docs/project-information.md
+++ b/docs/project-information.md
@@ -1,5 +1,5 @@
 ---
-title: Project Info
+title: Project & Support
 nav_group: project
 kicker: Project Guide
 summary: Release notes, support policies, contribution workflow, compatibility guidance, and security reporting.

--- a/docs/technical/index.md
+++ b/docs/technical/index.md
@@ -1,14 +1,14 @@
 ---
-title: Technical Docs
+title: Technical Reference
 nav_group: technical
-kicker: Maintainer Guide
-summary: Architecture, tool contracts, and design decisions for contributors working inside the codebase.
+kicker: Technical Guide
+summary: Architecture, tool contracts, implementation details, and design decisions for contributors working inside the codebase.
 breadcrumbs:
   - title: Overview
     url: /
 ---
 
-The technical docs are aimed at maintainers and advanced contributors who need to understand how the server is wired, where responsibilities live, and which design choices are deliberate.
+This section is aimed at maintainers and advanced contributors who need to understand how the server is wired, where responsibilities live, and which design choices are deliberate.
 
 <div class="card-grid">
   <a class="card" href="{{ '/technical/specification/' | relative_url }}">

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,14 +1,14 @@
 ---
-title: User Docs
+title: Use the Server
 nav_group: user
-kicker: Audience Guide
+kicker: User Guide
 summary: Installation, client setup, prompting, examples, and troubleshooting for people using the server through an MCP host.
 breadcrumbs:
   - title: Overview
     url: /
 ---
 
-The user docs are for people who want to get the server running quickly, choose the right MCP tool, and avoid common data-model mistakes.
+This section is for people who want to get the server running quickly, choose the right MCP tool, and avoid common data-model mistakes.
 
 <div class="card-grid">
   <a class="card" href="{{ '/getting-started/' | relative_url }}">

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,3 +15,4 @@
 - When the repository has standing SOPs, document them explicitly in `AGENTS.md` instead of relying on adjacent bullets or implied behavior.
 - When running `/issue-batch-run` or another repo workflow shortcut, do not stop at isolated validated worktrees; finish the documented change-management path on branches rooted at `origin/main`, then open PRs, watch checks, and merge unless the user explicitly asks to pause.
 - If a task requires temporary local scratch files for work that ultimately lives elsewhere, remove those files before closing the task and do not leave workspace-only artifacts behind.
+- When tool checks report a command as missing, verify common install locations before concluding the dependency is unavailable; this environment may have working binaries outside the inherited PATH.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,39 @@
+# Docs IA Rewrite For Homepage And Navigation
+
+Reference: issue #177 and user request to make the GitHub Pages site identity and information architecture clearer.
+
+## Goals
+
+- [x] Make the homepage H1 explicitly identify the product as the FDIC BankFind MCP Server.
+- [x] Rewrite homepage routing copy so the main paths are task-first and audience-clear.
+- [x] Rename the top-level navigation and section landing pages to match the revised IA.
+- [x] Validate the available local build path after the content changes and record the result.
+
+## Acceptance Criteria
+
+- [x] [docs/index.md](/Users/jlamb/Projects/bankfind-mcp/docs/index.md) uses `FDIC BankFind MCP Server` as the page title and explains the product in the summary.
+- [x] [docs/_data/navigation.yml](/Users/jlamb/Projects/bankfind-mcp/docs/_data/navigation.yml) uses clear top-level labels instead of generic documentation taxonomy.
+- [x] The section landing pages for user, technical, and project/support content use titles that align with the new navigation labels.
+- [x] The available local validation commands complete successfully, with the missing local Jekyll toolchain noted explicitly.
+
+## Validation
+
+- [x] `npm run build`
+- [x] `node scripts/generate-docs-release-data.mjs`
+- [x] `/Users/jlamb/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site_raw`
+- [x] `cp -R _site_raw/. _site/`
+- [x] `npm install`
+- [x] `npm run docs:search`
+
+## Review / Results
+
+- [x] Branch created for this work: `fix/docs-homepage-ia`.
+- [x] Rewrote the homepage in [docs/index.md](/Users/jlamb/Projects/bankfind-mcp/docs/index.md) so the H1 is the product name and the primary cards route readers by task.
+- [x] Renamed the global and section navigation labels in [docs/_data/navigation.yml](/Users/jlamb/Projects/bankfind-mcp/docs/_data/navigation.yml) to `Home`, `Use the Server`, `Technical Reference`, and `Project & Support`.
+- [x] Aligned the section landing page titles in [docs/user-guide.md](/Users/jlamb/Projects/bankfind-mcp/docs/user-guide.md), [docs/technical/index.md](/Users/jlamb/Projects/bankfind-mcp/docs/technical/index.md), and [docs/project-information.md](/Users/jlamb/Projects/bankfind-mcp/docs/project-information.md) with the revised IA.
+- [x] Updated the user-section breadcrumb in [docs/getting-started.md](/Users/jlamb/Projects/bankfind-mcp/docs/getting-started.md) to match the renamed section.
+- [x] Correction from user applied: both Docker and Jekyll were available locally but outside the inherited PATH, so validation used direct binary paths instead of assuming the tools were missing.
+
 # Issue #142: Node Engine Minimum Matches Supported CI Matrix
 
 Reference: issue #142.


### PR DESCRIPTION
## Summary
- make the docs homepage identify the product as the FDIC BankFind MCP Server instead of a generic documentation overview
- rename top-level and section navigation labels to clearer task-first paths
- align section landing pages and breadcrumbs with the revised IA

## Why
Closes #177.

The previous homepage buried the actual product identity in the site chrome while the main heading read `Documentation Overview`. For a small docs site, the page should immediately answer what this is, who it is for, and where to go next.

## Validation
- `npm run build`
- `node scripts/generate-docs-release-data.mjs`
- `/Users/jlamb/.gem/ruby/2.6.0/bin/jekyll build --source docs --destination _site_raw`
- `cp -R _site_raw/. _site/`
- `npm install`
- `npm run docs:search`
- `/Applications/Docker.app/Contents/Resources/bin/docker --version`
- `/Users/jlamb/.gem/ruby/2.6.0/bin/jekyll -v`

## Notes
- Recorded the PATH-related environment lesson in `tasks/lessons.md` after correcting the validation assumption.