### PR TITLE
feat: add global docs chat launcher

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -33,8 +33,6 @@ sections:
         url: /clients/
       - title: Prompting Guide
         url: /prompting-guide/
-      - title: Try It
-        url: /try-it/
       - title: Usage Examples
         url: /usage-examples/
       - title: Troubleshooting And FAQ

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,9 +9,10 @@
     <meta name="twitter:image" content="{{ '/assets/images/social-card.svg' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/docs.css' | relative_url }}">
     <script defer src="{{ '/assets/js/docs.js' | relative_url }}"></script>
+    <script defer src="{{ '/assets/js/chatbot.js' | relative_url }}"></script>
     {% seo %}
   </head>
-  <body class="{% if page.body_class %}{{ page.body_class }}{% endif %}" data-pagefind-script="{{ '/pagefind/pagefind.js' | relative_url }}">
+  <body class="{% if page.body_class %}{{ page.body_class }}{% endif %}" data-pagefind-script="{{ '/pagefind/pagefind.js' | relative_url }}" data-chat-endpoint="https://bankfind.jflamb.com/chat" data-chat-prompting-guide-url="{{ '/prompting-guide/' | relative_url }}">
     <a class="skip-link" href="#main-content">Skip to content</a>
     <div class="site-shell">
       <header class="site-header">

--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -499,22 +499,115 @@ img {
   white-space: inherit;
 }
 
-.chatbot-demo {
+.chatbot-inline-open {
+  appearance: none;
+  min-height: 2.9rem;
+  padding: 0 1rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--ink);
+  color: var(--surface-strong);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.chatbot-shell {
+  position: fixed;
+  right: 1.2rem;
+  bottom: 1.2rem;
+  z-index: 60;
+}
+
+.chatbot-launcher {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 3.5rem;
+  padding: 0 1rem 0 0.95rem;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgba(16, 34, 29, 0.96), rgba(13, 122, 102, 0.94));
+  color: #ffffff;
+  box-shadow: 0 18px 45px rgba(10, 37, 31, 0.28);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.chatbot-launcher:hover,
+.chatbot-launcher:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 52px rgba(10, 37, 31, 0.32);
+}
+
+.chatbot-launcher__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.chatbot-launcher__icon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
+}
+
+.chatbot-launcher__label {
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 160ms ease, opacity 160ms ease;
+  opacity: 0;
+}
+
+.chatbot-launcher:hover .chatbot-launcher__label,
+.chatbot-launcher:focus-visible .chatbot-launcher__label {
+  max-width: 6rem;
+  opacity: 1;
+}
+
+.chatbot-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+}
+
+.chatbot-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 19, 17, 0.42);
+  backdrop-filter: blur(12px);
+}
+
+.chatbot-overlay__panel {
+  position: absolute;
+  right: 1.2rem;
+  bottom: 5.5rem;
+  width: min(32rem, calc(100vw - 2rem));
+  max-height: min(46rem, calc(100vh - 7rem));
   display: grid;
-  gap: 1.35rem;
-}
-
-.chatbot-demo__intro,
-.chatbot-demo__panel {
-  padding: 1.4rem;
+  gap: 1rem;
+  padding: 1.15rem;
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.84);
-  border: 1px solid rgba(13, 122, 102, 0.1);
-  box-shadow: var(--shadow-sm);
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(13, 122, 102, 0.12);
+  box-shadow: var(--shadow-lg);
 }
 
-.chatbot-demo__eyebrow {
-  margin: 0 0 0.45rem;
+.chatbot-overlay__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chatbot-overlay__eyebrow {
+  margin: 0 0 0.2rem;
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.12em;
@@ -522,31 +615,41 @@ img {
   color: var(--accent);
 }
 
-.chatbot-demo__intro h2 {
-  margin: 0 0 0.75rem;
-  font-size: clamp(1.65rem, 2.6vw, 2.3rem);
+.chatbot-overlay__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
-.chatbot-demo__intro p:last-child {
-  margin-bottom: 0;
-}
-
-.chatbot-demo__intro-note {
+.chatbot-overlay__summary {
+  margin: 0.35rem 0 0;
   color: var(--muted);
 }
 
-.chatbot-demo__prompts {
+.chatbot-overlay__close {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(16, 34, 29, 0.08);
+  color: var(--ink);
+  min-height: 2.6rem;
+  padding: 0 0.9rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.chatbot-overlay__prompts {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
 }
 
 .chatbot-demo__prompt {
   appearance: none;
   display: grid;
-  gap: 0.45rem;
+  gap: 0.3rem;
   width: 100%;
-  padding: 1rem;
+  padding: 0.9rem;
   text-align: left;
   border: 1px solid rgba(13, 122, 102, 0.14);
   border-radius: var(--radius-md);
@@ -565,17 +668,9 @@ img {
   box-shadow: var(--shadow-md);
 }
 
-.chatbot-demo__prompt-label {
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent);
-}
-
 .chatbot-demo__thread {
-  min-height: 24rem;
-  max-height: 38rem;
+  min-height: 18rem;
+  max-height: 22rem;
   overflow-y: auto;
   padding: 1rem;
   border-radius: var(--radius-md);
@@ -675,7 +770,7 @@ img {
 
 .chatbot-demo__fallback,
 .chatbot-demo__fallback-noscript {
-  margin: 1rem 0 0;
+  margin: 0;
   color: var(--muted);
 }
 
@@ -1488,6 +1583,36 @@ img {
   .chatbot-demo__send {
     width: 100%;
   }
+
+  .chatbot-shell {
+    right: 1rem;
+    left: 1rem;
+    bottom: 1rem;
+  }
+
+  .chatbot-launcher {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .chatbot-launcher__label {
+    max-width: none;
+    opacity: 1;
+  }
+
+  .chatbot-overlay__panel {
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    max-height: calc(100vh - 1rem);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .chatbot-overlay__prompts {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media print {
@@ -1616,8 +1741,7 @@ img {
   .hero-panel,
   .doc-callout,
   .table-wrap,
-  .chatbot-demo__intro,
-  .chatbot-demo__panel,
+  .chatbot-overlay__panel,
   .chatbot-demo__message--assistant .chatbot-demo__bubble {
     background: rgba(17, 33, 29, 0.92);
   }
@@ -1630,11 +1754,20 @@ img {
 
   .chatbot-demo__thread,
   .chatbot-demo__composer textarea,
-  .chatbot-demo__prompt {
+  .chatbot-demo__prompt,
+  .chatbot-overlay__close {
     background: rgba(13, 24, 21, 0.92);
   }
 
   .chatbot-demo__message--error .chatbot-demo__bubble {
     background: rgba(67, 29, 24, 0.92);
+  }
+
+  .chatbot-overlay__backdrop {
+    background: rgba(0, 0, 0, 0.56);
+  }
+
+  .chatbot-launcher {
+    background: linear-gradient(145deg, rgba(17, 33, 29, 0.98), rgba(16, 48, 41, 0.98));
   }
 }

--- a/docs/assets/js/chatbot.js
+++ b/docs/assets/js/chatbot.js
@@ -2,6 +2,14 @@ const CHATBOT_SESSION_KEY = "bankfind-chatbot-session-id";
 const CHATBOT_THREAD_KEY = "bankfind-chatbot-thread";
 const RELOAD_TYPE = "reload";
 
+const SUGGESTED_PROMPTS = [
+  "Find active banks in Texas with over $5 billion in assets",
+  "List the 10 costliest bank failures since 2000",
+  "Show quarterly financials for Bank of America during 2024",
+  "Compare North Carolina banks between 2021 and 2025 by deposit growth",
+  "Build a peer group for CERT 29846 and rank on ROA and efficiency ratio",
+];
+
 const escapeHtml = (value) =>
   value
     .replaceAll("&", "&amp;")
@@ -28,7 +36,11 @@ const parseMarkdown = (source) => {
       continue;
     }
 
-    if (line.includes("|") && index + 1 < lines.length && isTableSeparator(lines[index + 1])) {
+    if (
+      line.includes("|") &&
+      index + 1 < lines.length &&
+      isTableSeparator(lines[index + 1])
+    ) {
       const header = line
         .split("|")
         .map((cell) => cell.trim())
@@ -47,11 +59,15 @@ const parseMarkdown = (source) => {
 
       blocks.push(`
         <table>
-          <thead><tr>${header.map((cell) => `<th>${formatInline(cell)}</th>`).join("")}</tr></thead>
+          <thead><tr>${header
+            .map((cell) => `<th>${formatInline(cell)}</th>`)
+            .join("")}</tr></thead>
           <tbody>${rows
             .map(
               (row) =>
-                `<tr>${row.map((cell) => `<td>${formatInline(cell)}</td>`).join("")}</tr>`,
+                `<tr>${row
+                  .map((cell) => `<td>${formatInline(cell)}</td>`)
+                  .join("")}</tr>`,
             )
             .join("")}</tbody>
         </table>
@@ -65,7 +81,9 @@ const parseMarkdown = (source) => {
         items.push(lines[index].trim().slice(2));
         index += 1;
       }
-      blocks.push(`<ul>${items.map((item) => `<li>${formatInline(item)}</li>`).join("")}</ul>`);
+      blocks.push(
+        `<ul>${items.map((item) => `<li>${formatInline(item)}</li>`).join("")}</ul>`,
+      );
       continue;
     }
 
@@ -78,6 +96,107 @@ const parseMarkdown = (source) => {
   }
 
   return blocks.join("");
+};
+
+const readStoredThread = () => {
+  try {
+    const raw = window.sessionStorage.getItem(CHATBOT_THREAD_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+
+const storeThread = (messages) => {
+  window.sessionStorage.setItem(CHATBOT_THREAD_KEY, JSON.stringify(messages));
+};
+
+const clearSessionOnReload = () => {
+  const navigation = performance.getEntriesByType?.("navigation")?.[0];
+  if (navigation && navigation.type === RELOAD_TYPE) {
+    window.sessionStorage.removeItem(CHATBOT_SESSION_KEY);
+    window.sessionStorage.removeItem(CHATBOT_THREAD_KEY);
+  }
+};
+
+const isEditableTarget = (target) => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest(
+      "input, textarea, select, [contenteditable=''], [contenteditable='true']",
+    ),
+  );
+};
+
+const createLauncherMarkup = (promptingGuideUrl) => {
+  const shell = document.createElement("div");
+  shell.className = "chatbot-shell";
+  shell.innerHTML = `
+    <button
+      type="button"
+      class="chatbot-launcher"
+      data-chatbot-launcher
+      aria-label="Open the FDIC BankFind chat demo. Keyboard shortcut: question mark."
+      title="Try it!"
+    >
+      <span class="chatbot-launcher__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false">
+          <path d="M4 5.5C4 4.12 5.12 3 6.5 3h11C18.88 3 20 4.12 20 5.5v7C20 13.88 18.88 15 17.5 15H10l-4.4 4.12A.75.75 0 0 1 4.35 18.6V15.1A2.5 2.5 0 0 1 4 13.82V5.5Z"></path>
+        </svg>
+      </span>
+      <span class="chatbot-launcher__label">Try it!</span>
+    </button>
+
+    <div class="chatbot-overlay" data-chatbot-overlay hidden>
+      <div class="chatbot-overlay__backdrop" data-chatbot-close></div>
+      <section
+        class="chatbot-overlay__panel"
+        data-chatbot-panel
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chatbot-title"
+      >
+        <header class="chatbot-overlay__header">
+          <div>
+            <p class="chatbot-overlay__eyebrow">Hosted Demo</p>
+            <h2 id="chatbot-title">FDIC BankFind chat</h2>
+            <p class="chatbot-overlay__summary">Ask about institutions, failures, financials, deposits, demographics, and peer groups.</p>
+          </div>
+          <button type="button" class="chatbot-overlay__close" data-chatbot-close aria-label="Close chat demo">Close</button>
+        </header>
+
+        <section class="chatbot-overlay__prompts" aria-label="Suggested prompts" data-chatbot-prompts></section>
+
+        <div class="chatbot-demo__thread" data-chatbot-thread aria-live="polite" aria-busy="false"></div>
+
+        <form class="chatbot-demo__composer" data-chatbot-form>
+          <label class="chatbot-demo__composer-label" for="chatbot-input">Ask about FDIC bank data</label>
+          <div class="chatbot-demo__composer-row">
+            <textarea
+              id="chatbot-input"
+              name="message"
+              rows="3"
+              maxlength="500"
+              placeholder="Type a question about banks, failures, deposits, financials, or peer groups..."
+              data-chatbot-input
+            ></textarea>
+            <button type="submit" class="chatbot-demo__send" data-chatbot-send>Send</button>
+          </div>
+        </form>
+
+        <p class="chatbot-demo__fallback" data-chatbot-fallback hidden>
+          The interactive demo is currently unavailable. See the
+          <a href="${promptingGuideUrl}">Prompting Guide</a>
+          for example queries you can try in your own MCP client.
+        </p>
+      </section>
+    </div>
+  `;
+
+  return shell;
 };
 
 const createMessageElement = (message) => {
@@ -106,45 +225,41 @@ const createMessageElement = (message) => {
   return article;
 };
 
-const readStoredThread = () => {
-  try {
-    const raw = window.sessionStorage.getItem(CHATBOT_THREAD_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
-};
-
-const storeThread = (messages) => {
-  window.sessionStorage.setItem(CHATBOT_THREAD_KEY, JSON.stringify(messages));
-};
-
-const clearSessionOnReload = () => {
-  const navigation = performance.getEntriesByType?.("navigation")?.[0];
-  if (navigation && navigation.type === RELOAD_TYPE) {
-    window.sessionStorage.removeItem(CHATBOT_SESSION_KEY);
-    window.sessionStorage.removeItem(CHATBOT_THREAD_KEY);
-  }
-};
-
 const initChatbot = async () => {
-  const root = document.querySelector("[data-chatbot-root]");
-  if (!root) {
+  const endpoint = document.body?.dataset.chatEndpoint;
+  const promptingGuideUrl =
+    document.body?.dataset.chatPromptingGuideUrl || "/prompting-guide/";
+  if (!endpoint) {
     return;
   }
 
   clearSessionOnReload();
 
-  const thread = root.querySelector("[data-chatbot-thread]");
-  const prompts = Array.from(root.querySelectorAll("[data-prompt]"));
-  const form = root.querySelector("[data-chatbot-form]");
-  const input = root.querySelector("[data-chatbot-input]");
-  const sendButton = root.querySelector("[data-chatbot-send]");
-  const fallback = root.querySelector("[data-chatbot-fallback]");
-  const promptSection = root.querySelector("[data-chatbot-prompts]");
-  const endpoint = root.dataset.chatEndpoint;
+  const shell = createLauncherMarkup(promptingGuideUrl);
+  document.body.appendChild(shell);
 
-  if (!thread || !form || !input || !sendButton || !fallback || !promptSection || !endpoint) {
+  const launcher = shell.querySelector("[data-chatbot-launcher]");
+  const overlay = shell.querySelector("[data-chatbot-overlay]");
+  const panel = shell.querySelector("[data-chatbot-panel]");
+  const thread = shell.querySelector("[data-chatbot-thread]");
+  const promptsRoot = shell.querySelector("[data-chatbot-prompts]");
+  const form = shell.querySelector("[data-chatbot-form]");
+  const input = shell.querySelector("[data-chatbot-input]");
+  const sendButton = shell.querySelector("[data-chatbot-send]");
+  const fallback = shell.querySelector("[data-chatbot-fallback]");
+  const closeButtons = shell.querySelectorAll("[data-chatbot-close]");
+
+  if (
+    !launcher ||
+    !overlay ||
+    !panel ||
+    !thread ||
+    !promptsRoot ||
+    !form ||
+    !input ||
+    !sendButton ||
+    !fallback
+  ) {
     return;
   }
 
@@ -152,6 +267,18 @@ const initChatbot = async () => {
   const statusEndpoint = `${normalizeEndpoint}/status`;
   let sessionId = window.sessionStorage.getItem(CHATBOT_SESSION_KEY) || "";
   let messages = readStoredThread();
+  let statusLoaded = false;
+  let available = true;
+  let lastActiveElement = null;
+
+  promptsRoot.innerHTML = SUGGESTED_PROMPTS.map(
+    (prompt) => `
+      <button type="button" class="chatbot-demo__prompt" data-prompt="${prompt.replaceAll('"', "&quot;")}">
+        <strong>${prompt}</strong>
+      </button>
+    `,
+  ).join("");
+  const prompts = Array.from(promptsRoot.querySelectorAll("[data-prompt]"));
 
   const renderThread = () => {
     thread.innerHTML = "";
@@ -169,24 +296,43 @@ const initChatbot = async () => {
     messages.forEach((message) => {
       thread.appendChild(createMessageElement(message));
     });
+
     thread.scrollTop = thread.scrollHeight;
     thread.setAttribute("aria-busy", "false");
     storeThread(messages);
   };
 
   const setComposerState = (enabled) => {
-    input.disabled = !enabled;
-    sendButton.disabled = !enabled;
+    input.disabled = !enabled || !available;
+    sendButton.disabled = !enabled || !available;
     prompts.forEach((prompt) => {
-      prompt.disabled = !enabled;
+      prompt.disabled = !enabled || !available;
     });
   };
 
-  const setUnavailable = () => {
-    setComposerState(false);
-    promptSection.hidden = true;
-    form.hidden = true;
-    fallback.hidden = false;
+  const applyAvailabilityState = () => {
+    promptsRoot.hidden = !available;
+    form.hidden = !available;
+    fallback.hidden = available;
+    setComposerState(true);
+  };
+
+  const loadAvailability = async () => {
+    if (statusLoaded) {
+      return;
+    }
+
+    statusLoaded = true;
+
+    try {
+      const statusResponse = await fetch(statusEndpoint, { credentials: "omit" });
+      const statusPayload = await statusResponse.json();
+      available = Boolean(statusResponse.ok && statusPayload.available === true);
+    } catch {
+      available = false;
+    }
+
+    applyAvailabilityState();
   };
 
   const addMessage = (message) => {
@@ -194,19 +340,31 @@ const initChatbot = async () => {
     renderThread();
   };
 
-  renderThread();
+  const getFocusableElements = () =>
+    Array.from(
+      panel.querySelectorAll(
+        'button:not([disabled]), textarea:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
 
-  try {
-    const statusResponse = await fetch(statusEndpoint, { credentials: "omit" });
-    const statusPayload = await statusResponse.json();
-    if (!statusResponse.ok || statusPayload.available !== true) {
-      setUnavailable();
-      return;
-    }
-  } catch {
-    setUnavailable();
-    return;
-  }
+  const closeOverlay = () => {
+    overlay.hidden = true;
+    document.body.classList.remove("chatbot-open");
+    document.body.style.overflow = "";
+    lastActiveElement?.focus?.();
+  };
+
+  const openOverlay = async () => {
+    lastActiveElement = document.activeElement;
+    overlay.hidden = false;
+    document.body.classList.add("chatbot-open");
+    document.body.style.overflow = "hidden";
+    renderThread();
+    await loadAvailability();
+    window.requestAnimationFrame(() => {
+      (available ? input : panel.querySelector("[data-chatbot-close]"))?.focus();
+    });
+  };
 
   const sendMessage = async (content) => {
     addMessage({ role: "user", content });
@@ -253,7 +411,10 @@ const initChatbot = async () => {
         window.sessionStorage.setItem(CHATBOT_SESSION_KEY, sessionId);
       }
 
-      addMessage({ role: "assistant", content: payload.reply || "No reply returned." });
+      addMessage({
+        role: "assistant",
+        content: payload.reply || "No reply returned.",
+      });
     } catch {
       messages = messages.filter((message) => !message.loading);
       addMessage({
@@ -267,10 +428,73 @@ const initChatbot = async () => {
     }
   };
 
+  renderThread();
+  applyAvailabilityState();
+
+  launcher.addEventListener("click", () => {
+    void openOverlay();
+  });
+
+  document.querySelectorAll("[data-chatbot-open]").forEach((button) => {
+    button.addEventListener("click", () => {
+      void openOverlay();
+    });
+  });
+
+  closeButtons.forEach((button) => {
+    button.addEventListener("click", closeOverlay);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+
+    if (overlay.hidden !== true && event.key === "Escape") {
+      event.preventDefault();
+      closeOverlay();
+      return;
+    }
+
+    if (
+      overlay.hidden === true &&
+      (event.key === "?" || (event.key === "/" && event.shiftKey))
+    ) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      void openOverlay();
+    }
+  });
+
+  panel.addEventListener("keydown", (event) => {
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
     const value = input.value.trim();
-    if (!value) {
+    if (!value || !available) {
       return;
     }
 
@@ -278,7 +502,7 @@ const initChatbot = async () => {
     await sendMessage(value);
   });
 
-  input.addEventListener("keydown", async (event) => {
+  input.addEventListener("keydown", (event) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       form.requestSubmit();
@@ -286,7 +510,7 @@ const initChatbot = async () => {
   });
 
   prompts.forEach((prompt) => {
-    prompt.addEventListener("click", async () => {
+    prompt.addEventListener("click", () => {
       const value = prompt.dataset.prompt;
       if (!value) {
         return;

--- a/docs/try-it.md
+++ b/docs/try-it.md
@@ -2,7 +2,7 @@
 title: Try It
 nav_group: user
 kicker: Interactive Demo
-summary: Ask the hosted demo assistant to explore FDIC bank data through the same MCP tools the server exposes to clients.
+summary: Open the site-wide chat launcher from the lower-right corner or by pressing `?` anywhere in the docs.
 breadcrumbs:
   - title: Overview
     url: /
@@ -11,71 +11,21 @@ breadcrumbs:
 body_class: page-try-it
 ---
 
-<div class="chatbot-demo" data-chatbot-root data-chat-endpoint="https://bankfind.jflamb.com/chat">
-  <section class="chatbot-demo__intro">
-    <p class="chatbot-demo__eyebrow">Hosted Demo</p>
-    <h2>Try the MCP server without installing anything.</h2>
-    <p>
-      This demo stays scoped to FDIC BankFind data. It uses the hosted Cloud Run service, calls the registered MCP tools in-process,
-      and returns a short conversational answer.
-    </p>
-    <p class="chatbot-demo__intro-note">
-      Need prompt ideas for your own host instead? See the
-      <a href="{{ '/prompting-guide/' | relative_url }}">Prompting Guide</a>.
-    </p>
-  </section>
+<section class="doc-callout doc-callout--hero">
+  <p class="doc-callout__eyebrow">Global Launcher</p>
+  <h2>Open the chat from anywhere in the docs.</h2>
+  <p>
+    Use the floating chat button in the lower-right corner or press <code>?</code> when focus is not inside a text field.
+    The launcher opens the same hosted demo assistant without forcing navigation away from the page you are reading.
+  </p>
+  <p>
+    Need prompt ideas first? See the <a href="{{ '/prompting-guide/' | relative_url }}">Prompting Guide</a>.
+  </p>
+  <p>
+    <button type="button" class="chatbot-inline-open" data-chatbot-open>Open The Chat Launcher</button>
+  </p>
+</section>
 
-  <section class="chatbot-demo__prompts" aria-label="Suggested prompts" data-chatbot-prompts>
-    <button type="button" class="chatbot-demo__prompt" data-prompt="Find active banks in Texas with over $5 billion in assets">
-      <span class="chatbot-demo__prompt-label">Institution Search</span>
-      <strong>Find active banks in Texas with over $5 billion in assets</strong>
-    </button>
-    <button type="button" class="chatbot-demo__prompt" data-prompt="List the 10 costliest bank failures since 2000">
-      <span class="chatbot-demo__prompt-label">Failures</span>
-      <strong>List the 10 costliest bank failures since 2000</strong>
-    </button>
-    <button type="button" class="chatbot-demo__prompt" data-prompt="Show quarterly financials for Bank of America during 2024">
-      <span class="chatbot-demo__prompt-label">Financials</span>
-      <strong>Show quarterly financials for Bank of America during 2024</strong>
-    </button>
-    <button type="button" class="chatbot-demo__prompt" data-prompt="Compare North Carolina banks between 2021 and 2025 by deposit growth">
-      <span class="chatbot-demo__prompt-label">Comparison</span>
-      <strong>Compare North Carolina banks between 2021 and 2025 by deposit growth</strong>
-    </button>
-    <button type="button" class="chatbot-demo__prompt" data-prompt="Build a peer group for CERT 29846 and rank on ROA and efficiency ratio">
-      <span class="chatbot-demo__prompt-label">Peer Analysis</span>
-      <strong>Build a peer group for CERT 29846 and rank on ROA and efficiency ratio</strong>
-    </button>
-  </section>
-
-  <section class="chatbot-demo__panel" aria-label="Chat demo">
-    <div class="chatbot-demo__thread" data-chatbot-thread aria-live="polite" aria-busy="false"></div>
-    <form class="chatbot-demo__composer" data-chatbot-form>
-      <label class="chatbot-demo__composer-label" for="chatbot-input">Ask about FDIC bank data</label>
-      <div class="chatbot-demo__composer-row">
-        <textarea
-          id="chatbot-input"
-          name="message"
-          rows="3"
-          maxlength="500"
-          placeholder="Type a question about banks, failures, deposits, financials, or peer groups..."
-          data-chatbot-input
-        ></textarea>
-        <button type="submit" class="chatbot-demo__send" data-chatbot-send>Send</button>
-      </div>
-    </form>
-    <p class="chatbot-demo__fallback" data-chatbot-fallback hidden>
-      The interactive demo is currently unavailable. See the
-      <a href="{{ '/prompting-guide/' | relative_url }}">Prompting Guide</a>
-      for example queries you can try in your own MCP client.
-    </p>
-  </section>
-
-  <noscript>
-    <p class="chatbot-demo__fallback-noscript">
-      This demo requires JavaScript. See the <a href="{{ '/prompting-guide/' | relative_url }}">Prompting Guide</a> for copyable prompts.
-    </p>
-  </noscript>
-</div>
-
-<script defer src="{{ '/assets/js/chatbot.js' | relative_url }}"></script>
+<noscript>
+  <p>This demo requires JavaScript. See the <a href="{{ '/prompting-guide/' | relative_url }}">Prompting Guide</a> for copyable prompts.</p>
+</noscript>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -20,7 +20,7 @@ Rules:
 - Do not make up data. If a tool returns no results, say so.`;
 
 export const DEFAULT_CHAT_ALLOWED_ORIGINS = ["https://jflamb.github.io"];
-export const DEFAULT_CHAT_MODEL = "gemini-2.0-flash";
+export const DEFAULT_CHAT_MODEL = "gemini-2.5-flash";
 export const DEFAULT_CHAT_RATE_LIMIT_MAX_REQUESTS = 10;
 export const DEFAULT_CHAT_RATE_LIMIT_WINDOW_MS = 60_000;
 export const DEFAULT_CHAT_MAX_MESSAGES = 20;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -16,3 +16,4 @@
 - When running `/issue-batch-run` or another repo workflow shortcut, do not stop at isolated validated worktrees; finish the documented change-management path on branches rooted at `origin/main`, then open PRs, watch checks, and merge unless the user explicitly asks to pause.
 - If a task requires temporary local scratch files for work that ultimately lives elsewhere, remove those files before closing the task and do not leave workspace-only artifacts behind.
 - When tool checks report a command as missing, verify common install locations before concluding the dependency is unavailable; this environment may have working binaries outside the inherited PATH.
+- For docs features meant to be discoverable across the site, do not hide the primary entry point inside a section page or secondary navigation when the user expectation is a global launcher or site-wide affordance.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,27 +1,27 @@
-# Docs Chatbot Demo
+# Docs Chatbot Global Launcher
 
-Reference: approved design in [docs/plans/2026-03-18-docs-chatbot-demo-design.md](/Users/jlamb/Projects/bankfind-mcp/docs/plans/2026-03-18-docs-chatbot-demo-design.md), implementation plan in [docs/plans/2026-03-18-docs-chatbot-demo-plan.md](/Users/jlamb/Projects/bankfind-mcp/docs/plans/2026-03-18-docs-chatbot-demo-plan.md), and the 2026-03-18 user request to implement the feature under the repo workflow.
+Reference: issue #181, the merged docs chatbot demo work from PR #180, and the 2026-03-18 user correction that the chat entry point should be a site-wide floating launcher rather than a page-first destination.
 
 ## Goals
 
-- [x] Add a Gemini-backed `/chat` demo endpoint to the existing HTTP app without changing MCP tool contracts.
-- [x] Add a protected `/chat/status` endpoint, origin checks, per-IP rate limiting, request validation, and in-memory chat session handling.
-- [x] Add a docs "Try It" page with suggested prompts, conversational UI, loading/error states, and graceful degradation when chat is unavailable.
-- [x] Add regression coverage for the server endpoint, rate limiter, docs integration, and chatbot UI behavior.
-- [x] Validate the feature with repo-standard commands plus targeted docs/e2e checks.
+- [x] Replace the docs chatbot's primary entry point with a site-wide floating launcher.
+- [x] Support opening the chat via the launcher and the `?` key without hijacking keyboard input inside editable fields.
+- [x] Make the chat surface work across desktop and mobile with accessible focus and dismissal behavior.
+- [x] Update the backend chat model to a currently supported Gemini model so the live demo works again.
+- [x] Add or update automated coverage for the launcher UX, keyboard shortcut, and live-chat fallback behavior.
+- [x] Validate the change with repo-standard commands plus chatbot e2e coverage.
 
 ## Acceptance Criteria
 
-- [x] [src/chat.ts](/Users/jlamb/Projects/bankfind-mcp/src/chat.ts) provides `POST /chat` and `GET /chat/status` behavior matching the approved design, including request/response shapes, origin validation, rate limiting, size limits, and bounded Gemini tool-call rounds.
-- [x] [src/index.ts](/Users/jlamb/Projects/bankfind-mcp/src/index.ts) wires the chat routes into `createApp()` while preserving existing `/health` and `/mcp` behavior.
-- [x] [docs/try-it.md](/Users/jlamb/Projects/bankfind-mcp/docs/try-it.md), [docs/assets/js/chatbot.js](/Users/jlamb/Projects/bankfind-mcp/docs/assets/js/chatbot.js), and [docs/assets/css/docs.css](/Users/jlamb/Projects/bankfind-mcp/docs/assets/css/docs.css) deliver the chatbot experience and unavailable-state fallback described in the design.
-- [x] [docs/_data/navigation.yml](/Users/jlamb/Projects/bankfind-mcp/docs/_data/navigation.yml) exposes the new Try It page in site navigation.
-- [x] Automated coverage verifies the chat rate limiter, the `/chat` endpoint contract, and the docs chatbot behavior, including markdown rendering and rate-limit feedback.
-- [x] CI/deploy workflow updates cover the new chat tests and post-deploy `/chat/status` smoke check.
+- [x] The docs layout renders a floating action button in the lower-right across the site with a chat icon, an accessible label, and `Try it!` text on hover/focus.
+- [x] Pressing `?` opens the chat only when focus is not inside a text input, textarea, select, or editable surface.
+- [x] The chat opens in an accessible modal or drawer that traps focus appropriately, supports explicit close controls, and scales to mobile viewports.
+- [x] The old dedicated page is no longer the primary entry path; the launcher is available site-wide.
+- [x] The backend chat route uses a currently supported Gemini model and returns successful live responses again.
+- [x] Automated tests verify launcher visibility, modal opening, keyboard shortcut behavior, and the existing chat request/response flows.
 
 ## Validation
 
-- [x] `npm install`
 - [x] `npm run typecheck`
 - [x] `npm test`
 - [x] `npm run build`
@@ -29,11 +29,8 @@ Reference: approved design in [docs/plans/2026-03-18-docs-chatbot-demo-design.md
 
 ## Review / Results
 
-- [x] Branch created for this work: `feat/docs-chatbot-demo`.
-- [x] Server-side chat endpoint, protection layers, and Gemini tool execution integrated without breaking existing MCP routes.
-- [x] Docs Try It experience added with suggested prompts, conversation rendering, and unavailable-state handling.
-- [x] Test coverage added for backend, frontend, and workflow integration.
+- [x] Branch created for this work: `feat/docs-chatbot-launcher`.
+- [x] Site-wide launcher and overlay UX implemented.
+- [x] Keyboard shortcut and accessibility details implemented and tested.
+- [x] Backend model updated to restore live chat functionality.
 - [x] Validation results recorded here before closeout.
-
-Notes:
-- Implemented the Gemini integration with `@google/genai` instead of the deprecated `@google/generative-ai` package named in the original plan. The endpoint contract and deployment model remain the same, but the dependency is the current supported SDK.

--- a/tests/docs-site.test.ts
+++ b/tests/docs-site.test.ts
@@ -42,17 +42,17 @@ describe("docs site review v2 follow-up", () => {
     expect(docsCss).toContain(".site-footer");
   });
 
-  it("adds the Try It docs page and navigation entry for the chatbot demo", () => {
-    const navigation = readRepoFile("docs/_data/navigation.yml");
+  it("loads the chatbot launcher from the shared layout and keeps the fallback page", () => {
+    const layout = readRepoFile("docs/_layouts/default.html");
     const tryItPage = readRepoFile("docs/try-it.md");
     const chatbotScript = readRepoFile("docs/assets/js/chatbot.js");
 
-    expect(navigation).toContain("title: Try It");
-    expect(navigation).toContain("url: /try-it/");
-    expect(tryItPage).toContain("data-chatbot-root");
-    expect(tryItPage).toContain("data-chat-endpoint=\"https://bankfind.jflamb.com/chat\"");
-    expect(tryItPage).toContain("data-prompt=");
-    expect(chatbotScript).toContain("CHATBOT_SESSION_KEY");
+    expect(layout).toContain("data-chat-endpoint=\"https://bankfind.jflamb.com/chat\"");
+    expect(layout).toContain("/assets/js/chatbot.js");
+    expect(tryItPage).toContain("data-chatbot-open");
+    expect(tryItPage).toContain("press <code>?</code>");
+    expect(chatbotScript).toContain("data-chatbot-launcher");
+    expect(chatbotScript).toContain("Open the FDIC BankFind chat demo");
     expect(chatbotScript).toContain("Rate limit reached");
   });
 });

--- a/tests/e2e/chatbot.spec.ts
+++ b/tests/e2e/chatbot.spec.ts
@@ -1,11 +1,19 @@
 import { expect, test } from "@playwright/test";
 
-test("suggested prompt cards render and clicking one sends a message", async ({
+test("floating launcher opens the chat and suggested prompts send a message", async ({
   page,
 }) => {
-  await page.goto("/try-it/");
+  await page.goto("/");
 
-  await expect(page.getByText("Try the MCP server without installing anything.")).toBeVisible();
+  const launcher = page.locator("[data-chatbot-launcher]");
+  await expect(launcher).toBeVisible();
+  await expect(launcher).toHaveAttribute(
+    "aria-label",
+    /Open the FDIC BankFind chat demo/i,
+  );
+
+  await launcher.click();
+  await expect(page.locator("[data-chatbot-panel]")).toBeVisible();
   await expect(page.getByRole("button", { name: /Find active banks in Texas/i })).toBeVisible();
 
   await page.getByRole("button", { name: /Find active banks in Texas/i }).click();
@@ -15,8 +23,28 @@ test("suggested prompt cards render and clicking one sends a message", async ({
   await expect(page.getByText("Bank A")).toBeVisible();
 });
 
+test("question-mark shortcut opens the chat outside editable fields", async ({ page }) => {
+  await page.goto("/");
+
+  await page.keyboard.press("Shift+/");
+  await expect(page.locator("[data-chatbot-panel]")).toBeVisible();
+});
+
+test("question-mark shortcut does not hijack editable fields", async ({ page }) => {
+  await page.goto("/");
+
+  await page.locator("[data-chatbot-launcher]").click();
+  const input = page.locator("[data-chatbot-input]");
+  await input.focus();
+  await page.keyboard.press("Shift+/");
+
+  await expect(input).toBeFocused();
+});
+
 test("manual input supports Enter and renders markdown tables", async ({ page }) => {
-  await page.goto("/try-it/");
+  await page.goto("/");
+
+  await page.locator("[data-chatbot-launcher]").click();
 
   const input = page.locator("[data-chatbot-input]");
   await input.fill("Show a demo table");
@@ -27,7 +55,9 @@ test("manual input supports Enter and renders markdown tables", async ({ page })
 });
 
 test("unavailable status hides prompts and the composer", async ({ page }) => {
-  await page.goto("/try-it-unavailable/");
+  await page.goto("/unavailable/");
+
+  await page.locator("[data-chatbot-launcher]").click();
 
   await expect(page.getByText("The interactive demo is currently unavailable.")).toBeVisible();
   await expect(page.locator("[data-chatbot-form]")).toHaveAttribute("hidden", "");
@@ -35,10 +65,13 @@ test("unavailable status hides prompts and the composer", async ({ page }) => {
 });
 
 test("429 responses surface rate-limit feedback", async ({ page }) => {
-  await page.goto("/try-it-rate-limit/");
+  await page.goto("/rate-limit/");
 
-  await page.locator("[data-chatbot-input]").fill("Trigger rate-limit");
-  await page.getByRole("button", { name: "Send" }).click();
+  await page.locator("[data-chatbot-launcher]").click();
+
+  const input = page.locator("[data-chatbot-input]");
+  await input.fill("Trigger rate-limit");
+  await input.press("Enter");
 
   await expect(page.locator(".chatbot-demo__loading")).toBeVisible();
   await expect(page.getByText("Rate limit reached. Wait a minute, then try again.")).toBeVisible();

--- a/tests/e2e/test-server.ts
+++ b/tests/e2e/test-server.ts
@@ -1,21 +1,10 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import express from "express";
 
 const app = express();
 const repoRoot = process.cwd();
-const tryItPage = readFileSync(path.join(repoRoot, "docs/try-it.md"), "utf8");
-
-function stripFrontMatter(source: string): string {
-  return source.replace(/^---[\s\S]*?---\n/, "").trim();
-}
 
 function renderPage(endpoint: string): string {
-  const content = stripFrontMatter(tryItPage).replace(
-    'data-chat-endpoint="https://bankfind.jflamb.com/chat"',
-    `data-chat-endpoint="${endpoint}"`,
-  );
-
   return `<!doctype html>
   <html lang="en">
     <head>
@@ -23,14 +12,13 @@ function renderPage(endpoint: string): string {
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>Try It</title>
       <link rel="stylesheet" href="/assets/css/docs.css">
+      <script defer src="/assets/js/chatbot.js"></script>
     </head>
-    <body>
+    <body data-chat-endpoint="${endpoint}">
       <main class="page-shell">
         <div class="page-frame">
           <article class="doc-content">
-            ${content
-              .replaceAll("{{ '/prompting-guide/' | relative_url }}", "/prompting-guide/")
-              .replaceAll("{{ '/assets/js/chatbot.js' | relative_url }}", "/assets/js/chatbot.js")}
+            <p>Docs page content.</p>
           </article>
         </div>
       </main>
@@ -45,15 +33,15 @@ app.get("/prompting-guide/", (_req, res) => {
   res.type("html").send("<!doctype html><title>Prompting Guide</title>");
 });
 
-app.get("/try-it/", (_req, res) => {
+app.get("/", (_req, res) => {
   res.type("html").send(renderPage("/chat"));
 });
 
-app.get("/try-it-unavailable/", (_req, res) => {
+app.get("/unavailable/", (_req, res) => {
   res.type("html").send(renderPage("/chat-unavailable"));
 });
 
-app.get("/try-it-rate-limit/", (_req, res) => {
+app.get("/rate-limit/", (_req, res) => {
   res.type("html").send(renderPage("/chat-rate-limit"));
 });
 


### PR DESCRIPTION
## Summary
- replace the page-first chat entry with a site-wide floating launcher and modal chat surface
- add `?` keyboard access, editable-field guardrails, and mobile-safe overlay behavior
- switch the backend default Gemini model to `gemini-2.5-flash` so the live demo uses a current supported model

Closes #181.

## Validation
- npm run typecheck
- npm test
- npm run build
- npm run test:e2e

## Notes
- The dedicated `/try-it/` page remains as a fallback explainer page, but it is no longer the primary entry point.
- The user-provided design and plan docs under `docs/plans/` remain untracked and are not part of this PR.
