### PR TITLE
fix: simplify chatbot launcher and convert panel to full-height drawer

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -523,9 +523,10 @@ img {
   appearance: none;
   display: inline-flex;
   align-items: center;
-  gap: 0.7rem;
-  min-height: 3.5rem;
-  padding: 0 1rem 0 0.95rem;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  padding: 0;
   border: 0;
   border-radius: 999px;
   background: linear-gradient(145deg, rgba(16, 34, 29, 0.96), rgba(13, 122, 102, 0.94));
@@ -545,30 +546,18 @@ img {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.35rem;
-  height: 2.35rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
 }
 
 .chatbot-launcher__icon svg {
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 1.3rem;
+  height: 1.3rem;
   fill: currentColor;
 }
 
-.chatbot-launcher__label {
-  max-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  transition: max-width 160ms ease, opacity 160ms ease;
+.chatbot-open .chatbot-launcher {
+  pointer-events: none;
   opacity: 0;
-}
-
-.chatbot-launcher:hover .chatbot-launcher__label,
-.chatbot-launcher:focus-visible .chatbot-launcher__label {
-  max-width: 6rem;
-  opacity: 1;
+  transition: opacity 120ms ease;
 }
 
 .chatbot-overlay {
@@ -586,17 +575,18 @@ img {
 
 .chatbot-overlay__panel {
   position: absolute;
-  right: 1.2rem;
-  bottom: 5.5rem;
-  width: min(32rem, calc(100vw - 2rem));
-  max-height: min(46rem, calc(100vh - 7rem));
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: min(42rem, calc(100vw - 2rem));
   display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
   gap: 1rem;
-  padding: 1.15rem;
-  border-radius: var(--radius-lg);
+  padding: 1.25rem;
   background: rgba(255, 255, 255, 0.96);
-  border: 1px solid rgba(13, 122, 102, 0.12);
+  border-left: 1px solid rgba(13, 122, 102, 0.12);
   box-shadow: var(--shadow-lg);
+  overflow: hidden;
 }
 
 .chatbot-overlay__header {
@@ -641,15 +631,15 @@ img {
 .chatbot-overlay__prompts {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.7rem;
+  gap: 0.75rem;
 }
 
 .chatbot-demo__prompt {
   appearance: none;
   display: grid;
-  gap: 0.3rem;
+  gap: 0.25rem;
   width: 100%;
-  padding: 0.9rem;
+  padding: 0.75rem 1rem;
   text-align: left;
   border: 1px solid rgba(13, 122, 102, 0.14);
   border-radius: var(--radius-md);
@@ -669,15 +659,15 @@ img {
 }
 
 .chatbot-demo__thread {
-  min-height: 18rem;
-  max-height: 22rem;
+  min-height: 0;
   overflow-y: auto;
   padding: 1rem;
   border-radius: var(--radius-md);
   background: linear-gradient(180deg, rgba(231, 241, 235, 0.72), rgba(255, 255, 255, 0.92));
   border: 1px solid rgba(16, 34, 29, 0.08);
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
+  align-content: start;
 }
 
 .chatbot-demo__message {
@@ -690,7 +680,7 @@ img {
 
 .chatbot-demo__bubble {
   max-width: min(44rem, 100%);
-  padding: 0.9rem 1rem;
+  padding: 0.75rem 1rem;
   border-radius: 1.15rem;
   box-shadow: var(--shadow-sm);
   line-height: 1.55;
@@ -721,7 +711,7 @@ img {
 .chatbot-demo__bubble ol,
 .chatbot-demo__bubble pre,
 .chatbot-demo__bubble table {
-  margin: 0 0 0.85rem;
+  margin: 0 0 0.75rem;
 }
 
 .chatbot-demo__bubble h2,
@@ -729,7 +719,7 @@ img {
 .chatbot-demo__bubble h4,
 .chatbot-demo__bubble h5,
 .chatbot-demo__bubble h6 {
-  margin: 0 0 0.65rem;
+  margin: 0 0 0.5rem;
   font-size: 1rem;
   line-height: 1.3;
 }
@@ -740,7 +730,7 @@ img {
 }
 
 .chatbot-demo__bubble li + li {
-  margin-top: 0.35rem;
+  margin-top: 0.25rem;
 }
 
 .chatbot-demo__bubble a {
@@ -783,24 +773,24 @@ img {
 }
 
 .chatbot-demo__composer {
-  margin-top: 1rem;
+  margin: 0;
 }
 
 .chatbot-demo__composer-label {
   display: block;
-  margin-bottom: 0.55rem;
+  margin-bottom: 0.5rem;
   font-weight: 700;
 }
 
 .chatbot-demo__composer-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.8rem;
+  display: flex;
+  gap: 0.75rem;
   align-items: end;
 }
 
 .chatbot-demo__composer textarea {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 0.9rem 1rem;
   border-radius: var(--radius-md);
   border: 1px solid rgba(16, 34, 29, 0.14);
@@ -812,16 +802,21 @@ img {
 
 .chatbot-demo__send {
   appearance: none;
-  min-height: 3.15rem;
-  padding: 0 1.2rem;
+  width: 3.25rem;
+  height: 3.25rem;
+  padding: 0;
   border: 0;
   border-radius: 999px;
-  background: var(--ink);
+  background: linear-gradient(145deg, rgba(16, 34, 29, 0.96), rgba(13, 122, 102, 0.94));
   color: #ffffff;
   font: inherit;
-  font-weight: 700;
+  font-size: 0;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 18px 45px rgba(10, 37, 31, 0.28);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .chatbot-demo__send:disabled,
@@ -1639,38 +1634,15 @@ img {
     min-width: 30rem;
   }
 
-  .chatbot-demo__composer-row {
-    grid-template-columns: 1fr;
-  }
-
-  .chatbot-demo__send {
-    width: 100%;
-  }
-
   .chatbot-shell {
     right: 1rem;
-    left: 1rem;
     bottom: 1rem;
   }
 
-  .chatbot-launcher {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .chatbot-launcher__label {
-    max-width: none;
-    opacity: 1;
-  }
-
   .chatbot-overlay__panel {
-    right: 0;
-    bottom: 0;
     left: 0;
     width: auto;
-    max-height: calc(100vh - 1rem);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-left: 0;
   }
 
   .chatbot-overlay__prompts {

--- a/docs/assets/js/chatbot.js
+++ b/docs/assets/js/chatbot.js
@@ -234,7 +234,6 @@ const createLauncherMarkup = (promptingGuideUrl) => {
           <path d="M4 5.5C4 4.12 5.12 3 6.5 3h11C18.88 3 20 4.12 20 5.5v7C20 13.88 18.88 15 17.5 15H10l-4.4 4.12A.75.75 0 0 1 4.35 18.6V15.1A2.5 2.5 0 0 1 4 13.82V5.5Z"></path>
         </svg>
       </span>
-      <span class="chatbot-launcher__label">Try it!</span>
     </button>
 
     <div class="chatbot-overlay" data-chatbot-overlay hidden>
@@ -270,7 +269,11 @@ const createLauncherMarkup = (promptingGuideUrl) => {
               placeholder="Type a question about banks, failures, deposits, financials, or peer groups..."
               data-chatbot-input
             ></textarea>
-            <button type="submit" class="chatbot-demo__send" data-chatbot-send>Send</button>
+            <button type="submit" class="chatbot-demo__send" data-chatbot-send aria-label="Send message">
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+                <path d="M3.4 20.4l17.45-7.48a1 1 0 0 0 0-1.84L3.4 3.6a.993.993 0 0 0-1.39.91L2 9.12c0 .5.37.93.87.99L17 12 2.87 13.88c-.5.07-.87.5-.87 1l.01 4.61c0 .71.73 1.2 1.39.91z"/>
+              </svg>
+            </button>
           </div>
         </form>
 


### PR DESCRIPTION
## Summary

- Replaces the two-layer pill-shaped launcher (inner circle + outer pill with label) with a single clean circle FAB
- Converts the floating modal chat panel to a full-height right-edge drawer for better content readability
- Widens the drawer from 32rem to 42rem so response tables and formatted output are easier to read
- Replaces the text "Send" button with a matching circle icon button that visually occupies the launcher's position when the drawer is open
- Normalizes all chatbot spacing to a consistent scale (0.25/0.5/0.75/1/1.25rem) and adds a 1rem grid gap to the panel so sections are evenly separated

## Test plan

- [ ] Verify launcher renders as a single circle with chat bubble icon
- [ ] Verify clicking launcher opens a full-height right-edge drawer
- [ ] Verify the drawer is wide enough for response tables to display cleanly
- [ ] Verify the send button appears as a circle with arrow icon, aligned bottom-right
- [ ] Verify launcher fades out when drawer is open
- [ ] Verify spacing between header, prompts, thread, and composer is uniform
- [ ] Verify mobile (< 520px) renders drawer full-width
- [ ] Verify dark mode styling remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)