### PR TITLE
fix: render chatbot markdown responses

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -693,6 +693,7 @@ img {
   padding: 0.9rem 1rem;
   border-radius: 1.15rem;
   box-shadow: var(--shadow-sm);
+  line-height: 1.55;
 }
 
 .chatbot-demo__message--assistant .chatbot-demo__bubble {
@@ -715,8 +716,70 @@ img {
   margin-bottom: 0;
 }
 
+.chatbot-demo__bubble p,
+.chatbot-demo__bubble ul,
+.chatbot-demo__bubble ol,
+.chatbot-demo__bubble pre,
+.chatbot-demo__bubble table {
+  margin: 0 0 0.85rem;
+}
+
+.chatbot-demo__bubble h2,
+.chatbot-demo__bubble h3,
+.chatbot-demo__bubble h4,
+.chatbot-demo__bubble h5,
+.chatbot-demo__bubble h6 {
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.chatbot-demo__bubble ul,
+.chatbot-demo__bubble ol {
+  padding-left: 1.2rem;
+}
+
+.chatbot-demo__bubble li + li {
+  margin-top: 0.35rem;
+}
+
+.chatbot-demo__bubble a {
+  color: inherit;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.14em;
+}
+
+.chatbot-demo__bubble code {
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.35rem;
+  background: rgba(16, 34, 29, 0.08);
+  font-size: 0.95em;
+}
+
+.chatbot-demo__bubble pre {
+  overflow-x: auto;
+  padding: 0.8rem 0.9rem;
+  border-radius: 0.8rem;
+  background: rgba(16, 34, 29, 0.92);
+  color: #f5fbf7;
+}
+
+.chatbot-demo__bubble pre code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
 .chatbot-demo__bubble table {
   margin-bottom: 0;
+}
+
+.chatbot-demo__message--user .chatbot-demo__bubble code {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.chatbot-demo__message--assistant .chatbot-demo__bubble a {
+  color: var(--pine);
 }
 
 .chatbot-demo__composer {

--- a/docs/assets/js/chatbot.js
+++ b/docs/assets/js/chatbot.js
@@ -16,13 +16,59 @@ const escapeHtml = (value) =>
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
 
-const formatInline = (value) =>
-  escapeHtml(value)
+const sanitizeHref = (value) => {
+  const trimmed = value.trim();
+  if (/^(https?:|mailto:|\/|#)/i.test(trimmed)) {
+    return escapeHtml(trimmed);
+  }
+
+  return "#";
+};
+
+const preserveInlineTokens = (value, pattern, render) => {
+  const tokens = [];
+  const replaced = value.replace(pattern, (...args) => {
+    const token = `@@CHATBOTTOKEN${tokens.length}@@`;
+    tokens.push({ token, html: render(...args) });
+    return token;
+  });
+
+  return { replaced, tokens };
+};
+
+const restoreInlineTokens = (value, tokens) =>
+  tokens.reduce(
+    (result, entry) => result.replaceAll(entry.token, entry.html),
+    value,
+  );
+
+const formatInline = (value) => {
+  const escaped = escapeHtml(value);
+  const codeTokens = preserveInlineTokens(
+    escaped,
+    /`([^`]+)`/g,
+    (_match, content) => `<code>${content}</code>`,
+  );
+  const linkTokens = preserveInlineTokens(
+    codeTokens.replaced,
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_match, label, href) =>
+      `<a href="${sanitizeHref(href)}" target="_blank" rel="noreferrer">${label}</a>`,
+  );
+
+  const formatted = linkTokens.replaced
     .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/`([^`]+)`/g, "<code>$1</code>");
+    .replace(/(^|[^\*])\*(?!\s)(.+?)(?<!\s)\*(?!\*)/g, "$1<em>$2</em>")
+    .replace(/(^|[^_])_(?!\s)(.+?)(?<!\s)_(?!_)/g, "$1<em>$2</em>");
+
+  return restoreInlineTokens(restoreInlineTokens(formatted, linkTokens.tokens), codeTokens.tokens);
+};
 
 const isTableSeparator = (line) =>
   /^\|?[\s:-]+\|[\s|:-]*$/.test(line.trim());
+
+const isListLine = (line) =>
+  /^([-*])\s+/.test(line.trim()) || /^\d+\.\s+/.test(line.trim());
 
 const parseMarkdown = (source) => {
   const lines = source.replace(/\r\n/g, "\n").trim().split("\n");
@@ -32,6 +78,30 @@ const parseMarkdown = (source) => {
   while (index < lines.length) {
     const line = lines[index].trim();
     if (!line) {
+      index += 1;
+      continue;
+    }
+
+    if (line.startsWith("```")) {
+      const codeLines = [];
+      index += 1;
+      while (index < lines.length && !lines[index].trim().startsWith("```")) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      blocks.push(
+        `<pre><code>${escapeHtml(codeLines.join("\n"))}</code></pre>`,
+      );
+      continue;
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = Math.min(headingMatch[1].length + 1, 6);
+      blocks.push(`<h${level}>${formatInline(headingMatch[2])}</h${level}>`);
       index += 1;
       continue;
     }
@@ -75,20 +145,37 @@ const parseMarkdown = (source) => {
       continue;
     }
 
-    if (line.startsWith("- ")) {
+    if (isListLine(line)) {
       const items = [];
-      while (index < lines.length && lines[index].trim().startsWith("- ")) {
-        items.push(lines[index].trim().slice(2));
+      const isOrdered = /^\d+\.\s+/.test(line);
+      const listTag = isOrdered ? "ol" : "ul";
+      const listPattern = isOrdered ? /^\d+\.\s+/ : /^[-*]\s+/;
+
+      while (index < lines.length && listPattern.test(lines[index].trim())) {
+        items.push(lines[index].trim().replace(listPattern, ""));
         index += 1;
       }
       blocks.push(
-        `<ul>${items.map((item) => `<li>${formatInline(item)}</li>`).join("")}</ul>`,
+        `<${listTag}>${items
+          .map((item) => `<li>${formatInline(item)}</li>`)
+          .join("")}</${listTag}>`,
       );
       continue;
     }
 
     const paragraph = [];
-    while (index < lines.length && lines[index].trim()) {
+    while (
+      index < lines.length &&
+      lines[index].trim() &&
+      !lines[index].trim().startsWith("```") &&
+      !/^(#{1,6})\s+/.test(lines[index].trim()) &&
+      !isListLine(lines[index]) &&
+      !(
+        lines[index].includes("|") &&
+        index + 1 < lines.length &&
+        isTableSeparator(lines[index + 1])
+      )
+    ) {
       paragraph.push(lines[index].trim());
       index += 1;
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -17,3 +17,4 @@
 - If a task requires temporary local scratch files for work that ultimately lives elsewhere, remove those files before closing the task and do not leave workspace-only artifacts behind.
 - When tool checks report a command as missing, verify common install locations before concluding the dependency is unavailable; this environment may have working binaries outside the inherited PATH.
 - For docs features meant to be discoverable across the site, do not hide the primary entry point inside a section page or secondary navigation when the user expectation is a global launcher or site-wide affordance.
+- When model output is presented directly in a docs UI, do not stop at plain-text transport success; verify that the rendered surface supports the markdown structures the model actually emits.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,20 +1,20 @@
-# Docs Chatbot Live Runtime Failure
+# Docs Chatbot Markdown Rendering
 
-Reference: issue #183 and the 2026-03-18 live docs report that the launcher sometimes responds with "The demo could not process that request right now."
+Reference: issue #185 and the 2026-03-18 user report that Gemini responses are still showing up as hard-to-read markdown in the hosted docs chat UI.
 
 ## Goals
 
-- [x] Reproduce or otherwise confirm the live failure mode against the deployed docs and chat service.
-- [x] Identify the root cause in the backend or launcher integration without relying on a speculative UI-only workaround.
-- [x] Add or update automated coverage for the failing path.
+- [x] Inspect the current renderer and identify which markdown patterns are not being formatted in the launcher UI.
+- [x] Improve the safe markdown renderer for common Gemini output patterns.
+- [x] Add or update automated coverage for richer markdown rendering.
 - [ ] Validate the fix with the repo-standard commands and merge it through the normal workflow.
 
 ## Acceptance Criteria
 
-- [x] Investigation captures evidence from the live deployment, not only local assumptions.
-- [x] The chat backend is more resilient to transient upstream failures that would otherwise surface as a generic demo error.
-- [x] Server-side failures emit enough structured information to diagnose future incidents from Cloud Run logs.
-- [x] Automated tests cover the retry or failure-handling path that caused the user-visible break.
+- [x] Assistant replies render common markdown structures such as headings, numbered lists, emphasis, links, inline code, and tables into readable HTML.
+- [x] The renderer continues to escape raw HTML rather than trusting model output.
+- [x] Bubble styling supports the richer markdown structure without collapsing spacing.
+- [x] Automated coverage verifies the richer markdown rendering path.
 
 ## Validation
 
@@ -25,7 +25,7 @@ Reference: issue #183 and the 2026-03-18 live docs report that the launcher some
 
 ## Review / Results
 
-- [x] Branch created for this work: `fix/chatbot-live-runtime-failure`.
-- [x] Confirmed the live service logged a real browser-side `POST /chat` 500 on revision `cc96580a3521c3856f5b135cae63934eda909623`.
-- [x] Added transient retry handling around Gemini generation calls and structured server-side failure logging.
-- [x] Local validation passed for typecheck, unit/integration tests, build, and e2e coverage.
+- [x] Branch created for this work: `fix/chatbot-markdown-rendering`.
+- [x] Confirmed the existing renderer only handles a narrow markdown subset and misses common Gemini output patterns.
+- [x] Added richer safe markdown rendering for headings, ordered lists, emphasis, links, inline code, and fenced code blocks.
+- [x] Updated bubble styling and e2e coverage, including an escaped raw HTML assertion.

--- a/tests/docs-site.test.ts
+++ b/tests/docs-site.test.ts
@@ -54,5 +54,7 @@ describe("docs site review v2 follow-up", () => {
     expect(chatbotScript).toContain("data-chatbot-launcher");
     expect(chatbotScript).toContain("Open the FDIC BankFind chat demo");
     expect(chatbotScript).toContain("Rate limit reached");
+    expect(chatbotScript).toContain("sanitizeHref");
+    expect(chatbotScript).toContain("startsWith(\"```\")");
   });
 });

--- a/tests/e2e/chatbot.spec.ts
+++ b/tests/e2e/chatbot.spec.ts
@@ -54,6 +54,27 @@ test("manual input supports Enter and renders markdown tables", async ({ page })
   await expect(page.getByRole("cell", { name: "First Demo Bank" })).toBeVisible();
 });
 
+test("assistant replies render richer markdown structures", async ({ page }) => {
+  await page.goto("/");
+
+  await page.locator("[data-chatbot-launcher]").click();
+
+  const input = page.locator("[data-chatbot-input]");
+  await input.fill("Show rich markdown");
+  await input.press("Enter");
+
+  const bubble = page.locator(".chatbot-demo__message--assistant .chatbot-demo__bubble").last();
+  await expect(bubble.locator("h3")).toHaveText("Results summary");
+  await expect(bubble.locator("a")).toHaveAttribute("href", "/prompting-guide/");
+  await expect(bubble.locator("ol li")).toHaveCount(2);
+  await expect(bubble.locator("ul li")).toHaveCount(2);
+  await expect(bubble.locator("em")).toHaveText("Efficient");
+  await expect(bubble.locator("li code")).toHaveText("CERT 12345");
+  await expect(bubble.locator("pre code")).toContainText("Assets: 125000");
+  await expect(bubble).toContainText("Literal HTML: <b>safe</b>");
+  await expect(bubble.locator("b")).toHaveCount(0);
+});
+
 test("unavailable status hides prompts and the composer", async ({ page }) => {
   await page.goto("/unavailable/");
 

--- a/tests/e2e/test-server.ts
+++ b/tests/e2e/test-server.ts
@@ -52,9 +52,29 @@ app.get("/chat/status", (_req, res) => {
 app.post("/chat", (req, res) => {
   const prompt = req.body?.messages?.[0]?.content ?? "";
   const isPromptClick = prompt.includes("Texas");
+  const isRichMarkdown = prompt.includes("rich markdown");
   const reply = isPromptClick
     ? "**Texas results**\n\n- Bank A\n- Bank B"
-    : "| Bank | State |\n| --- | --- |\n| First Demo Bank | NC |";
+    : isRichMarkdown
+      ? [
+          "## Results summary",
+          "",
+          "Use the [Prompting Guide](/prompting-guide/) for more examples.",
+          "",
+          "1. First ranked bank",
+          "2. Second ranked bank",
+          "",
+          "- _Efficient_ operations",
+          "- `CERT 12345`",
+          "",
+          "Literal HTML: <b>safe</b>",
+          "",
+          "```text",
+          "Assets: 125000",
+          "Deposits: 91000",
+          "```",
+        ].join("\n")
+      : "| Bank | State |\n| --- | --- |\n| First Demo Bank | NC |";
 
   setTimeout(() => {
     res.json({


### PR DESCRIPTION
## Summary
- expand the hosted docs chatbot renderer to support richer safe markdown output from Gemini
- add bubble styling for headings, lists, links, inline code, and fenced code blocks
- extend browser coverage to verify formatted markdown and escaped raw HTML

## Why
The chat transport was working, but the docs launcher still showed much of Gemini's markdown as hard-to-read plain text. This change renders the markdown structures the model actually emits while still escaping raw HTML.

Closes #185

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:e2e`
