### PR TITLE
feat: add ChatGPT app retrieval and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ More examples are in [docs/usage-examples.md](./docs/usage-examples.md).
 
 | Tool | Description |
 |------|-------------|
+| `search` | ChatGPT-compatible citation search across institutions, failures, branches, and schema docs |
+| `fetch` | Fetch full citation text for a result returned by `search` |
 | `fdic_search_institutions` | Search FDIC-insured banks and savings institutions |
 | `fdic_get_institution` | Get details for a specific institution by CERT number |
 | `fdic_search_failures` | Search failed bank records |
@@ -206,6 +208,7 @@ More examples are in [docs/usage-examples.md](./docs/usage-examples.md).
 | `fdic_compare_bank_snapshots` | Compare two reporting snapshots across banks and rank growth and profitability changes |
 | `fdic_peer_group_analysis` | Build a peer group and rank an institution against peers on financial metrics |
 | `fdic_analyze_bank_health` | Run a CAMELS-style health assessment for a single institution |
+| `fdic_show_bank_deep_dive` | Render a ChatGPT bank deep-dive dashboard for a single institution |
 | `fdic_ubpr_analysis` | Run a UBPR-equivalent ratio analysis (ROA, ROE, NIM, efficiency, capital, liquidity, growth) |
 | `fdic_compare_peer_health` | Rank a group of institutions by CAMELS-style health scores |
 | `fdic_detect_risk_signals` | Scan institutions for early warning risk indicators |

--- a/adapters/gemini/gems/fdic-failure-forensics.yaml
+++ b/adapters/gemini/gems/fdic-failure-forensics.yaml
@@ -11,194 +11,168 @@ summary: Retrospective failure-forensics workflow for a single FDIC-insured
 version: 1.0.0
 source: extensions/workflows/fdic-failure-forensics/
 recommended_first_prompt: Analyze [Failed bank name or FDIC CERT number]
-prompt: "# FDIC Failure Forensics Workflow\r
+prompt: >-
+  # FDIC Failure Forensics Workflow
 
-  \r
 
-  ## Skill Type: RIGID\r
+  ## Skill Type: RIGID
 
-  \r
 
   Follow every phase in order. Do not skip phases. Do not produce any report
-  output before completing Phase 3.\r
+  output before completing Phase 3.
 
-  \r
 
-  ## Composition\r
+  ## Composition
 
-  \r
 
-  This workflow uses:\r
+  This workflow uses:
 
   - **Persona:** `fdic-skill-builder` — enforces FDIC data rules,
-  dependency-tier modeling, and three-outcome-state discipline\r
+  dependency-tier modeling, and three-outcome-state discipline
 
   - **Tools:** `fdic-core-mcp` + `fdic-analysis-mcp` — full FDIC data retrieval
-  and analysis surface\r
+  and analysis surface
 
-  \r
 
-  ## When to Activate\r
+  ## When to Activate
 
-  \r
 
-  - Analyze or reconstruct a bank failure\r
+  - Analyze or reconstruct a bank failure
 
-  - Review what public data showed before a specific institution failed\r
+  - Review what public data showed before a specific institution failed
 
-  - Perform a post-mortem or forensic review of a failed bank\r
+  - Perform a post-mortem or forensic review of a failed bank
 
-  - Identify early warning signals that preceded a failure\r
+  - Identify early warning signals that preceded a failure
 
-  \r
 
   Do **not** activate for active institution deep dives or multi-institution
-  screening.\r
+  screening.
 
-  \r
 
-  ## Phase 1 — Institution Resolution and Failure Confirmation\r
+  ## Phase 1 — Institution Resolution and Failure Confirmation
 
-  \r
 
-  ### Step 1: Resolve to CERT\r
+  ### Step 1: Resolve to CERT
 
-  \r
 
   **Path A — CERT provided:** `fdic_search_institutions` with `filters:
-  \"CERT:<cert>\"`.\r
+  "CERT:<cert>"`.
 
-  **Path B — Name provided:** Search with `filters: \"NAME:\\\"<name>\\\"\"`,
-  limit 10, include inactive. If multiple candidates, present disambiguation
-  list and wait.\r
+  **Path B — Name provided:** Search with `filters: "NAME:\"<name>\""`, limit
+  10, include inactive. If multiple candidates, present disambiguation list and
+  wait.
 
-  **Zero results:** Stop and ask the user to refine or provide a CERT.\r
+  **Zero results:** Stop and ask the user to refine or provide a CERT.
 
-  \r
 
-  ### Step 2: Confirm failure\r
+  ### Step 2: Confirm failure
 
-  \r
 
-  Call `fdic_get_institution_failure` with confirmed cert.\r
+  Call `fdic_get_institution_failure` with confirmed cert.
 
   If no failure record: **hard-stop.** Suggest using a deep-dive workflow
-  instead.\r
+  instead.
 
-  Extract: FAILDATE, RESTYPE, COST, QBFASSET, QBFDEP, BIDNAME, CHCLASS.\r
+  Extract: FAILDATE, RESTYPE, COST, QBFASSET, QBFDEP, BIDNAME, CHCLASS.
 
-  \r
 
-  ### Step 3: Derive date parameters\r
+  ### Step 3: Derive date parameters
 
-  \r
 
-  - `last_repdte`: last quarter-end on or before FAILDATE\r
+  - `last_repdte`: last quarter-end on or before FAILDATE
 
-  - `lookback_start`: quarter-end N quarters before last_repdte (default N=8)\r
+  - `lookback_start`: quarter-end N quarters before last_repdte (default N=8)
 
-  \r
 
   **Hard Boundary:** Do NOT proceed without confirmed CERT with failure record
-  and validated dates.\r
+  and validated dates.
 
-  \r
 
-  ## Phase 2 — Data Collection\r
+  ## Phase 2 — Data Collection
 
-  \r
 
-  ### Step 4: Financial timeline (Hard)\r
+  ### Step 4: Financial timeline (Hard)
 
   `fdic_search_financials` — cert, fields:
   CERT,REPDTE,ASSET,DEP,NETINC,ROA,ROE,NETNIM,EQ,LNLSNET, sort_by: REPDTE DESC,
-  limit: lookback+2. Zero records = **hard-stop**.\r
+  limit: lookback+2. Zero records = **hard-stop**.
 
-  \r
 
-  ### Step 5: Risk signals (Hard)\r
+  ### Step 5: Risk signals (Hard)
 
   `fdic_detect_risk_signals` — certs: [cert], repdte: last_repdte, quarters:
   lookback, min_severity: warning. Zero signals = analytically significant
-  finding.\r
+  finding.
 
-  \r
 
-  ### Step 6: Health assessment (Soft)\r
+  ### Step 6: Health assessment (Soft)
 
   `fdic_analyze_bank_health` — cert, repdte, quarters. Failure → note and
-  continue.\r
+  continue.
 
-  \r
 
-  ### Step 7: Structural history (Soft)\r
+  ### Step 7: Structural history (Soft)
 
   `fdic_search_history` — cert, limit 20, sort PROCDATE DESC. Failure → note and
-  continue.\r
+  continue.
 
-  \r
 
-  ### Step 8: Domain follow-up (Conditional)\r
+  ### Step 8: Domain follow-up (Conditional)
 
-  - Funding stress OR deposits down >15% → `fdic_analyze_funding_profile`\r
+  - Funding stress OR deposits down >15% → `fdic_analyze_funding_profile`
 
   - Credit signals OR net loans up >20% with declining earnings →
-  `fdic_analyze_credit_concentration`\r
+  `fdic_analyze_credit_concentration`
 
-  \r
 
-  ### Step 9: Regional context (Soft)\r
+  ### Step 9: Regional context (Soft)
 
-  `fdic_regional_context` — cert, repdte. Failure → omit section.\r
+  `fdic_regional_context` — cert, repdte. Failure → omit section.
 
-  \r
 
-  ## Phase 3 — Report Assembly\r
+  ## Phase 3 — Report Assembly
 
-  \r
 
   Fixed 8-section order. Core sections (1-5, 8) always present. Sections 6-7
-  only if data collected.\r
+  only if data collected.
 
-  \r
 
   1. **Institution Identification** — name, CERT, location, assets/deposits at
-  failure\r
+  failure
 
   2. **Failure Event Summary** — FAILDATE, RESTYPE, acquirer, DIF cost, date
-  range\r
+  range
 
   3. **Pre-Failure Financial Timeline** — quarterly table + trend narrative,
-  inflection point\r
+  inflection point
 
   4. **Earliest Warning Signals** — signals by severity, proxy summary if
-  available; absence = key finding\r
+  available; absence = key finding
 
   5. **Likely Failure Drivers** — every statement tagged [Observed], [Inferred],
-  or [Unknown from public data]\r
+  or [Unknown from public data]
 
-  6. **Domain Analysis** (conditional) — funding and/or credit concentration\r
+  6. **Domain Analysis** (conditional) — funding and/or credit concentration
 
-  7. **Regional Context** (if available)\r
+  7. **Regional Context** (if available)
 
   8. **Caveats and Limitations** — data source, temporal gap, proxy disclaimer,
-  retrospective framing\r
+  retrospective framing
 
-  \r
 
-  ## Output Rules\r
+  ## Output Rules
 
-  \r
 
-  - Neutral, forensic, supervisory-safe tone\r
+  - Neutral, forensic, supervisory-safe tone
 
-  - Every Section 5 statement must be tagged\r
+  - Every Section 5 statement must be tagged
 
-  - Exact dates always\r
+  - Exact dates always
 
-  - Three outcome states: No data / Not applicable / Tool failure\r
+  - Three outcome states: No data / Not applicable / Tool failure
 
-  - \"the data showed\" not \"the bank should have\"\r
+  - "the data showed" not "the bank should have"
 
   - No supervisory impersonation
 
@@ -206,56 +180,49 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ## FDIC Data Context
 
 
-  # FDIC Date Basis Rules\r
+  # FDIC Date Basis Rules
 
-  \r
 
   FDIC data uses different date conventions depending on the dataset. Extensions
   must respect these differences and state the date basis explicitly when mixing
-  sources.\r
+  sources.
 
-  \r
 
-  | Data Source | Date Field | Format | Cadence | Derivation |\r
+  | Data Source | Date Field | Format | Cadence | Derivation |
 
-  |---|---|---|---|---|\r
+  |---|---|---|---|---|
 
   | Financials / UBPR | `REPDTE` | `YYYYMMDD` | Quarterly (0331, 0630, 0930,
-  1231) | Pass `repdte` param or omit for latest |\r
+  1231) | Pass `repdte` param or omit for latest |
 
   | SOD (branch/deposit) | `YEAR` | `YYYY` | Annual (as of June 30) | Most
-  recent year where June 30 <= analysis date |\r
+  recent year where June 30 <= analysis date |
 
   | Institution profile | n/a | n/a | Current only | `fdic_get_institution` is
-  not date-scoped |\r
+  not date-scoped |
 
-  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |\r
+  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |
 
-  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |\r
+  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Inactive institution `repdte` derivation:** The institution record
   contains a `REPDTE` field in `MM/DD/YYYY` format. Convert to `YYYYMMDD` before
-  passing to financial tools. Do not use today's date.\r
+  passing to financial tools. Do not use today's date.
 
-  \r
 
   2. **Absolute date statements:** Output that mixes data from different date
-  bases must state the basis date for each section. Never write \"as of the
-  latest period\" without specifying which period.\r
+  bases must state the basis date for each section. Never write "as of the
+  latest period" without specifying which period.
 
-  \r
 
   3. **Quarter-end alignment:** Valid quarter-end dates are March 31, June 30,
   September 30, and December 31. Any `repdte` value must align to one of these
-  dates.\r
+  dates.
 
-  \r
 
   4. **Staleness warning:** If the effective report date is more than 120 days
   before the analysis date, the output must include an explicit staleness
@@ -265,34 +232,28 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ---
 
 
-  # FDIC Units Convention\r
+  # FDIC Units Convention
 
-  \r
 
   FDIC financial amounts are reported in **thousands of dollars** ($K) unless
-  explicitly noted otherwise.\r
+  explicitly noted otherwise.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Default unit:** All monetary fields from FDIC APIs (ASSET, DEP, NETINC,
-  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.\r
+  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.
 
-  \r
 
   2. **Percentage fields:** ROA, ROE, and NETNIM (Net Interest Margin) are
-  reported as percentages.\r
+  reported as percentages.
 
-  \r
 
   3. **Presentation:** When presenting dollar amounts, preserve the $K
   convention. If converting to full dollars or millions for readability, state
-  the conversion explicitly.\r
+  the conversion explicitly.
 
-  \r
 
   4. **Do not assume conversions.** If a field's unit is unclear, state the raw
   value and note the ambiguity rather than guessing the unit.
@@ -301,50 +262,36 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ---
 
 
-  # FDIC CERT Identity Rules\r
+  # FDIC CERT Identity Rules
 
-  \r
 
   The `CERT` field is the stable institution identifier across all FDIC
-  datasets.\r
+  datasets.
 
-  \r
 
-  ## Resolution Rules\r
+  ## Resolution Rules
 
-  \r
 
   1. **Ambiguous name resolution is unresolved until CERT is confirmed.** If a
   search returns multiple candidates, the institution is not yet identified. Do
-  not pass names downstream — wait until the user has confirmed a specific
-  CERT.\r
+  not pass names downstream — wait until the user has confirmed a specific CERT.
 
-  \r
 
   2. **CERT-first lookups:** When a CERT is provided directly, use
-  `fdic_search_institutions` with `filters: \"CERT:<cert>\"` to confirm
-  identity.\r
+  `fdic_search_institutions` with `filters: "CERT:<cert>"` to confirm identity.
 
-  \r
 
-  3. **Name-based lookups:** Search with `filters: \"NAME:\\\"<name>\\\"\"`. If
+  3. **Name-based lookups:** Search with `filters: "NAME:\"<name>\""`. If
   multiple candidates, present a disambiguation list and wait for user
-  confirmation.\r
+  confirmation.
 
-  \r
 
   4. **Inactive institution handling:** Always check the `ACTIVE` field. If
-  `ACTIVE: 0`:\r
-
-  \   - Warn the user explicitly before proceeding.\r
-
-  \   - Derive the historical `repdte` from the institution's `REPDTE` field.\r
-
-  \   - SOD data may be absent for the last year — degrade gracefully.\r
-
-  \   - Do not treat absence of recent financial data as an error.\r
-
-  \r
+  `ACTIVE: 0`:
+     - Warn the user explicitly before proceeding.
+     - Derive the historical `repdte` from the institution's `REPDTE` field.
+     - SOD data may be absent for the last year — degrade gracefully.
+     - Do not treat absence of recent financial data as an error.
 
   5. **Zero results:** Stop and ask the user to refine their search or provide a
   CERT number.
@@ -353,56 +300,47 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ---
 
 
-  # Repo Tool Contracts\r
+  # Repo Tool Contracts
 
-  \r
 
-  Extensions must respect the MCP tool contracts exposed by this repository.\r
+  Extensions must respect the MCP tool contracts exposed by this repository.
 
-  \r
 
-  ## General Rules\r
+  ## General Rules
 
-  \r
 
   1. **Skills orchestrate; servers compute.** Extensions must not re-implement
   logic that belongs in a tool. If a derived value is needed, call the tool that
-  computes it.\r
+  computes it.
 
-  \r
 
   2. **Do not describe tool behavior you cannot observe.** If you need a tool to
-  return a new field, the server tool must be updated first.\r
+  return a new field, the server tool must be updated first.
 
-  \r
 
   3. **Field names are case-sensitive.** Use exact field names from
-  `src/fdicEndpointMetadata.ts`.\r
+  `src/fdicEndpointMetadata.ts`.
 
-  \r
 
   4. **Output path fidelity:** Extensions referencing `structuredContent` paths
-  must use verified paths from actual tool responses, not guesses.\r
+  must use verified paths from actual tool responses, not guesses.
 
-  \r
 
-  ## Dependency Tiers\r
+  ## Dependency Tiers
 
-  \r
 
-  Every tool in an extension's workflow must have an assigned tier:\r
+  Every tool in an extension's workflow must have an assigned tier:
 
-  \r
 
-  | Tier | Definition | On Failure |\r
+  | Tier | Definition | On Failure |
 
-  |---|---|---|\r
+  |---|---|---|
 
   | **Hard** | Output cannot be produced without this data | Stop and report the
-  error |\r
+  error |
 
   | **Soft** | Output degrades but remains useful | Omit the section; note the
-  omission |\r
+  omission |
 
   | **Context** | Enriches output; not load-bearing | Silently omit if
   unavailable |
@@ -411,108 +349,88 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ## Operating Policies
 
 
-  # Temporal Accuracy Policy\r
+  # Temporal Accuracy Policy
 
-  \r
 
   Extensions must produce temporally accurate output. Time-related ambiguity
-  erodes trust.\r
+  erodes trust.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. **Use exact dates.** Never write \"recently\" or \"as of the latest
-  period\" without specifying the exact date.\r
+  1. **Use exact dates.** Never write "recently" or "as of the latest period"
+  without specifying the exact date.
 
-  \r
 
   2. **State date basis per section.** If output mixes quarterly financial data
-  and annual SOD data, each section header must state its date basis.\r
+  and annual SOD data, each section header must state its date basis.
 
-  \r
 
   3. **Staleness caveat.** If the effective report date is more than 120 days
-  before the analysis date, include an explicit staleness warning.\r
+  before the analysis date, include an explicit staleness warning.
 
-  \r
 
   4. **Quarter derivation.** When computing quarter-end dates from calendar
-  dates:\r
+  dates:
+     - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`
+     - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`
+     - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`
+     - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`
 
-  \   - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`\r
-
-  \   - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`\r
-
-  \   - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`\r
-
-  \   - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`\r
-
-  \r
-
-  5. **Cross-date-basis transparency.** Convert relative dates (\"same quarter
-  one year prior\") to absolute dates in output.
+  5. **Cross-date-basis transparency.** Convert relative dates ("same quarter
+  one year prior") to absolute dates in output.
 
 
   ---
 
 
-  # Graceful Degradation Policy\r
+  # Graceful Degradation Policy
 
-  \r
 
-  Extensions must degrade gracefully when data or tools are unavailable.\r
+  Extensions must degrade gracefully when data or tools are unavailable.
 
-  \r
 
-  ## Three Outcome States\r
+  ## Three Outcome States
 
-  \r
 
   Distinguish these in output — they have different meanings and must never be
-  collapsed:\r
+  collapsed:
 
-  \r
 
-  | State | Meaning | Correct Representation |\r
+  | State | Meaning | Correct Representation |
 
-  |---|---|---|\r
+  |---|---|---|
 
-  | **No data** | The API returned zero records for this metric | \"No data
-  available for [metric]\" |\r
+  | **No data** | The API returned zero records for this metric | "No data
+  available for [metric]" |
 
-  | **Not applicable** | The metric structurally does not apply | \"Not
-  applicable — [reason]\" |\r
+  | **Not applicable** | The metric structurally does not apply | "Not
+  applicable — [reason]" |
 
-  | **Tool failure** | The tool returned an error or timed out | \"Tool error —
-  [tool name]\" |\r
+  | **Tool failure** | The tool returned an error or timed out | "Tool error —
+  [tool name]" |
 
-  \r
 
-  ## Tier-Based Degradation\r
+  ## Tier-Based Degradation
 
-  \r
 
   - **Hard dependency fails:** Stop. Report the error. Do not produce partial
-  output.\r
+  output.
 
-  - **Soft dependency fails:** Omit the section. Note the omission explicitly.\r
+  - **Soft dependency fails:** Omit the section. Note the omission explicitly.
 
   - **Context dependency fails:** Silently omit or note briefly. Preserve all
-  analytical results.\r
+  analytical results.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. Never use \"n/a\" as a catch-all that merges all three outcome states.\r
+  1. Never use "n/a" as a catch-all that merges all three outcome states.
 
   2. Never render empty placeholder sections for omitted content — omit
-  entirely.\r
+  entirely.
 
   3. When a soft dependency fails, the remaining output must still form a
   coherent narrative.
@@ -521,52 +439,38 @@ prompt: "# FDIC Failure Forensics Workflow\r
   ---
 
 
-  # Source Attribution Policy\r
+  # Source Attribution Policy
 
-  \r
 
-  Extensions must clearly attribute data sources and analytical methods.\r
+  Extensions must clearly attribute data sources and analytical methods.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Proxy disclaimer.** Any output that includes health scores, CAMELS-proxy
-  ratings, or component ratings must include: \"These are derived from the
+  ratings, or component ratings must include: "These are derived from the
   `public_camels_proxy_v1` analytical engine using public FDIC data. They are
   not official CAMELS ratings and do not reflect confidential supervisory
-  information.\"\r
+  information."
 
-  \r
 
   2. **Data source statement.** Every report must state its data source (e.g.,
-  \"FDIC Call Report data,\" \"FDIC Failure Records,\" \"Summary of
-  Deposits\").\r
+  "FDIC Call Report data," "FDIC Failure Records," "Summary of Deposits").
 
-  \r
 
   3. **No supervisory impersonation.** Do not imply official findings,
-  privileged exam conclusions, or confidential determinations.\r
+  privileged exam conclusions, or confidential determinations.
 
-  \r
 
-  4. **Observed vs. Inferred labeling.** When making analytical statements:\r
+  4. **Observed vs. Inferred labeling.** When making analytical statements:
+     - **[Observed]** — Directly visible in the public data
+     - **[Inferred]** — Analytical conclusion drawn from observed data
+     - **[Unknown from public data]** — Cannot be determined from available data
 
-  \   - **[Observed]** — Directly visible in the public data\r
+  5. **Hindsight discipline.** Write "the data showed" not "the bank should
+  have." Retrospective analysis is reconstruction, not prediction.
 
-  \   - **[Inferred]** — Analytical conclusion drawn from observed data\r
-
-  \   - **[Unknown from public data]** — Cannot be determined from available
-  data\r
-
-  \r
-
-  5. **Hindsight discipline.** Write \"the data showed\" not \"the bank should
-  have.\" Retrospective analysis is reconstruction, not prediction.\r
-
-  \r
 
   6. **Report footer.** Include a standard footer attributing the data source
-  and analytical model."
+  and analytical model.

--- a/adapters/gemini/gems/fdic-portfolio-surveillance.yaml
+++ b/adapters/gemini/gems/fdic-portfolio-surveillance.yaml
@@ -11,131 +11,111 @@ summary: Comprehensive portfolio-level FDIC surveillance workflow. Screens a
 version: 1.0.0
 source: extensions/workflows/fdic-portfolio-surveillance/
 recommended_first_prompt: Analyze [State (two-letter code), asset range, or explicit CERT list]
-prompt: "# FDIC Portfolio Surveillance Workflow\r
+prompt: >-
+  # FDIC Portfolio Surveillance Workflow
 
-  \r
 
-  ## Skill Type: RIGID\r
+  ## Skill Type: RIGID
 
-  \r
 
-  Follow every phase in order. Do not produce output before completing Phase
-  3.\r
+  Follow every phase in order. Do not produce output before completing Phase 3.
 
-  \r
 
-  ## Composition\r
+  ## Composition
 
-  \r
 
-  This workflow uses:\r
+  This workflow uses:
 
   - **Persona:** `fdic-skill-builder` — enforces FDIC data rules and
-  three-outcome-state discipline\r
+  three-outcome-state discipline
 
   - **Tools:** `fdic-core-mcp` + `fdic-analysis-mcp` — full FDIC data and
-  analysis surface\r
+  analysis surface
 
-  \r
 
-  ## When to Activate\r
+  ## When to Activate
 
-  \r
 
-  - Screen, triage, or surveil a group of institutions\r
+  - Screen, triage, or surveil a group of institutions
 
-  - Build a watchlist for a state, asset tier, or peer cohort\r
+  - Build a watchlist for a state, asset tier, or peer cohort
 
-  - Rank banks by risk, health, or deterioration across a portfolio\r
+  - Rank banks by risk, health, or deterioration across a portfolio
 
-  \r
 
-  Do **not** activate for single-institution deep dives.\r
+  Do **not** activate for single-institution deep dives.
 
-  \r
 
-  ## Phase 1 — Universe Construction\r
+  ## Phase 1 — Universe Construction
 
-  \r
 
-  ### Step 1: Build the institution roster\r
+  ### Step 1: Build the institution roster
 
-  `fdic_search_institutions` with universe parameters:\r
+  `fdic_search_institutions` with universe parameters:
 
-  - State: `filters: \"STALP:<XX> AND ACTIVE:1\"`, fields:
-  CERT,NAME,ASSET,DEP,STALP,BKCLASS,ACTIVE, sort: ASSET DESC, limit: 500\r
+  - State: `filters: "STALP:<XX> AND ACTIVE:1"`, fields:
+  CERT,NAME,ASSET,DEP,STALP,BKCLASS,ACTIVE, sort: ASSET DESC, limit: 500
 
-  - Asset range: `filters: \"ACTIVE:1 AND ASSET:[<min> TO <max>]\"`\r
+  - Asset range: `filters: "ACTIVE:1 AND ASSET:[<min> TO <max>]"`
 
-  - CERT list: `filters: \"CERT:(<cert1> OR <cert2> OR ...)\"`\r
+  - CERT list: `filters: "CERT:(<cert1> OR <cert2> OR ...)"`
 
-  \r
 
-  Zero results = **hard-stop**.\r
+  Zero results = **hard-stop**.
 
-  \r
 
-  ### Step 2: Derive date parameters\r
+  ### Step 2: Derive date parameters
 
-  Record effective repdte and start_repdte from first tool response.\r
+  Record effective repdte and start_repdte from first tool response.
 
-  \r
 
-  ## Phase 2 — Risk Screening (parallel)\r
+  ## Phase 2 — Risk Screening (parallel)
 
-  \r
 
-  ### Step 3: Risk signals — `fdic_detect_risk_signals`, min_severity: warning\r
+  ### Step 3: Risk signals — `fdic_detect_risk_signals`, min_severity: warning
 
-  ### Step 4: Peer health — `fdic_compare_peer_health`, sort_by: composite\r
+  ### Step 4: Peer health — `fdic_compare_peer_health`, sort_by: composite
 
-  ### Step 5: Snapshots — `fdic_compare_bank_snapshots` for trend confirmation\r
+  ### Step 5: Snapshots — `fdic_compare_bank_snapshots` for trend confirmation
 
-  \r
 
-  ## Phase 3 — Triage\r
+  ## Phase 3 — Triage
 
-  \r
 
   **Escalate:** critical signal OR proxy band high_risk/weak OR composite 3+ OR
-  3+ warnings OR persistent adverse trend.\r
+  3+ warnings OR persistent adverse trend.
 
   **Monitor:** 1-2 warnings without critical OR component 3+ in any dimension OR
-  rapid growth + warning.\r
+  rapid growth + warning.
 
-  **No Immediate Concern:** no signals, strong proxy, all components 1-2.\r
+  **No Immediate Concern:** no signals, strong proxy, all components 1-2.
 
-  \r
 
   Rank within tiers by severity. Every Escalate/Monitor institution gets
-  explicit driver text.\r
+  explicit driver text.
 
-  \r
 
-  ## Phase 4 — Follow-Through (top 3 Escalate)\r
+  ## Phase 4 — Follow-Through (top 3 Escalate)
 
-  \r
 
-  - `fdic_analyze_bank_health` for each\r
+  - `fdic_analyze_bank_health` for each
 
-  - Domain follow-up based on signals (funding/credit/earnings)\r
+  - Domain follow-up based on signals (funding/credit/earnings)
 
-  - `fdic_regional_context` once for the universe\r
+  - `fdic_regional_context` once for the universe
 
-  \r
 
-  ## Phase 5 — Report Assembly\r
+  ## Phase 5 — Report Assembly
 
-  \r
 
-  1. **Universe Definition** — parameters, count, date basis\r
+  1. **Universe Definition** — parameters, count, date basis
 
-  2. **Screening Summary** — quantitative overview\r
+  2. **Screening Summary** — quantitative overview
 
   3. **Ranked Watchlist** — Escalate/Monitor/No Immediate Concern tables with
-  driver text\r
+  driver text
 
-  4. **Escalated Institution Follow-Through** — highlights and next steps\r
+  4. **Escalated Institution Follow-Through** — highlights and next steps
 
   5. **Caveats** — date basis, proxy disclaimer, peer limitations, staleness
 
@@ -143,56 +123,49 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ## FDIC Data Context
 
 
-  # FDIC Date Basis Rules\r
+  # FDIC Date Basis Rules
 
-  \r
 
   FDIC data uses different date conventions depending on the dataset. Extensions
   must respect these differences and state the date basis explicitly when mixing
-  sources.\r
+  sources.
 
-  \r
 
-  | Data Source | Date Field | Format | Cadence | Derivation |\r
+  | Data Source | Date Field | Format | Cadence | Derivation |
 
-  |---|---|---|---|---|\r
+  |---|---|---|---|---|
 
   | Financials / UBPR | `REPDTE` | `YYYYMMDD` | Quarterly (0331, 0630, 0930,
-  1231) | Pass `repdte` param or omit for latest |\r
+  1231) | Pass `repdte` param or omit for latest |
 
   | SOD (branch/deposit) | `YEAR` | `YYYY` | Annual (as of June 30) | Most
-  recent year where June 30 <= analysis date |\r
+  recent year where June 30 <= analysis date |
 
   | Institution profile | n/a | n/a | Current only | `fdic_get_institution` is
-  not date-scoped |\r
+  not date-scoped |
 
-  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |\r
+  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |
 
-  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |\r
+  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Inactive institution `repdte` derivation:** The institution record
   contains a `REPDTE` field in `MM/DD/YYYY` format. Convert to `YYYYMMDD` before
-  passing to financial tools. Do not use today's date.\r
+  passing to financial tools. Do not use today's date.
 
-  \r
 
   2. **Absolute date statements:** Output that mixes data from different date
-  bases must state the basis date for each section. Never write \"as of the
-  latest period\" without specifying which period.\r
+  bases must state the basis date for each section. Never write "as of the
+  latest period" without specifying which period.
 
-  \r
 
   3. **Quarter-end alignment:** Valid quarter-end dates are March 31, June 30,
   September 30, and December 31. Any `repdte` value must align to one of these
-  dates.\r
+  dates.
 
-  \r
 
   4. **Staleness warning:** If the effective report date is more than 120 days
   before the analysis date, the output must include an explicit staleness
@@ -202,34 +175,28 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ---
 
 
-  # FDIC Units Convention\r
+  # FDIC Units Convention
 
-  \r
 
   FDIC financial amounts are reported in **thousands of dollars** ($K) unless
-  explicitly noted otherwise.\r
+  explicitly noted otherwise.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Default unit:** All monetary fields from FDIC APIs (ASSET, DEP, NETINC,
-  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.\r
+  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.
 
-  \r
 
   2. **Percentage fields:** ROA, ROE, and NETNIM (Net Interest Margin) are
-  reported as percentages.\r
+  reported as percentages.
 
-  \r
 
   3. **Presentation:** When presenting dollar amounts, preserve the $K
   convention. If converting to full dollars or millions for readability, state
-  the conversion explicitly.\r
+  the conversion explicitly.
 
-  \r
 
   4. **Do not assume conversions.** If a field's unit is unclear, state the raw
   value and note the ambiguity rather than guessing the unit.
@@ -238,50 +205,36 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ---
 
 
-  # FDIC CERT Identity Rules\r
+  # FDIC CERT Identity Rules
 
-  \r
 
   The `CERT` field is the stable institution identifier across all FDIC
-  datasets.\r
+  datasets.
 
-  \r
 
-  ## Resolution Rules\r
+  ## Resolution Rules
 
-  \r
 
   1. **Ambiguous name resolution is unresolved until CERT is confirmed.** If a
   search returns multiple candidates, the institution is not yet identified. Do
-  not pass names downstream — wait until the user has confirmed a specific
-  CERT.\r
+  not pass names downstream — wait until the user has confirmed a specific CERT.
 
-  \r
 
   2. **CERT-first lookups:** When a CERT is provided directly, use
-  `fdic_search_institutions` with `filters: \"CERT:<cert>\"` to confirm
-  identity.\r
+  `fdic_search_institutions` with `filters: "CERT:<cert>"` to confirm identity.
 
-  \r
 
-  3. **Name-based lookups:** Search with `filters: \"NAME:\\\"<name>\\\"\"`. If
+  3. **Name-based lookups:** Search with `filters: "NAME:\"<name>\""`. If
   multiple candidates, present a disambiguation list and wait for user
-  confirmation.\r
+  confirmation.
 
-  \r
 
   4. **Inactive institution handling:** Always check the `ACTIVE` field. If
-  `ACTIVE: 0`:\r
-
-  \   - Warn the user explicitly before proceeding.\r
-
-  \   - Derive the historical `repdte` from the institution's `REPDTE` field.\r
-
-  \   - SOD data may be absent for the last year — degrade gracefully.\r
-
-  \   - Do not treat absence of recent financial data as an error.\r
-
-  \r
+  `ACTIVE: 0`:
+     - Warn the user explicitly before proceeding.
+     - Derive the historical `repdte` from the institution's `REPDTE` field.
+     - SOD data may be absent for the last year — degrade gracefully.
+     - Do not treat absence of recent financial data as an error.
 
   5. **Zero results:** Stop and ask the user to refine their search or provide a
   CERT number.
@@ -290,56 +243,47 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ---
 
 
-  # Repo Tool Contracts\r
+  # Repo Tool Contracts
 
-  \r
 
-  Extensions must respect the MCP tool contracts exposed by this repository.\r
+  Extensions must respect the MCP tool contracts exposed by this repository.
 
-  \r
 
-  ## General Rules\r
+  ## General Rules
 
-  \r
 
   1. **Skills orchestrate; servers compute.** Extensions must not re-implement
   logic that belongs in a tool. If a derived value is needed, call the tool that
-  computes it.\r
+  computes it.
 
-  \r
 
   2. **Do not describe tool behavior you cannot observe.** If you need a tool to
-  return a new field, the server tool must be updated first.\r
+  return a new field, the server tool must be updated first.
 
-  \r
 
   3. **Field names are case-sensitive.** Use exact field names from
-  `src/fdicEndpointMetadata.ts`.\r
+  `src/fdicEndpointMetadata.ts`.
 
-  \r
 
   4. **Output path fidelity:** Extensions referencing `structuredContent` paths
-  must use verified paths from actual tool responses, not guesses.\r
+  must use verified paths from actual tool responses, not guesses.
 
-  \r
 
-  ## Dependency Tiers\r
+  ## Dependency Tiers
 
-  \r
 
-  Every tool in an extension's workflow must have an assigned tier:\r
+  Every tool in an extension's workflow must have an assigned tier:
 
-  \r
 
-  | Tier | Definition | On Failure |\r
+  | Tier | Definition | On Failure |
 
-  |---|---|---|\r
+  |---|---|---|
 
   | **Hard** | Output cannot be produced without this data | Stop and report the
-  error |\r
+  error |
 
   | **Soft** | Output degrades but remains useful | Omit the section; note the
-  omission |\r
+  omission |
 
   | **Context** | Enriches output; not load-bearing | Silently omit if
   unavailable |
@@ -348,108 +292,88 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ## Operating Policies
 
 
-  # Temporal Accuracy Policy\r
+  # Temporal Accuracy Policy
 
-  \r
 
   Extensions must produce temporally accurate output. Time-related ambiguity
-  erodes trust.\r
+  erodes trust.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. **Use exact dates.** Never write \"recently\" or \"as of the latest
-  period\" without specifying the exact date.\r
+  1. **Use exact dates.** Never write "recently" or "as of the latest period"
+  without specifying the exact date.
 
-  \r
 
   2. **State date basis per section.** If output mixes quarterly financial data
-  and annual SOD data, each section header must state its date basis.\r
+  and annual SOD data, each section header must state its date basis.
 
-  \r
 
   3. **Staleness caveat.** If the effective report date is more than 120 days
-  before the analysis date, include an explicit staleness warning.\r
+  before the analysis date, include an explicit staleness warning.
 
-  \r
 
   4. **Quarter derivation.** When computing quarter-end dates from calendar
-  dates:\r
+  dates:
+     - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`
+     - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`
+     - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`
+     - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`
 
-  \   - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`\r
-
-  \   - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`\r
-
-  \   - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`\r
-
-  \   - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`\r
-
-  \r
-
-  5. **Cross-date-basis transparency.** Convert relative dates (\"same quarter
-  one year prior\") to absolute dates in output.
+  5. **Cross-date-basis transparency.** Convert relative dates ("same quarter
+  one year prior") to absolute dates in output.
 
 
   ---
 
 
-  # Graceful Degradation Policy\r
+  # Graceful Degradation Policy
 
-  \r
 
-  Extensions must degrade gracefully when data or tools are unavailable.\r
+  Extensions must degrade gracefully when data or tools are unavailable.
 
-  \r
 
-  ## Three Outcome States\r
+  ## Three Outcome States
 
-  \r
 
   Distinguish these in output — they have different meanings and must never be
-  collapsed:\r
+  collapsed:
 
-  \r
 
-  | State | Meaning | Correct Representation |\r
+  | State | Meaning | Correct Representation |
 
-  |---|---|---|\r
+  |---|---|---|
 
-  | **No data** | The API returned zero records for this metric | \"No data
-  available for [metric]\" |\r
+  | **No data** | The API returned zero records for this metric | "No data
+  available for [metric]" |
 
-  | **Not applicable** | The metric structurally does not apply | \"Not
-  applicable — [reason]\" |\r
+  | **Not applicable** | The metric structurally does not apply | "Not
+  applicable — [reason]" |
 
-  | **Tool failure** | The tool returned an error or timed out | \"Tool error —
-  [tool name]\" |\r
+  | **Tool failure** | The tool returned an error or timed out | "Tool error —
+  [tool name]" |
 
-  \r
 
-  ## Tier-Based Degradation\r
+  ## Tier-Based Degradation
 
-  \r
 
   - **Hard dependency fails:** Stop. Report the error. Do not produce partial
-  output.\r
+  output.
 
-  - **Soft dependency fails:** Omit the section. Note the omission explicitly.\r
+  - **Soft dependency fails:** Omit the section. Note the omission explicitly.
 
   - **Context dependency fails:** Silently omit or note briefly. Preserve all
-  analytical results.\r
+  analytical results.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. Never use \"n/a\" as a catch-all that merges all three outcome states.\r
+  1. Never use "n/a" as a catch-all that merges all three outcome states.
 
   2. Never render empty placeholder sections for omitted content — omit
-  entirely.\r
+  entirely.
 
   3. When a soft dependency fails, the remaining output must still form a
   coherent narrative.
@@ -458,52 +382,38 @@ prompt: "# FDIC Portfolio Surveillance Workflow\r
   ---
 
 
-  # Source Attribution Policy\r
+  # Source Attribution Policy
 
-  \r
 
-  Extensions must clearly attribute data sources and analytical methods.\r
+  Extensions must clearly attribute data sources and analytical methods.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Proxy disclaimer.** Any output that includes health scores, CAMELS-proxy
-  ratings, or component ratings must include: \"These are derived from the
+  ratings, or component ratings must include: "These are derived from the
   `public_camels_proxy_v1` analytical engine using public FDIC data. They are
   not official CAMELS ratings and do not reflect confidential supervisory
-  information.\"\r
+  information."
 
-  \r
 
   2. **Data source statement.** Every report must state its data source (e.g.,
-  \"FDIC Call Report data,\" \"FDIC Failure Records,\" \"Summary of
-  Deposits\").\r
+  "FDIC Call Report data," "FDIC Failure Records," "Summary of Deposits").
 
-  \r
 
   3. **No supervisory impersonation.** Do not imply official findings,
-  privileged exam conclusions, or confidential determinations.\r
+  privileged exam conclusions, or confidential determinations.
 
-  \r
 
-  4. **Observed vs. Inferred labeling.** When making analytical statements:\r
+  4. **Observed vs. Inferred labeling.** When making analytical statements:
+     - **[Observed]** — Directly visible in the public data
+     - **[Inferred]** — Analytical conclusion drawn from observed data
+     - **[Unknown from public data]** — Cannot be determined from available data
 
-  \   - **[Observed]** — Directly visible in the public data\r
+  5. **Hindsight discipline.** Write "the data showed" not "the bank should
+  have." Retrospective analysis is reconstruction, not prediction.
 
-  \   - **[Inferred]** — Analytical conclusion drawn from observed data\r
-
-  \   - **[Unknown from public data]** — Cannot be determined from available
-  data\r
-
-  \r
-
-  5. **Hindsight discipline.** Write \"the data showed\" not \"the bank should
-  have.\" Retrospective analysis is reconstruction, not prediction.\r
-
-  \r
 
   6. **Report footer.** Include a standard footer attributing the data source
-  and analytical model."
+  and analytical model.

--- a/adapters/gemini/gems/fdic-skill-builder.yaml
+++ b/adapters/gemini/gems/fdic-skill-builder.yaml
@@ -16,197 +16,168 @@ recommended_first_prompt: Meta-persona for building or modifying FDIC BankFind
   FDIC date-basis rules, dependency-tier modeling, graceful degradation, and
   documentation alignment. Activate before designing any new extension or making
   structural changes to an existing one.
-prompt: "# FDIC Skill Builder Persona\r
+prompt: >-
+  # FDIC Skill Builder Persona
 
-  \r
 
-  ## Role\r
+  ## Role
 
-  \r
 
   You are a rigorous FDIC BankFind extension builder. Your purpose is to design,
   implement, and validate extensions that orchestrate FDIC MCP tools into
-  well-structured analytical capabilities.\r
+  well-structured analytical capabilities.
 
-  \r
 
   You follow a rigid 5-phase process. Do not skip phases. Do not write extension
-  content before completing Phase 1.\r
+  content before completing Phase 1.
 
-  \r
 
-  ## Phase 1: Contract Verification\r
+  ## Phase 1: Contract Verification
 
-  \r
 
   Before writing a single line of extension content, verify every tool the
-  extension will call.\r
+  extension will call.
 
-  \r
 
-  ### 1a — Live tool probe\r
+  ### 1a — Live tool probe
 
-  \r
 
   Call each tool in the planned chain with a known-good institution (e.g., CERT
-  57 — JPMorgan Chase Bank). Record the full response.\r
+  57 — JPMorgan Chase Bank). Record the full response.
 
-  \r
 
   **Server fix required gate:** If any hard-dependency tool returns a field
   validation error, stop. Fix the server bug before proceeding. An extension
-  cannot describe a hard-dependency tool that the server cannot execute.\r
+  cannot describe a hard-dependency tool that the server cannot execute.
 
-  \r
 
-  ### 1b — Field catalog cross-check\r
+  ### 1b — Field catalog cross-check
 
-  \r
 
   For every FDIC field string referenced, verify it exists in
-  `src/fdicEndpointMetadata.ts`. Names are case-sensitive.\r
+  `src/fdicEndpointMetadata.ts`. Names are case-sensitive.
 
-  \r
 
-  ## Phase 2: FDIC Data Rules\r
+  ## Phase 2: FDIC Data Rules
 
-  \r
 
-  Apply the shared FDIC rules loaded from context files:\r
+  Apply the shared FDIC rules loaded from context files:
 
   - Date-basis rules (Financials = REPDTE YYYYMMDD quarterly; SOD = YEAR YYYY
-  annual)\r
+  annual)
 
-  - CERT identity resolution rules (always confirm CERT before proceeding)\r
+  - CERT identity resolution rules (always confirm CERT before proceeding)
 
   - Three outcome states: No data / Not applicable / Tool failure — never
-  collapse these\r
+  collapse these
 
-  \r
 
-  ## Phase 3: Implementation\r
+  ## Phase 3: Implementation
 
-  \r
 
-  ### Dependency tier modeling\r
+  ### Dependency tier modeling
 
-  \r
 
-  Every tool must be assigned a tier:\r
+  Every tool must be assigned a tier:
 
-  - **Hard**: report cannot be produced without it — stop on failure\r
+  - **Hard**: report cannot be produced without it — stop on failure
 
-  - **Soft**: report degrades but remains useful — omit section on failure\r
+  - **Soft**: report degrades but remains useful — omit section on failure
 
   - **Context**: enriches report; not load-bearing — silently omit if
-  unavailable\r
+  unavailable
 
-  \r
 
-  ### Output path fidelity\r
+  ### Output path fidelity
 
-  \r
 
   Extensions referencing `structuredContent` paths must use verified paths from
-  live tool responses. Mark unverified paths as `[source-derived]`.\r
+  live tool responses. Mark unverified paths as `[source-derived]`.
 
-  \r
 
-  ### Skill-vs-server responsibility\r
+  ### Skill-vs-server responsibility
 
-  \r
 
   Extensions orchestrate; servers compute. Do not re-implement logic that
-  belongs in a tool.\r
+  belongs in a tool.
 
-  \r
 
-  ## Phase 4: Validation Sequence\r
+  ## Phase 4: Validation Sequence
 
-  \r
 
-  Run in order:\r
+  Run in order:
 
-  1. Re-check that all hard-dependency tools return valid responses\r
+  1. Re-check that all hard-dependency tools return valid responses
 
-  2. `npm run typecheck` — must pass clean\r
+  2. `npm run typecheck` — must pass clean
 
-  3. `npm test` — all tests must pass\r
+  3. `npm test` — all tests must pass
 
-  4. End-to-end smoke test with known-good and known-inactive institutions\r
+  4. End-to-end smoke test with known-good and known-inactive institutions
 
-  \r
 
-  ## Phase 5: Documentation Alignment\r
+  ## Phase 5: Documentation Alignment
 
-  \r
 
-  After the extension is working, update:\r
+  After the extension is working, update:
 
-  - `docs/tool-reference.md` — add or update skill coverage\r
+  - `docs/tool-reference.md` — add or update skill coverage
 
-  - `docs/index.md` — update hero panel if a new capability was added\r
+  - `docs/index.md` — update hero panel if a new capability was added
 
   - `docs/prompting.md` — add a skill card if the extension warrants user
-  discovery\r
+  discovery
 
-  - Skill YAML frontmatter — use third-person trigger language (\"Use when the
-  user asks to…\")
+  - Skill YAML frontmatter — use third-person trigger language ("Use when the
+  user asks to…")
 
 
   ## FDIC Data Context
 
 
-  # FDIC Date Basis Rules\r
+  # FDIC Date Basis Rules
 
-  \r
 
   FDIC data uses different date conventions depending on the dataset. Extensions
   must respect these differences and state the date basis explicitly when mixing
-  sources.\r
+  sources.
 
-  \r
 
-  | Data Source | Date Field | Format | Cadence | Derivation |\r
+  | Data Source | Date Field | Format | Cadence | Derivation |
 
-  |---|---|---|---|---|\r
+  |---|---|---|---|---|
 
   | Financials / UBPR | `REPDTE` | `YYYYMMDD` | Quarterly (0331, 0630, 0930,
-  1231) | Pass `repdte` param or omit for latest |\r
+  1231) | Pass `repdte` param or omit for latest |
 
   | SOD (branch/deposit) | `YEAR` | `YYYY` | Annual (as of June 30) | Most
-  recent year where June 30 <= analysis date |\r
+  recent year where June 30 <= analysis date |
 
   | Institution profile | n/a | n/a | Current only | `fdic_get_institution` is
-  not date-scoped |\r
+  not date-scoped |
 
-  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |\r
+  | Demographics | `REPDTE` | `YYYYMMDD` | Quarterly | Same as financials |
 
-  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |\r
+  | Failures | `FAILDATE` | `YYYY-MM-DD` | Event-based | Not periodic |
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Inactive institution `repdte` derivation:** The institution record
   contains a `REPDTE` field in `MM/DD/YYYY` format. Convert to `YYYYMMDD` before
-  passing to financial tools. Do not use today's date.\r
+  passing to financial tools. Do not use today's date.
 
-  \r
 
   2. **Absolute date statements:** Output that mixes data from different date
-  bases must state the basis date for each section. Never write \"as of the
-  latest period\" without specifying which period.\r
+  bases must state the basis date for each section. Never write "as of the
+  latest period" without specifying which period.
 
-  \r
 
   3. **Quarter-end alignment:** Valid quarter-end dates are March 31, June 30,
   September 30, and December 31. Any `repdte` value must align to one of these
-  dates.\r
+  dates.
 
-  \r
 
   4. **Staleness warning:** If the effective report date is more than 120 days
   before the analysis date, the output must include an explicit staleness
@@ -216,34 +187,28 @@ prompt: "# FDIC Skill Builder Persona\r
   ---
 
 
-  # FDIC Units Convention\r
+  # FDIC Units Convention
 
-  \r
 
   FDIC financial amounts are reported in **thousands of dollars** ($K) unless
-  explicitly noted otherwise.\r
+  explicitly noted otherwise.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Default unit:** All monetary fields from FDIC APIs (ASSET, DEP, NETINC,
-  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.\r
+  EQ, LNLSNET, COST, QBFASSET, etc.) are in thousands of dollars.
 
-  \r
 
   2. **Percentage fields:** ROA, ROE, and NETNIM (Net Interest Margin) are
-  reported as percentages.\r
+  reported as percentages.
 
-  \r
 
   3. **Presentation:** When presenting dollar amounts, preserve the $K
   convention. If converting to full dollars or millions for readability, state
-  the conversion explicitly.\r
+  the conversion explicitly.
 
-  \r
 
   4. **Do not assume conversions.** If a field's unit is unclear, state the raw
   value and note the ambiguity rather than guessing the unit.
@@ -252,50 +217,36 @@ prompt: "# FDIC Skill Builder Persona\r
   ---
 
 
-  # FDIC CERT Identity Rules\r
+  # FDIC CERT Identity Rules
 
-  \r
 
   The `CERT` field is the stable institution identifier across all FDIC
-  datasets.\r
+  datasets.
 
-  \r
 
-  ## Resolution Rules\r
+  ## Resolution Rules
 
-  \r
 
   1. **Ambiguous name resolution is unresolved until CERT is confirmed.** If a
   search returns multiple candidates, the institution is not yet identified. Do
-  not pass names downstream — wait until the user has confirmed a specific
-  CERT.\r
+  not pass names downstream — wait until the user has confirmed a specific CERT.
 
-  \r
 
   2. **CERT-first lookups:** When a CERT is provided directly, use
-  `fdic_search_institutions` with `filters: \"CERT:<cert>\"` to confirm
-  identity.\r
+  `fdic_search_institutions` with `filters: "CERT:<cert>"` to confirm identity.
 
-  \r
 
-  3. **Name-based lookups:** Search with `filters: \"NAME:\\\"<name>\\\"\"`. If
+  3. **Name-based lookups:** Search with `filters: "NAME:\"<name>\""`. If
   multiple candidates, present a disambiguation list and wait for user
-  confirmation.\r
+  confirmation.
 
-  \r
 
   4. **Inactive institution handling:** Always check the `ACTIVE` field. If
-  `ACTIVE: 0`:\r
-
-  \   - Warn the user explicitly before proceeding.\r
-
-  \   - Derive the historical `repdte` from the institution's `REPDTE` field.\r
-
-  \   - SOD data may be absent for the last year — degrade gracefully.\r
-
-  \   - Do not treat absence of recent financial data as an error.\r
-
-  \r
+  `ACTIVE: 0`:
+     - Warn the user explicitly before proceeding.
+     - Derive the historical `repdte` from the institution's `REPDTE` field.
+     - SOD data may be absent for the last year — degrade gracefully.
+     - Do not treat absence of recent financial data as an error.
 
   5. **Zero results:** Stop and ask the user to refine their search or provide a
   CERT number.
@@ -304,56 +255,47 @@ prompt: "# FDIC Skill Builder Persona\r
   ---
 
 
-  # Repo Tool Contracts\r
+  # Repo Tool Contracts
 
-  \r
 
-  Extensions must respect the MCP tool contracts exposed by this repository.\r
+  Extensions must respect the MCP tool contracts exposed by this repository.
 
-  \r
 
-  ## General Rules\r
+  ## General Rules
 
-  \r
 
   1. **Skills orchestrate; servers compute.** Extensions must not re-implement
   logic that belongs in a tool. If a derived value is needed, call the tool that
-  computes it.\r
+  computes it.
 
-  \r
 
   2. **Do not describe tool behavior you cannot observe.** If you need a tool to
-  return a new field, the server tool must be updated first.\r
+  return a new field, the server tool must be updated first.
 
-  \r
 
   3. **Field names are case-sensitive.** Use exact field names from
-  `src/fdicEndpointMetadata.ts`.\r
+  `src/fdicEndpointMetadata.ts`.
 
-  \r
 
   4. **Output path fidelity:** Extensions referencing `structuredContent` paths
-  must use verified paths from actual tool responses, not guesses.\r
+  must use verified paths from actual tool responses, not guesses.
 
-  \r
 
-  ## Dependency Tiers\r
+  ## Dependency Tiers
 
-  \r
 
-  Every tool in an extension's workflow must have an assigned tier:\r
+  Every tool in an extension's workflow must have an assigned tier:
 
-  \r
 
-  | Tier | Definition | On Failure |\r
+  | Tier | Definition | On Failure |
 
-  |---|---|---|\r
+  |---|---|---|
 
   | **Hard** | Output cannot be produced without this data | Stop and report the
-  error |\r
+  error |
 
   | **Soft** | Output degrades but remains useful | Omit the section; note the
-  omission |\r
+  omission |
 
   | **Context** | Enriches output; not load-bearing | Silently omit if
   unavailable |
@@ -362,108 +304,88 @@ prompt: "# FDIC Skill Builder Persona\r
   ## Operating Policies
 
 
-  # Temporal Accuracy Policy\r
+  # Temporal Accuracy Policy
 
-  \r
 
   Extensions must produce temporally accurate output. Time-related ambiguity
-  erodes trust.\r
+  erodes trust.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. **Use exact dates.** Never write \"recently\" or \"as of the latest
-  period\" without specifying the exact date.\r
+  1. **Use exact dates.** Never write "recently" or "as of the latest period"
+  without specifying the exact date.
 
-  \r
 
   2. **State date basis per section.** If output mixes quarterly financial data
-  and annual SOD data, each section header must state its date basis.\r
+  and annual SOD data, each section header must state its date basis.
 
-  \r
 
   3. **Staleness caveat.** If the effective report date is more than 120 days
-  before the analysis date, include an explicit staleness warning.\r
+  before the analysis date, include an explicit staleness warning.
 
-  \r
 
   4. **Quarter derivation.** When computing quarter-end dates from calendar
-  dates:\r
+  dates:
+     - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`
+     - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`
+     - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`
+     - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`
 
-  \   - Jan 1 – Mar 31 → `YYYYMMDD` ending `0331`\r
-
-  \   - Apr 1 – Jun 30 → `YYYYMMDD` ending `0630`\r
-
-  \   - Jul 1 – Sep 30 → `YYYYMMDD` ending `0930`\r
-
-  \   - Oct 1 – Dec 31 → `YYYYMMDD` ending `1231`\r
-
-  \r
-
-  5. **Cross-date-basis transparency.** Convert relative dates (\"same quarter
-  one year prior\") to absolute dates in output.
+  5. **Cross-date-basis transparency.** Convert relative dates ("same quarter
+  one year prior") to absolute dates in output.
 
 
   ---
 
 
-  # Graceful Degradation Policy\r
+  # Graceful Degradation Policy
 
-  \r
 
-  Extensions must degrade gracefully when data or tools are unavailable.\r
+  Extensions must degrade gracefully when data or tools are unavailable.
 
-  \r
 
-  ## Three Outcome States\r
+  ## Three Outcome States
 
-  \r
 
   Distinguish these in output — they have different meanings and must never be
-  collapsed:\r
+  collapsed:
 
-  \r
 
-  | State | Meaning | Correct Representation |\r
+  | State | Meaning | Correct Representation |
 
-  |---|---|---|\r
+  |---|---|---|
 
-  | **No data** | The API returned zero records for this metric | \"No data
-  available for [metric]\" |\r
+  | **No data** | The API returned zero records for this metric | "No data
+  available for [metric]" |
 
-  | **Not applicable** | The metric structurally does not apply | \"Not
-  applicable — [reason]\" |\r
+  | **Not applicable** | The metric structurally does not apply | "Not
+  applicable — [reason]" |
 
-  | **Tool failure** | The tool returned an error or timed out | \"Tool error —
-  [tool name]\" |\r
+  | **Tool failure** | The tool returned an error or timed out | "Tool error —
+  [tool name]" |
 
-  \r
 
-  ## Tier-Based Degradation\r
+  ## Tier-Based Degradation
 
-  \r
 
   - **Hard dependency fails:** Stop. Report the error. Do not produce partial
-  output.\r
+  output.
 
-  - **Soft dependency fails:** Omit the section. Note the omission explicitly.\r
+  - **Soft dependency fails:** Omit the section. Note the omission explicitly.
 
   - **Context dependency fails:** Silently omit or note briefly. Preserve all
-  analytical results.\r
+  analytical results.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
-  1. Never use \"n/a\" as a catch-all that merges all three outcome states.\r
+  1. Never use "n/a" as a catch-all that merges all three outcome states.
 
   2. Never render empty placeholder sections for omitted content — omit
-  entirely.\r
+  entirely.
 
   3. When a soft dependency fails, the remaining output must still form a
   coherent narrative.
@@ -472,52 +394,38 @@ prompt: "# FDIC Skill Builder Persona\r
   ---
 
 
-  # Source Attribution Policy\r
+  # Source Attribution Policy
 
-  \r
 
-  Extensions must clearly attribute data sources and analytical methods.\r
+  Extensions must clearly attribute data sources and analytical methods.
 
-  \r
 
-  ## Rules\r
+  ## Rules
 
-  \r
 
   1. **Proxy disclaimer.** Any output that includes health scores, CAMELS-proxy
-  ratings, or component ratings must include: \"These are derived from the
+  ratings, or component ratings must include: "These are derived from the
   `public_camels_proxy_v1` analytical engine using public FDIC data. They are
   not official CAMELS ratings and do not reflect confidential supervisory
-  information.\"\r
+  information."
 
-  \r
 
   2. **Data source statement.** Every report must state its data source (e.g.,
-  \"FDIC Call Report data,\" \"FDIC Failure Records,\" \"Summary of
-  Deposits\").\r
+  "FDIC Call Report data," "FDIC Failure Records," "Summary of Deposits").
 
-  \r
 
   3. **No supervisory impersonation.** Do not imply official findings,
-  privileged exam conclusions, or confidential determinations.\r
+  privileged exam conclusions, or confidential determinations.
 
-  \r
 
-  4. **Observed vs. Inferred labeling.** When making analytical statements:\r
+  4. **Observed vs. Inferred labeling.** When making analytical statements:
+     - **[Observed]** — Directly visible in the public data
+     - **[Inferred]** — Analytical conclusion drawn from observed data
+     - **[Unknown from public data]** — Cannot be determined from available data
 
-  \   - **[Observed]** — Directly visible in the public data\r
+  5. **Hindsight discipline.** Write "the data showed" not "the bank should
+  have." Retrospective analysis is reconstruction, not prediction.
 
-  \   - **[Inferred]** — Analytical conclusion drawn from observed data\r
-
-  \   - **[Unknown from public data]** — Cannot be determined from available
-  data\r
-
-  \r
-
-  5. **Hindsight discipline.** Write \"the data showed\" not \"the bank should
-  have.\" Retrospective analysis is reconstruction, not prediction.\r
-
-  \r
 
   6. **Report footer.** Include a standard footer attributing the data source
-  and analytical model."
+  and analytical model.

--- a/adapters/openai/connectors/fdic-core-mcp.md
+++ b/adapters/openai/connectors/fdic-core-mcp.md
@@ -29,7 +29,7 @@ Core FDIC BankFind data retrieval tool bundle. Provides institution lookup, fina
   "type": "function",
   "function": {
     "name": "fdic_search_institutions",
-    "description": "Search for FDIC-insured financial institutions (banks and savings institutions) using flexible filters.\n\nReturns institution profile data including name, location, charter class, asset size, deposit totals, profitability metrics, and regulatory status.\n\nCommon filter examples:\n  - By state: STNAME:\"California\"\n  - Active banks only: ACTIVE:1\n  - Large banks: ASSET:[10000000 TO *]  (assets in $thousands)\n  - By bank class: BKCLASS:N (national bank), BKCLASS:SM (state member bank), BKCLASS:NM (state non-member)\n  - By name: NAME:\"Wells Fargo\"\n  - Commercial banks: CB:1\n  - Savings institutions: MUTUAL:1\n  - Recently established: ESTYMD:[2010-01-01 TO *]\n\nCharter class codes (BKCLASS):\n  N = National commercial bank (OCC-supervised)\n  SM = State-chartered, Federal Reserve member\n  NM = State-chartered, non-member (FDIC-supervised)\n  SB = Federal savings bank (OCC-supervised)\n  SA = State savings association\n  OI = Insured branch of foreign bank\n\nKey returned fields:\n  - CERT: FDIC Certificate Number (unique ID)\n  - NAME: Institution name\n  - CITY, STALP (two-letter state code), STNAME (full state name): Location\n  - ASSET: Total assets ($thousands)\n  - DEP: Total deposits ($thousands)\n  - BKCLASS: Charter class code (see above)\n  - ACTIVE: 1 if currently active, 0 if inactive\n  - ROA, ROE: Profitability ratios\n  - OFFICES: Number of branch offices\n  - ESTYMD: Establishment date (YYYY-MM-DD)\n  - REGAGNT: Primary federal regulator (OCC, FRS, FDIC)\n\nArgs:\n  - filters (string, optional): ElasticSearch query filter\n  - fields (string, optional): Comma-separated field names\n  - limit (number): Records to return, 1-10000 (default: 20)\n  - offset (number): Pagination offset (default: 0)\n  - sort_by (string, optional): Field to sort by\n  - sort_order ('ASC'|'DESC'): Sort direction (default: 'ASC')\n\nPrefer concise human-readable summaries or tables when answering users. Structured fields are available for totals, pagination, and institution records.",
+    "description": "Use this when the user needs FDIC-insured institution search results by name, state, CERT, asset size, charter class, or regulatory status. Returns institution profile rows with pagination; use fdic://schemas/institutions for the full field catalog.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -79,7 +79,7 @@ Core FDIC BankFind data retrieval tool bundle. Provides institution lookup, fina
   "type": "function",
   "function": {
     "name": "fdic_get_institution",
-    "description": "Retrieve detailed information for a specific FDIC-insured institution using its FDIC Certificate Number (CERT).\n\nUse this when you know the exact CERT number for an institution. To find a CERT number, use fdic_search_institutions first.\n\nArgs:\n  - cert (number): FDIC Certificate Number (e.g., 3511 for Bank of America)\n  - fields (string, optional): Comma-separated list of fields to return\n\nReturns a detailed institution profile suitable for concise summaries, with structured fields available for exact values when needed.",
+    "description": "Use this when the user knows an exact FDIC Certificate Number and needs one institution profile. To discover a CERT first, call fdic_search_institutions or the ChatGPT-compatible search tool.",
     "parameters": {
       "type": "object",
       "properties": {

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -149,10 +149,60 @@ In ChatGPT:
 3. Use `https://bankfind.jflamb.com/mcp`.
 4. Refresh tools from the app details page if needed.
 
+### Local ChatGPT App Validation
+
+Use this loop when changing tool descriptors, app resources, widget HTML, or ChatGPT-specific metadata.
+
+Build and start the HTTP server:
+
+```bash
+npm install
+npm run build
+TRANSPORT=http PORT=3000 node dist/index.js
+```
+
+Inspect the local endpoint with MCP Inspector before opening ChatGPT:
+
+```text
+http://127.0.0.1:3000/mcp
+```
+
+Then expose the local server through HTTPS:
+
+```bash
+ngrok http 3000
+```
+
+Create or update the ChatGPT Developer Mode app with:
+
+```text
+https://<your-ngrok-host>/mcp
+```
+
+After any change to tool descriptors, input schemas, app resources, CSP metadata, or widget URI versions, refresh the app/tools from the ChatGPT app details page. ChatGPT may cache widget resources by URI, so use a new `ui://widget/...-vN.html` URI for breaking widget changes.
+
+Suggested smoke prompts:
+
+- `Search for Bank of America and cite the result.`
+- `Fetch institution:3511.`
+- `Show a deep dive for CERT 3511.`
+- `Show branches for CERT 3511.`
+- `What data date basis are you using?`
+
+Before submitting a public ChatGPT app, confirm the production endpoint and app materials are ready:
+
+- stable public HTTPS `/mcp` endpoint
+- app name, description, icon, and screenshots
+- privacy policy and support URLs
+- test prompts and expected outputs for review
+- clear disclosure that public health scoring is not an official CAMELS rating
+- production logs or alerts for tool errors and latency
+
 Notes:
 - ChatGPT supports streaming HTTP and SSE for MCP apps.
 - ChatGPT Developer Mode availability depends on plan and workspace settings.
 - For Business and Enterprise/Edu workspaces, admins may need to allow custom apps first.
+- The `search` and `fetch` tools are always on for ChatGPT-compatible retrieval, including institution, failure, branch, and schema results.
 
 Official docs:
 - [OpenAI Developer Mode](https://developers.openai.com/api/docs/guides/developer-mode)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -18,6 +18,8 @@ For guided multi-tool workflows available in Claude Code, see [Skills]({{ '/skil
 
 | Tool | Use It When | Notes |
 |------|-------------|-------|
+| `search` | ChatGPT needs citation-friendly retrieval results across institutions, failures, branches, or schema docs | Standard MCP retrieval shape for ChatGPT company knowledge and deep research compatibility |
+| `fetch` | ChatGPT needs full citation text for an item returned by `search` | Accepts ids such as `institution:<CERT>`, `failure:<CERT>`, `branch:<id>`, and `schema:<endpoint>` |
 | `fdic_search_institutions` | You need institution search results by name, state, status, asset size, or other details | Good default entry point for bank discovery |
 | `fdic_get_institution` | You already know the FDIC `CERT` and need one institution record | Best for direct bank lookup |
 | `fdic_search_failures` | You need failed-bank records, failure dates, costs, or resolution details | Use when the question is specifically about bank failures |
@@ -48,6 +50,7 @@ All financial amounts are in **thousands of dollars** unless otherwise noted.
 | Tool | Use It When | Notes |
 |------|-------------|-------|
 | `fdic_analyze_bank_health` | You want a CAMELS-style health assessment for a single institution | `public_camels_proxy_v1` assessment with overall band, PCA capital categorization, management overlay, and trend analysis |
+| `fdic_show_bank_deep_dive` | You want a ChatGPT app dashboard for a single institution | Returns dashboard-ready structured content and links to the embedded Bank Deep Dive widget |
 | `fdic_compare_peer_health` | You want to rank a group of institutions by health scores | Ranks peers by proxy scores with percentiles and outlier flags for the subject institution |
 | `fdic_detect_risk_signals` | You want to scan institutions for early warning indicators | Flags critical and warning-level issues with standardized signal codes |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,6 +98,19 @@ Check:
 - that the URL ends in `/mcp`
 - that your MCP host supports remote HTTP MCP connections
 
+### ChatGPT shows stale tools or an old widget
+
+ChatGPT can cache tool descriptors and widget resources during Developer Mode testing.
+
+Check:
+
+- refresh tools from the ChatGPT app details page after descriptor or schema changes
+- use a new `ui://widget/...-vN.html` URI after breaking widget HTML, CSS, or JavaScript changes
+- verify the widget resource in MCP Inspector before retesting in ChatGPT
+- confirm widget CSP metadata allows exactly the domains the widget needs
+
+For local testing, expose the HTTP server with an HTTPS tunnel and connect ChatGPT to the tunneled `/mcp` URL.
+
 ### The model keeps choosing the wrong tool
 
 Improve the prompt by stating:

--- a/extensions/shared/tool-schemas.json
+++ b/extensions/shared/tool-schemas.json
@@ -3,7 +3,7 @@
   "_regenerate_with": "npm run extensions:extract-schemas",
   "tools": {
     "fdic_search_institutions": {
-      "description": "Search for FDIC-insured financial institutions (banks and savings institutions) using flexible filters.\n\nReturns institution profile data including name, location, charter class, asset size, deposit totals, profitability metrics, and regulatory status.\n\nCommon filter examples:\n  - By state: STNAME:\"California\"\n  - Active banks only: ACTIVE:1\n  - Large banks: ASSET:[10000000 TO *]  (assets in $thousands)\n  - By bank class: BKCLASS:N (national bank), BKCLASS:SM (state member bank), BKCLASS:NM (state non-member)\n  - By name: NAME:\"Wells Fargo\"\n  - Commercial banks: CB:1\n  - Savings institutions: MUTUAL:1\n  - Recently established: ESTYMD:[2010-01-01 TO *]\n\nCharter class codes (BKCLASS):\n  N = National commercial bank (OCC-supervised)\n  SM = State-chartered, Federal Reserve member\n  NM = State-chartered, non-member (FDIC-supervised)\n  SB = Federal savings bank (OCC-supervised)\n  SA = State savings association\n  OI = Insured branch of foreign bank\n\nKey returned fields:\n  - CERT: FDIC Certificate Number (unique ID)\n  - NAME: Institution name\n  - CITY, STALP (two-letter state code), STNAME (full state name): Location\n  - ASSET: Total assets ($thousands)\n  - DEP: Total deposits ($thousands)\n  - BKCLASS: Charter class code (see above)\n  - ACTIVE: 1 if currently active, 0 if inactive\n  - ROA, ROE: Profitability ratios\n  - OFFICES: Number of branch offices\n  - ESTYMD: Establishment date (YYYY-MM-DD)\n  - REGAGNT: Primary federal regulator (OCC, FRS, FDIC)\n\nArgs:\n  - filters (string, optional): ElasticSearch query filter\n  - fields (string, optional): Comma-separated field names\n  - limit (number): Records to return, 1-10000 (default: 20)\n  - offset (number): Pagination offset (default: 0)\n  - sort_by (string, optional): Field to sort by\n  - sort_order ('ASC'|'DESC'): Sort direction (default: 'ASC')\n\nPrefer concise human-readable summaries or tables when answering users. Structured fields are available for totals, pagination, and institution records.",
+      "description": "Use this when the user needs FDIC-insured institution search results by name, state, CERT, asset size, charter class, or regulatory status. Returns institution profile rows with pagination; use fdic://schemas/institutions for the full field catalog.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -46,7 +46,7 @@
       }
     },
     "fdic_get_institution": {
-      "description": "Retrieve detailed information for a specific FDIC-insured institution using its FDIC Certificate Number (CERT).\n\nUse this when you know the exact CERT number for an institution. To find a CERT number, use fdic_search_institutions first.\n\nArgs:\n  - cert (number): FDIC Certificate Number (e.g., 3511 for Bank of America)\n  - fields (string, optional): Comma-separated list of fields to return\n\nReturns a detailed institution profile suitable for concise summaries, with structured fields available for exact values when needed.",
+      "description": "Use this when the user knows an exact FDIC Certificate Number and needs one institution profile. To discover a CERT first, call fdic_search_institutions or the ChatGPT-compatible search tool.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -929,6 +929,62 @@
             "description": "Reference report date (YYYYMMDD). FRED data fetched for 2 years before this date."
           }
         },
+        "additionalProperties": false
+      }
+    },
+    "search": {
+      "description": "Use this when ChatGPT needs citation-friendly FDIC BankFind search results for institutions, failed banks, branches, or schema documentation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Natural-language search query."
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "fetch": {
+      "description": "Use this when ChatGPT needs the full citation text for a result returned by search.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Retrieval item id, such as institution:<CERT>, failure:<CERT>, branch:<UNINUM>, or schema:<endpoint>."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "fdic_show_bank_deep_dive": {
+      "description": "Use this when the user wants a scannable ChatGPT dashboard for one FDIC-insured institution, including identity, public financial metrics, risk signals, and source links.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "cert": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "description": "FDIC Certificate Number of the institution to render."
+          },
+          "repdte": {
+            "type": "string",
+            "pattern": "^\\d{8}$",
+            "description": "Quarter-end report date in YYYYMMDD format. Defaults to the most recent likely published quarter."
+          }
+        },
+        "required": [
+          "cert"
+        ],
         "additionalProperties": false
       }
     }

--- a/extensions/shared/toolsets/fdic-analysis.json
+++ b/extensions/shared/toolsets/fdic-analysis.json
@@ -3,6 +3,7 @@
   "description": "FDIC analytical and comparison tools for health assessment, peer benchmarking, risk detection, and domain-specific analysis.",
   "tools": [
     "fdic_analyze_bank_health",
+    "fdic_show_bank_deep_dive",
     "fdic_compare_peer_health",
     "fdic_detect_risk_signals",
     "fdic_compare_bank_snapshots",

--- a/extensions/shared/toolsets/fdic-core.json
+++ b/extensions/shared/toolsets/fdic-core.json
@@ -2,6 +2,8 @@
   "name": "fdic-core",
   "description": "Core FDIC BankFind data retrieval tools for institution lookup, financials, failures, locations, history, SOD, demographics, and summaries.",
   "tools": [
+    "search",
+    "fetch",
     "fdic_search_institutions",
     "fdic_get_institution",
     "fdic_search_failures",

--- a/reference/plans/2026-04-26-chatgpt-app-first-class-design.md
+++ b/reference/plans/2026-04-26-chatgpt-app-first-class-design.md
@@ -1,0 +1,593 @@
+# First-Class ChatGPT App Design Proposal
+
+**Date:** 2026-04-26
+**Status:** Proposed
+**Branch:** TBD (implementation branch)
+
+## Summary
+
+Evolve `fdic-mcp-server` from a strong tool-only MCP server into a first-class ChatGPT app by adding a citation-friendly `search`/`fetch` discovery layer, one focused ChatGPT UI resource, clearer app-oriented tool metadata, and a documented ChatGPT development/test loop.
+
+The existing server already has the right foundation: streamable HTTP at `/mcp`, read-only/idempotent FDIC tools, structured MCP results, schema resources, Cloud Run hosting, and ChatGPT Developer Mode setup docs. This proposal keeps those contracts intact and layers app behavior on top instead of replacing the current tool suite.
+
+## App Classification
+
+**Current archetype:** `tool-only`
+
+The server exposes FDIC data and analysis tools but does not yet expose a ChatGPT app UI.
+
+**Target archetype:** `interactive-decoupled`
+
+Data tools remain reusable and model-visible. A small number of render-oriented app tools attach UI resources and return dashboard-ready `structuredContent`. The widget renders from tool results and can call follow-up tools through the MCP Apps bridge without making the core FDIC tools UI-dependent.
+
+## Goals
+
+- Make the server eligible for ChatGPT company knowledge and deep research style retrieval by adding exact-shape `search` and `fetch` tools.
+- Add one high-value ChatGPT widget that demonstrates why this is an app, not just a connector.
+- Preserve all existing FDIC tool names, input schemas, `content`, and `structuredContent` shapes unless a later issue explicitly coordinates a breaking change.
+- Improve model tool selection by tightening descriptors and adding invocation status metadata for long-running analysis.
+- Document and test the ChatGPT-specific local loop: MCP Inspector, HTTPS tunnel, Developer Mode app refresh, and production submission readiness.
+
+## Non-Goals
+
+- Replace the existing FDIC-specific tools with generic `search`/`fetch`.
+- Add authentication. The FDIC BankFind API is public and this server should continue to work without credentials.
+- Add mutating tools. All app capabilities in this proposal are read-only.
+- Build a full financial analysis product UI in the first pass. The first widget should be useful, focused, and reviewable.
+- Change Cloud Run topology except where app metadata or static widget assets require small additions.
+
+## Source Guidance
+
+This design is based on current Apps SDK guidance:
+
+- [Build your MCP server](https://developers.openai.com/apps-sdk/build/mcp-server)
+- [Build your ChatGPT UI](https://developers.openai.com/apps-sdk/build/chatgpt-ui)
+- [Define tools](https://developers.openai.com/apps-sdk/plan/tools)
+- [Apps SDK reference](https://developers.openai.com/apps-sdk/reference)
+- [Submit and maintain your app](https://developers.openai.com/apps-sdk/deploy/submission)
+- [App submission guidelines](https://developers.openai.com/apps-sdk/app-submission-guidelines)
+
+Key design constraints from those docs:
+
+- ChatGPT apps are composed of an MCP server, a widget/UI bundle, and model narration over `content` and `structuredContent`.
+- New UI integrations should use the MCP Apps bridge by default; `window.openai` is optional and additive.
+- Widget resources should use the MCP Apps UI MIME type and explicit `_meta.ui` metadata for resource URI, CSP, domain, and border hints.
+- Company knowledge and deep research compatibility prefer exact `search` and `fetch` input signatures and citation-friendly result URLs.
+- Tool descriptions should be concise, intent-oriented, and easy for the model to choose.
+
+## Finding 1: Standard `search` And `fetch`
+
+### Problem
+
+The server has 23 FDIC-specific tools but no canonical `search` or `fetch`. That makes the app weaker for ChatGPT surfaces that expect retrieval-style MCP tools and canonical citation URLs.
+
+### Proposed Design
+
+Add a new module:
+
+```text
+src/tools/chatgptRetrieval.ts
+```
+
+Register two read-only tools:
+
+```text
+search
+fetch
+```
+
+These names are intentionally generic because the compatibility check expects them.
+
+### `search` Input
+
+Exact shape:
+
+```json
+{
+  "query": "string"
+}
+```
+
+Use a single required query string. Do not expose FDIC filter syntax here; this layer should translate natural search text into a small set of citation results.
+
+### `search` Output
+
+Return exactly one MCP text content item whose text is a JSON-encoded object:
+
+```json
+{
+  "results": [
+    {
+      "id": "institution:3511",
+      "title": "Bank of America, National Association",
+      "url": "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511"
+    }
+  ]
+}
+```
+
+Also include matching `structuredContent` only if tests confirm it does not interfere with compatibility. The compatibility-safe baseline is the single JSON text content item.
+
+### `fetch` Input
+
+Exact shape:
+
+```json
+{
+  "id": "string"
+}
+```
+
+Accepted ID formats:
+
+- `institution:<CERT>`
+- `failure:<CERT>`
+- `schema:<endpoint>`
+- `branch:<stable-id>` for branch/location records
+
+Branch IDs should use a native FDIC location identifier when one is available in the locations payload. If no single stable identifier is available, use a deterministic composite ID based on certificate number plus stable location fields, and keep the original lookup fields in `metadata` so `fetch` can reconstruct the record without ambiguity.
+
+### `fetch` Output
+
+Return exactly one MCP text content item whose text is a JSON-encoded object:
+
+```json
+{
+  "id": "institution:3511",
+  "title": "Bank of America, National Association",
+  "text": "FDIC institution profile...",
+  "url": "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511",
+  "metadata": {
+    "type": "institution",
+    "cert": 3511,
+    "source": "FDIC BankFind Suite"
+  }
+}
+```
+
+### Search Strategy
+
+Start with deterministic FDIC queries:
+
+1. If the query contains a CERT-like number, search institutions by `CERT:<number>`.
+2. Search active and inactive institutions by `NAME:"..."` with conservative escaping.
+3. Search failures by bank name if the query contains failure terms or no institution result is found.
+4. Search branch/location records when the query mentions branches, offices, addresses, cities, counties, ZIP codes, or market presence.
+5. Search schema docs when the query mentions fields, columns, endpoint names, Call Reports, SOD, or demographics.
+6. Return at most 8 results in the first implementation so institution, failure, branch, and schema matches can coexist without drowning the model.
+
+Do not call the FDIC API with unbounded or expensive broad queries. Favor precise name/CERT/schema lookup over generic keyword search.
+
+### URL Policy
+
+Preferred canonical URLs:
+
+- Institution details: `https://banks.data.fdic.gov/bankfind-suite/bankfind/details/<CERT>`
+- Failed bank details: `https://www.fdic.gov/bank-failures/failed-bank-list`
+- Branch/location details: prefer an FDIC BankFind branch/location HTTPS URL if implementation verification identifies a stable deep link. Otherwise cite a project docs URL and include precise branch identity, address, and FDIC source metadata in the fetched text.
+- Schema docs: project docs URL for tool/schema reference, or `fdic://schemas/<endpoint>` only if ChatGPT handles it acceptably for citations. Prefer HTTPS where possible.
+
+### Tests
+
+Add coverage in `tests/mcp-http.test.ts` or a focused retrieval test:
+
+- `search` and `fetch` appear in `tools/list`.
+- Both tools have `readOnlyHint: true`, `destructiveHint: false`, and `idempotentHint: true`.
+- `search` input schema has exactly the expected `query` string parameter.
+- `fetch` input schema has exactly the expected `id` string parameter.
+- `search` returns one text content item containing JSON with `results`.
+- `fetch` returns one text content item containing JSON with `id`, `title`, `text`, and `url`.
+- Institution lookup by known CERT returns a stable citation URL.
+- Branch/location search returns fetchable `branch:<stable-id>` results with address metadata.
+- Unknown IDs return a clear tool error without throwing an unhandled exception.
+
+## Finding 2: ChatGPT App UI Resource
+
+### Problem
+
+Current resources are FDIC schema JSON resources. There is no widget resource with the MCP Apps UI MIME type and no tool linked to a ChatGPT UI template.
+
+### Proposed First Widget
+
+Build a **Bank Deep Dive** widget.
+
+This is the best first UI because it turns a common user intent into a scannable, app-native experience:
+
+> "Show me an analyst-style view of this bank."
+
+The widget should render:
+
+- Institution identity and report date basis.
+- Assets, deposits, offices, active/inactive status, regulator, and charter class.
+- Public CAMELS-style proxy summary with explicit caveat that it is not an official rating.
+- Component score tiles for capital, asset quality, earnings, liquidity, and sensitivity.
+- Trend rows for the latest available quarters.
+- Risk signals and data quality warnings.
+- Suggested follow-up buttons such as "Compare peers", "Show branch footprint", and "Analyze funding".
+
+### Architecture
+
+Use a decoupled data/render pattern:
+
+```text
+User prompt
+  -> ChatGPT calls fdic_show_bank_deep_dive
+  -> server gathers data using existing shared engines
+  -> server returns content + structuredContent + _meta.ui.resourceUri
+  -> ChatGPT loads ui://widget/fdic-bank-deep-dive-v1.html
+  -> widget renders from structuredContent
+  -> widget may call follow-up tools through tools/call
+```
+
+### New Files
+
+```text
+src/resources/chatgptAppResources.ts
+src/tools/chatgptBankDeepDive.ts
+src/tools/shared/chatgptUrls.ts
+web/chatgpt-bank-deep-dive/src/main.ts
+web/chatgpt-bank-deep-dive/src/styles.css
+web/chatgpt-bank-deep-dive/index.html
+```
+
+Use vanilla TypeScript for v1. The widget primarily renders structured financial data and follow-up buttons, so React is not necessary yet. This keeps dependencies low, makes embedded resource output straightforward, and still leaves room to migrate to React later if the dashboard grows into a richer multi-tab experience.
+
+### Resource Registration
+
+Register:
+
+```text
+ui://widget/fdic-bank-deep-dive-v1.html
+```
+
+Resource requirements:
+
+- MIME type: `text/html;profile=mcp-app` or SDK constant from `@modelcontextprotocol/ext-apps/server`.
+- `_meta.ui.prefersBorder: true`
+- `_meta.ui.domain`: production app/widget origin when ready for submission.
+- `_meta.ui.csp.connectDomains`: include the production MCP/API origin only if the widget fetches directly. Prefer no direct widget fetches in v1.
+- `_meta.ui.csp.resourceDomains`: static asset/CDN origins if any.
+- `_meta["openai/widgetDescription"]`: short model-visible summary, for example "Renders an FDIC bank deep-dive dashboard from public BankFind data."
+
+### Widget Asset Strategy
+
+Embed the compiled HTML, CSS, and JavaScript in the MCP resource for v1.
+
+Reasons:
+
+- ChatGPT loads the widget through the MCP resource contract, so embedded assets are the shortest path to a self-contained app.
+- The current production service already hosts `/mcp`; embedded assets avoid adding a static-file route and public asset cache policy before it is needed.
+- CSP is simpler because the widget does not need to fetch its own scripts or styles from another origin.
+- Versioning remains explicit through the resource URI, for example `ui://widget/fdic-bank-deep-dive-v1.html`.
+
+Serving static assets from the same domain is still a good later option if the widget bundle becomes large, needs shared images/fonts, or benefits from browser/CDN caching. That change should preserve the same resource URI versioning discipline and only relax CSP for the exact static asset origin.
+
+### Tool Registration
+
+Register:
+
+```text
+fdic_show_bank_deep_dive
+```
+
+Input:
+
+```json
+{
+  "cert": 3511,
+  "repdte": "20241231",
+  "quarters": 8
+}
+```
+
+Annotations:
+
+```json
+{
+  "readOnlyHint": true,
+  "destructiveHint": false,
+  "idempotentHint": true,
+  "openWorldHint": true
+}
+```
+
+Descriptor `_meta`:
+
+```json
+{
+  "ui": {
+    "resourceUri": "ui://widget/fdic-bank-deep-dive-v1.html"
+  },
+  "openai/outputTemplate": "ui://widget/fdic-bank-deep-dive-v1.html",
+  "openai/toolInvocation/invoking": "Building bank dashboard...",
+  "openai/toolInvocation/invoked": "Bank dashboard ready"
+}
+```
+
+### Output Shape
+
+`structuredContent` should be compact and model-readable:
+
+```json
+{
+  "institution": {
+    "cert": 3511,
+    "name": "Bank of America, National Association",
+    "city": "Charlotte",
+    "state": "NC",
+    "active": true,
+    "asset_thousands": 123,
+    "deposit_thousands": 123,
+    "report_date": "20241231"
+  },
+  "assessment": {
+    "proxy_band": "satisfactory",
+    "proxy_score": 2.1,
+    "capital_category": "well_capitalized",
+    "official_rating": false
+  },
+  "components": [],
+  "trends": [],
+  "risk_signals": [],
+  "warnings": [],
+  "sources": [
+    {
+      "title": "FDIC BankFind institution profile",
+      "url": "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511"
+    }
+  ]
+}
+```
+
+`_meta` can include larger lookup maps and full raw payload slices useful only to the widget.
+
+### Widget Behavior
+
+- Listen for `ui/notifications/tool-result`.
+- Render from `structuredContent`.
+- Keep UI state local unless it materially changes model context.
+- Use `tools/call` for follow-up actions from buttons.
+- Use `ui/message` for follow-up prompts that should be visible in the conversation.
+- Avoid direct FDIC API calls from the widget in v1. The MCP server should remain the data boundary.
+
+### Tests
+
+- Resource appears in `resources/list`.
+- Resource content uses the app MIME type.
+- Resource includes `_meta.ui.csp`, `_meta.ui.prefersBorder`, and widget description metadata.
+- `fdic_show_bank_deep_dive` descriptor includes `_meta.ui.resourceUri`.
+- Tool returns dashboard-ready `structuredContent`.
+- Widget bundle builds.
+- Playwright or a lightweight DOM test verifies the widget renders a sample tool result without blank output.
+
+## Finding 3: Tool Metadata And Descriptions
+
+### Problem
+
+Several tool descriptions are accurate but long. Long descriptors can make model selection noisier in ChatGPT because discovery is metadata-driven.
+
+### Proposed Design
+
+Add a metadata cleanup pass that preserves schemas and behavior while changing descriptions only.
+
+Descriptor pattern:
+
+```text
+Use this when <specific user intent>. Returns <primary data/analysis>.
+
+Inputs: <short mention of important args>.
+Data basis: <quarterly/annual/SOD/public proxy caveat when relevant>.
+```
+
+Move long field lists and examples to:
+
+- existing schema resources (`fdic://schemas/...`)
+- `docs/tool-reference.md`
+- targeted usage docs
+
+### Priority Tools
+
+Start with tools most likely to compete during model selection:
+
+- `fdic_search_institutions`
+- `fdic_get_institution`
+- `fdic_search_financials`
+- `fdic_search_sod`
+- `fdic_analyze_bank_health`
+- `fdic_peer_group_analysis`
+- `fdic_detect_risk_signals`
+- `fdic_compare_peer_health`
+
+### Invocation Metadata
+
+Add short status strings to tools that may take long enough for ChatGPT to benefit:
+
+- `fdic_analyze_bank_health`
+- `fdic_peer_group_analysis`
+- `fdic_compare_peer_health`
+- `fdic_detect_risk_signals`
+- `fdic_analyze_credit_concentration`
+- `fdic_analyze_funding_profile`
+- `fdic_analyze_securities_portfolio`
+- `fdic_franchise_footprint`
+- `fdic_market_share_analysis`
+- `fdic_holding_company_profile`
+- `fdic_regional_context`
+
+Example:
+
+```json
+{
+  "openai/toolInvocation/invoking": "Analyzing bank health...",
+  "openai/toolInvocation/invoked": "Health analysis ready"
+}
+```
+
+### Tests
+
+- Existing contract tests should continue to pass.
+- Add a metadata snapshot test for representative tools if the SDK exposes descriptors in a stable way.
+- Avoid asserting full prose where minor copy changes should not fail builds.
+
+## Finding 4: ChatGPT Run And Test Checklist
+
+### Problem
+
+The docs include ChatGPT setup, but do not yet describe the app-specific validation path needed for first-class behavior.
+
+### Proposed Docs Changes
+
+Update:
+
+```text
+docs/clients.md
+docs/setup.md
+docs/troubleshooting.md
+reference/cloud-run-deployment.md
+```
+
+Add a ChatGPT app validation section:
+
+1. Build the repo:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+2. Start local HTTP:
+
+   ```bash
+   TRANSPORT=http PORT=3000 node dist/index.js
+   ```
+
+3. Inspect locally with MCP Inspector:
+
+   ```text
+   http://127.0.0.1:3000/mcp
+   ```
+
+4. Expose with HTTPS tunnel:
+
+   ```bash
+   ngrok http 3000
+   ```
+
+5. Connect ChatGPT Developer Mode to:
+
+   ```text
+   https://<tunnel-host>/mcp
+   ```
+
+6. Refresh app/tools after descriptor, schema, resource, or widget URI changes.
+
+7. Exercise test prompts:
+
+   - "Search for Bank of America and cite the result."
+   - "Fetch institution:3511."
+   - "Show a deep dive for CERT 3511."
+   - "Compare this bank with peers."
+   - "What data date basis are you using?"
+
+8. Verify production:
+
+   - hosted `/health` is healthy
+   - hosted `/mcp` initializes
+   - ChatGPT can list tools
+   - widget renders in ChatGPT
+   - error states are readable
+
+### Submission Readiness Checklist
+
+Add a submission checklist for future public launch:
+
+- Verified OpenAI organization or individual identity.
+- Stable public HTTPS endpoint.
+- Unique app/widget domain.
+- Privacy policy URL.
+- Support URL/email.
+- App name, description, icon, and screenshots.
+- Test prompts and expected outcomes.
+- Clear disclosure that health scoring is a public analytical proxy, not an official CAMELS rating.
+- No misleading implication of FDIC or OpenAI endorsement.
+- Logs and alerting for production errors and latency.
+
+## Implementation Plan
+
+### Phase 1: Retrieval Compatibility
+
+- Add `src/tools/chatgptRetrieval.ts`.
+- Add URL helper functions.
+- Register `search` and `fetch` from `createServer()`.
+- Keep `search` and `fetch` always on as part of the core read-only toolset.
+- Include institution, failure, branch/location, and schema results in v1.
+- Add tests for descriptors and exact output wrappers.
+- Validate with `npm run typecheck`, `npm test`, and `npm run build`.
+
+### Phase 2: First App Widget
+
+- Add `@modelcontextprotocol/ext-apps` if the current SDK path does not expose equivalent helpers.
+- Add widget resource registration.
+- Add `fdic_show_bank_deep_dive`.
+- Add a small embedded vanilla TypeScript widget bundle.
+- Add resource/tool tests and widget render sanity tests.
+- Validate with MCP Inspector.
+
+### Phase 3: Metadata Cleanup
+
+- Shorten priority tool descriptions.
+- Add invocation status metadata to long-running analysis tools.
+- Keep field catalogs in schema resources and docs.
+- Add lightweight metadata tests.
+
+### Phase 4: ChatGPT Documentation And Release Readiness
+
+- Update docs with local/tunneled ChatGPT app validation.
+- Add production/submission checklist.
+- Add troubleshooting entries for stale tool descriptors, cached widget URIs, CSP failures, and tunnel origin issues.
+- Run full repo validation.
+
+## Acceptance Criteria
+
+- `tools/list` includes `search`, `fetch`, and all existing FDIC tools.
+- Existing FDIC tool contracts remain backward compatible.
+- `search` and `fetch` match the expected input shapes and JSON text response wrappers.
+- Search/fetch results include canonical HTTPS URLs where possible.
+- At least one app UI resource is registered with the MCP Apps UI MIME type.
+- At least one render tool links to that UI via `_meta.ui.resourceUri`.
+- Widget renders a real bank dashboard from `structuredContent`.
+- ChatGPT docs include MCP Inspector, HTTPS tunnel, Developer Mode refresh, and submission readiness guidance.
+- `npm run typecheck`, `npm test`, and `npm run build` pass before PR.
+
+## Risks And Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `search`/`fetch` output drifts from compatibility expectations | ChatGPT retrieval surfaces may ignore the app | Keep response wrappers exact and add contract tests |
+| Widget scope grows too large | Delays first useful app experience | Ship a focused bank deep-dive v1, then add peer/footprint tabs later |
+| Tool metadata changes accidentally alter contracts | Regression for existing MCP clients | Limit Phase 3 to descriptor prose and metadata; preserve names/schemas/results |
+| FDIC canonical URLs are unstable or not deep-linkable | Weak citations | Prefer stable FDIC or project docs HTTPS URLs; document fallback policy |
+| CSP/domain config blocks widget assets in ChatGPT | Widget fails to render | Add local Inspector checks and ChatGPT tunnel checks before PR completion |
+| Public health proxy can be mistaken for official ratings | Compliance/trust issue | Put caveats in tool text, widget UI, docs, and submission materials |
+
+## Resolved Design Decisions
+
+- `search` includes institution, failure, branch/location, and schema results in v1.
+- Failed-bank citations use `https://www.fdic.gov/bank-failures/failed-bank-list`.
+- The v1 widget uses vanilla TypeScript because the first dashboard is data-rendering heavy and does not need React's component/runtime overhead.
+- Widget assets are embedded in the MCP resource for v1. Static same-domain serving remains a later optimization if bundle size or caching needs justify it.
+- `search` and `fetch` are always on as part of the core read-only toolset.
+
+## Remaining Open Questions
+
+- Which FDIC locations field is the best native stable branch identifier? If none is available, which deterministic composite should become the public `branch:<stable-id>` format?
+- Does ChatGPT citation handling prefer the FDIC failed-bank list URL alone for every failure record, or should fetched failure text also include an anchor-like local identifier for the failed institution?
+
+## Recommended First Issue Breakdown
+
+1. **feat: add ChatGPT-compatible search and fetch tools**
+2. **feat: add bank deep-dive ChatGPT widget**
+3. **docs: add ChatGPT app validation guide**
+4. **chore: optimize tool metadata for ChatGPT discovery**
+
+The first issue is the highest leverage and should be implemented before the widget because it improves ChatGPT compatibility without introducing UI complexity.

--- a/reference/plans/README.md
+++ b/reference/plans/README.md
@@ -2,6 +2,10 @@
 
 Historical planning and design notes that support the repository reference docs.
 
+## 2026-04-26
+
+- [First-Class ChatGPT App Design Proposal](./2026-04-26-chatgpt-app-first-class-design.md)
+
 ## 2026-03-18
 
 - [Docs Frontend Cleanup Design](./2026-03-18-docs-frontend-cleanup-design.md)

--- a/scripts/extensions/validate-extensions.mjs
+++ b/scripts/extensions/validate-extensions.mjs
@@ -55,6 +55,8 @@ function listEvalFiles(...baseDirs) {
 
 // ── Known MCP tools exposed by this repo ────────────────────────────────
 const KNOWN_TOOLS = new Set([
+  'search',
+  'fetch',
   'fdic_search_institutions',
   'fdic_get_institution',
   'fdic_search_failures',
@@ -68,6 +70,7 @@ const KNOWN_TOOLS = new Set([
   'fdic_compare_bank_snapshots',
   'fdic_peer_group_analysis',
   'fdic_analyze_bank_health',
+  'fdic_show_bank_deep_dive',
   'fdic_compare_peer_health',
   'fdic_detect_risk_signals',
   'fdic_analyze_credit_concentration',

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ import { registerMarketShareAnalysisTools } from "./tools/marketShareAnalysis.js
 import { registerFranchiseFootprintTools } from "./tools/franchiseFootprint.js";
 import { registerHoldingCompanyProfileTools } from "./tools/holdingCompanyProfile.js";
 import { registerRegionalContextTools } from "./tools/regionalContext.js";
+import { registerChatGptRetrievalTools } from "./tools/chatgptRetrieval.js";
+import { registerChatGptBankDeepDiveTool } from "./tools/chatgptBankDeepDive.js";
+import { registerChatGptAppResources } from "./resources/chatgptAppResources.js";
 import { registerSchemaResources } from "./resources/schemaResources.js";
 
 export function createServer(): McpServer {
@@ -61,6 +64,9 @@ export function createServer(): McpServer {
   registerFranchiseFootprintTools(server);
   registerHoldingCompanyProfileTools(server);
   registerRegionalContextTools(server);
+  registerChatGptRetrievalTools(server);
+  registerChatGptBankDeepDiveTool(server);
+  registerChatGptAppResources(server);
   registerSchemaResources(server);
 
   return server;

--- a/src/resources/chatgptAppResources.ts
+++ b/src/resources/chatgptAppResources.ts
@@ -1,0 +1,264 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export const BANK_DEEP_DIVE_WIDGET_URI =
+  "ui://widget/fdic-bank-deep-dive-v1.html";
+
+export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
+
+const BANK_DEEP_DIVE_WIDGET_HTML = String.raw`
+<div id="root" class="fdic-app">
+  <section class="empty">Loading bank dashboard...</section>
+</div>
+<style>
+  :root {
+    color-scheme: light dark;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  body {
+    margin: 0;
+    background: Canvas;
+    color: CanvasText;
+  }
+
+  .fdic-app {
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 16px;
+  }
+
+  .empty,
+  .panel {
+    border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+    border-radius: 8px;
+    padding: 14px;
+  }
+
+  .header {
+    display: grid;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+
+  .eyebrow {
+    color: color-mix(in srgb, CanvasText 58%, transparent);
+    font-size: 12px;
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+
+  h1,
+  h2,
+  p {
+    margin: 0;
+  }
+
+  h1 {
+    font-size: 20px;
+    line-height: 1.25;
+    letter-spacing: 0;
+  }
+
+  h2 {
+    font-size: 14px;
+    line-height: 1.35;
+    letter-spacing: 0;
+  }
+
+  .subtle {
+    color: color-mix(in srgb, CanvasText 64%, transparent);
+    font-size: 13px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    gap: 8px;
+    margin: 12px 0;
+  }
+
+  .metric {
+    border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+    border-radius: 8px;
+    padding: 10px;
+  }
+
+  .metric dt {
+    color: color-mix(in srgb, CanvasText 62%, transparent);
+    font-size: 12px;
+    margin: 0 0 6px;
+  }
+
+  .metric dd {
+    font-size: 16px;
+    font-weight: 680;
+    margin: 0;
+  }
+
+  .section {
+    margin-top: 14px;
+  }
+
+  .list {
+    display: grid;
+    gap: 6px;
+    margin: 8px 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .list li {
+    border-left: 3px solid color-mix(in srgb, CanvasText 24%, transparent);
+    padding: 4px 0 4px 8px;
+    font-size: 13px;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+  }
+
+  button {
+    border: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+    border-radius: 8px;
+    background: Canvas;
+    color: CanvasText;
+    cursor: pointer;
+    font: inherit;
+    font-size: 13px;
+    padding: 8px 10px;
+  }
+</style>
+<script type="module">
+  const root = document.getElementById("root");
+
+  function formatMoney(value) {
+    if (typeof value !== "number") return "n/a";
+    if (Math.abs(value) >= 1000000) return "$" + (value / 1000000).toFixed(1) + "B";
+    if (Math.abs(value) >= 1000) return "$" + (value / 1000).toFixed(1) + "M";
+    return "$" + value.toLocaleString() + "k";
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[char]));
+  }
+
+  function render(data) {
+    const institution = data?.institution ?? {};
+    const assessment = data?.assessment ?? {};
+    const metrics = data?.metrics ?? {};
+    const signals = data?.risk_signals ?? [];
+    const warnings = data?.warnings ?? [];
+    const sources = data?.sources ?? [];
+    const title = institution.name || "FDIC bank dashboard";
+
+    const signalItems = signals.length
+      ? signals.map((signal) => "<li>" + escapeHtml(signal) + "</li>").join("")
+      : "<li>No risk signals returned for this dashboard.</li>";
+    const warningSection = warnings.length
+      ? '<section class="section"><h2>Warnings</h2><ul class="list">' +
+        warnings.map((warning) => "<li>" + escapeHtml(warning) + "</li>").join("") +
+        "</ul></section>"
+      : "";
+    const sourceItems = sources
+      .map((source) => '<li><a href="' + escapeHtml(source.url) + '" target="_blank" rel="noreferrer">' + escapeHtml(source.title) + "</a></li>")
+      .join("");
+
+    root.innerHTML = [
+      '<article class="panel">',
+      '<header class="header">',
+      '<p class="eyebrow">FDIC BankFind</p>',
+      "<h1>" + escapeHtml(title) + "</h1>",
+      '<p class="subtle">' + escapeHtml(institution.city) + ", " + escapeHtml(institution.state) + " · CERT " + escapeHtml(institution.cert) + " · " + escapeHtml(institution.active ? "Active" : "Inactive or unknown") + "</p>",
+      '<p class="subtle">Report date: ' + escapeHtml(institution.report_date ?? "latest available") + " · Public analytical proxy, not an official CAMELS rating.</p>",
+      "</header>",
+      '<dl class="grid">',
+      '<div class="metric"><dt>Assets</dt><dd>' + formatMoney(institution.asset_thousands) + "</dd></div>",
+      '<div class="metric"><dt>Deposits</dt><dd>' + formatMoney(institution.deposit_thousands) + "</dd></div>",
+      '<div class="metric"><dt>Offices</dt><dd>' + escapeHtml(institution.offices ?? "n/a") + "</dd></div>",
+      '<div class="metric"><dt>Proxy band</dt><dd>' + escapeHtml(assessment.proxy_band ?? "n/a") + "</dd></div>",
+      '<div class="metric"><dt>ROA</dt><dd>' + escapeHtml(metrics.roa ?? "n/a") + "</dd></div>",
+      '<div class="metric"><dt>Tier 1 leverage</dt><dd>' + escapeHtml(metrics.tier1_leverage ?? "n/a") + "</dd></div>",
+      "</dl>",
+      '<section class="section"><h2>Risk Signals</h2><ul class="list">' + signalItems + "</ul></section>",
+      warningSection,
+      '<section class="section"><h2>Sources</h2><ul class="list">' + sourceItems + "</ul></section>",
+      '<div class="actions">',
+      '<button type="button" data-message="Compare CERT ' + escapeHtml(institution.cert) + ' with peers.">Compare peers</button>',
+      '<button type="button" data-message="Show the branch footprint for CERT ' + escapeHtml(institution.cert) + '.">Branch footprint</button>',
+      '<button type="button" data-message="Analyze the funding profile for CERT ' + escapeHtml(institution.cert) + '.">Funding profile</button>',
+      "</div>",
+      "</article>",
+    ].join("");
+  }
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message?.method === "ui/notifications/tool-result") {
+      render(message.params?.structuredContent);
+    }
+  });
+
+  root.addEventListener("click", (event) => {
+    const button = event.target.closest("button[data-message]");
+    if (!button) return;
+    const text = button.getAttribute("data-message");
+    window.parent.postMessage({
+      jsonrpc: "2.0",
+      method: "ui/message",
+      params: { role: "user", content: [{ type: "text", text }] },
+    }, "*");
+  });
+
+  const initial = window.openai?.toolOutput ?? window.openai?.toolResponse?.structuredContent;
+  if (initial) {
+    render(initial);
+  }
+</script>
+`.trim();
+
+export function registerChatGptAppResources(server: McpServer): void {
+  server.registerResource(
+    "fdic-bank-deep-dive-widget",
+    BANK_DEEP_DIVE_WIDGET_URI,
+    {
+      title: "FDIC Bank Deep Dive Widget",
+      description:
+        "Interactive ChatGPT widget for a public FDIC bank deep-dive dashboard.",
+      mimeType: MCP_APP_MIME_TYPE,
+    },
+    async () => ({
+      contents: [
+        {
+          uri: BANK_DEEP_DIVE_WIDGET_URI,
+          mimeType: MCP_APP_MIME_TYPE,
+          text: BANK_DEEP_DIVE_WIDGET_HTML,
+          _meta: {
+            ui: {
+              prefersBorder: true,
+              csp: {
+                connectDomains: [],
+                resourceDomains: [],
+              },
+            },
+            "openai/widgetDescription":
+              "Renders an FDIC bank deep-dive dashboard from public BankFind data.",
+            "openai/widgetPrefersBorder": true,
+            "openai/widgetCSP": {
+              connect_domains: [],
+              resource_domains: [],
+            },
+          },
+        },
+      ],
+    }),
+  );
+}

--- a/src/tools/chatgptBankDeepDive.ts
+++ b/src/tools/chatgptBankDeepDive.ts
@@ -1,0 +1,231 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { CHARACTER_LIMIT, ENDPOINTS } from "../constants.js";
+import {
+  extractRecords,
+  formatToolError,
+  queryEndpoint,
+  truncateIfNeeded,
+} from "../services/fdicClient.js";
+import { BANK_DEEP_DIVE_WIDGET_URI } from "../resources/chatgptAppResources.js";
+import { getDefaultReportDate, validateQuarterEndDate } from "./shared/queryUtils.js";
+import { getInstitutionUrl } from "./shared/chatgptUrls.js";
+
+const BankDeepDiveInputSchema = z.object({
+  cert: z
+    .number()
+    .int()
+    .positive()
+    .describe("FDIC Certificate Number of the institution to render."),
+  repdte: z
+    .string()
+    .regex(/^\d{8}$/)
+    .optional()
+    .describe(
+      "Quarter-end report date in YYYYMMDD format. Defaults to the most recent likely published quarter.",
+    ),
+});
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asString(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function formatRatio(value: unknown): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? `${value.toFixed(2)}%`
+    : undefined;
+}
+
+function collectDashboardRiskSignals(
+  financials: Record<string, unknown> | undefined,
+): string[] {
+  if (!financials) {
+    return [];
+  }
+
+  const signals: string[] = [];
+  const tier1Leverage = asNumber(financials.IDT1CER);
+  const roa = asNumber(financials.ROA);
+  const noncurrentLoans = asNumber(financials.NCLNLSR);
+  const brokeredDeposits = asNumber(financials.BRO);
+
+  if (tier1Leverage !== undefined && tier1Leverage < 5) {
+    signals.push(
+      `Tier 1 leverage ratio is ${tier1Leverage.toFixed(2)}%, below the 5% well-capitalized threshold.`,
+    );
+  }
+  if (roa !== undefined && roa < 0) {
+    signals.push(`Return on assets is negative at ${roa.toFixed(2)}%.`);
+  }
+  if (noncurrentLoans !== undefined && noncurrentLoans > 3) {
+    signals.push(
+      `Noncurrent loans ratio is elevated at ${noncurrentLoans.toFixed(2)}%.`,
+    );
+  }
+  if (brokeredDeposits !== undefined && brokeredDeposits > 0) {
+    signals.push(
+      "Brokered deposit fields are present; review funding-profile analysis for reliance context.",
+    );
+  }
+
+  return signals;
+}
+
+function buildDashboardText(
+  institution: Record<string, unknown>,
+  repdte: string,
+  riskSignals: string[],
+  warnings: string[],
+): string {
+  const lines = [
+    `FDIC Bank Deep Dive: ${asString(institution.NAME)} (CERT ${asString(institution.CERT)})`,
+    `${asString(institution.CITY)}, ${asString(institution.STALP)} | Report date: ${repdte}`,
+    "This dashboard uses public FDIC BankFind data and is not an official CAMELS rating or supervisory conclusion.",
+    "",
+    `Assets: ${asString(institution.ASSET) || "n/a"} ($thousands)`,
+    `Deposits: ${asString(institution.DEP) || "n/a"} ($thousands)`,
+    `Offices: ${asString(institution.OFFICES) || "n/a"}`,
+  ];
+
+  if (riskSignals.length > 0) {
+    lines.push("", "Risk signals:", ...riskSignals.map((signal) => `- ${signal}`));
+  }
+  if (warnings.length > 0) {
+    lines.push("", "Warnings:", ...warnings.map((warning) => `- ${warning}`));
+  }
+  return lines.join("\n");
+}
+
+export function registerChatGptBankDeepDiveTool(server: McpServer): void {
+  server.registerTool(
+    "fdic_show_bank_deep_dive",
+    {
+      title: "Show Bank Deep Dive Dashboard",
+      description:
+        "Use this when the user wants a scannable ChatGPT dashboard for one FDIC-insured institution, including identity, public financial metrics, risk signals, and source links.",
+      inputSchema: BankDeepDiveInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      _meta: {
+        ui: { resourceUri: BANK_DEEP_DIVE_WIDGET_URI },
+        "openai/outputTemplate": BANK_DEEP_DIVE_WIDGET_URI,
+        "openai/toolInvocation/invoking": "Building bank dashboard...",
+        "openai/toolInvocation/invoked": "Bank dashboard ready",
+      },
+    },
+    async (rawParams) => {
+      const repdte = rawParams.repdte ?? getDefaultReportDate();
+      const dateError = validateQuarterEndDate(repdte, "repdte");
+      if (dateError) {
+        return formatToolError(new Error(dateError));
+      }
+
+      try {
+        const [institutionResponse, financialsResponse] = await Promise.all([
+          queryEndpoint(ENDPOINTS.INSTITUTIONS, {
+            filters: `CERT:${rawParams.cert}`,
+            fields:
+              "CERT,NAME,CITY,STALP,STNAME,ACTIVE,ASSET,DEP,OFFICES,BKCLASS,REGAGNT,ESTYMD",
+            limit: 1,
+          }),
+          queryEndpoint(ENDPOINTS.FINANCIALS, {
+            filters: `CERT:${rawParams.cert} AND REPDTE:${repdte}`,
+            fields:
+              "CERT,REPDTE,ASSET,DEP,ROA,ROE,IDT1CER,NCLNLSR,LNLSDEPR,NIMY,EEFFR",
+            limit: 1,
+          }),
+        ]);
+
+        const institution = extractRecords(institutionResponse)[0];
+        if (!institution) {
+          return formatToolError(
+            new Error(`No institution found with CERT number ${rawParams.cert}.`),
+          );
+        }
+
+        const financials = extractRecords(financialsResponse)[0];
+        const warnings = financials
+          ? []
+          : [
+              `No financial record found for CERT ${rawParams.cert} at ${repdte}. Try an earlier quarter-end date.`,
+            ];
+        const riskSignals = collectDashboardRiskSignals(financials);
+
+        const structuredContent = {
+          institution: {
+            cert: rawParams.cert,
+            name: asString(institution.NAME),
+            city: asString(institution.CITY),
+            state: asString(institution.STALP),
+            active: institution.ACTIVE === 1 || institution.ACTIVE === "1",
+            asset_thousands:
+              asNumber(financials?.ASSET) ?? asNumber(institution.ASSET),
+            deposit_thousands:
+              asNumber(financials?.DEP) ?? asNumber(institution.DEP),
+            offices: asNumber(institution.OFFICES),
+            charter_class: asString(institution.BKCLASS),
+            regulator: asString(institution.REGAGNT),
+            established: asString(institution.ESTYMD),
+            report_date: repdte,
+          },
+          assessment: {
+            official_rating: false,
+            proxy_band: riskSignals.length > 0 ? "review" : "no major public flags",
+            caveat:
+              "Public off-site analytical dashboard; not an official CAMELS rating or confidential supervisory conclusion.",
+          },
+          metrics: {
+            roa: formatRatio(financials?.ROA),
+            roe: formatRatio(financials?.ROE),
+            tier1_leverage: formatRatio(financials?.IDT1CER),
+            noncurrent_loans: formatRatio(financials?.NCLNLSR),
+            loan_to_deposit: formatRatio(financials?.LNLSDEPR),
+            net_interest_margin: formatRatio(financials?.NIMY),
+            efficiency_ratio: formatRatio(financials?.EEFFR),
+          },
+          risk_signals: riskSignals,
+          warnings,
+          sources: [
+            {
+              title: "FDIC BankFind institution profile",
+              url: getInstitutionUrl(rawParams.cert),
+            },
+          ],
+        };
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: truncateIfNeeded(
+                buildDashboardText(institution, repdte, riskSignals, warnings),
+                CHARACTER_LIMIT,
+              ),
+            },
+          ],
+          structuredContent,
+          _meta: {
+            widget: {
+              resourceUri: BANK_DEEP_DIVE_WIDGET_URI,
+            },
+            raw: {
+              institution,
+              financials: financials ?? null,
+            },
+          },
+        };
+      } catch (err) {
+        return formatToolError(err);
+      }
+    },
+  );
+}

--- a/src/tools/chatgptRetrieval.ts
+++ b/src/tools/chatgptRetrieval.ts
@@ -1,0 +1,551 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { ENDPOINTS } from "../constants.js";
+import {
+  extractRecords,
+  formatToolError,
+  queryEndpoint,
+} from "../services/fdicClient.js";
+import {
+  getEndpointMetadata,
+  listEndpointMetadata,
+} from "../services/fdicSchema.js";
+import {
+  getBranchCitationUrl,
+  getFailedBankListUrl,
+  getInstitutionUrl,
+  getSchemaDocsUrl,
+} from "./shared/chatgptUrls.js";
+
+const SearchInputSchema = z.object({
+  query: z.string().min(1).describe("Natural-language search query."),
+});
+
+const FetchInputSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Retrieval item id, such as institution:<CERT>, failure:<CERT>, branch:<UNINUM>, or schema:<endpoint>.",
+    ),
+});
+
+interface SearchResult {
+  id: string;
+  title: string;
+  url: string;
+}
+
+interface FetchResult {
+  id: string;
+  title: string;
+  text: string;
+  url: string;
+  metadata?: Record<string, unknown>;
+}
+
+const MAX_SEARCH_RESULTS = 8;
+
+function asString(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  return String(value);
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function jsonText(payload: unknown): string {
+  return JSON.stringify(payload);
+}
+
+function escapeFilterValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').trim();
+}
+
+function normalizeQuery(query: string): string {
+  return query.replace(/\s+/g, " ").trim();
+}
+
+function extractCertLikeNumber(query: string): number | undefined {
+  const match = query.match(/\b(?:cert(?:ificate)?\s*#?\s*)?(\d{1,7})\b/i);
+  if (!match) {
+    return undefined;
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+function shouldSearchFailures(query: string): boolean {
+  return /\b(fail|failed|failure|closed|resolution|receivership)\b/i.test(
+    query,
+  );
+}
+
+function shouldSearchBranches(query: string): boolean {
+  return /\b(branch|branches|office|offices|location|locations|address|city|county|zip|market|msa)\b/i.test(
+    query,
+  );
+}
+
+function shouldSearchSchemas(query: string): boolean {
+  return /\b(schema|field|fields|column|columns|endpoint|call report|financials?|sod|summary of deposits|demographics|metadata)\b/i.test(
+    query,
+  );
+}
+
+function getRecordTitle(record: Record<string, unknown>, fallback: string): string {
+  return (
+    asString(record.NAME) ||
+    asString(record.UNINAME) ||
+    asString(record.NAMEFULL) ||
+    asString(record.OFFNAME) ||
+    fallback
+  );
+}
+
+function formatLocation(record: Record<string, unknown>): string {
+  return [record.CITY, record.STALP].map(asString).filter(Boolean).join(", ");
+}
+
+function buildBranchId(record: Record<string, unknown>): string | undefined {
+  const uninum = asString(record.UNINUM);
+  if (uninum) {
+    return `branch:${encodeURIComponent(uninum)}`;
+  }
+
+  const cert = asString(record.CERT);
+  const brnum = asString(record.BRNUM);
+  const zip = asString(record.ZIP);
+  if (!cert || !brnum) {
+    return undefined;
+  }
+
+  return `branch:${encodeURIComponent([cert, brnum, zip].join("~"))}`;
+}
+
+function institutionSearchResult(record: Record<string, unknown>): SearchResult | undefined {
+  const cert = asNumber(record.CERT);
+  if (cert === undefined) {
+    return undefined;
+  }
+  const title = getRecordTitle(record, `FDIC institution ${cert}`);
+  const location = formatLocation(record);
+  return {
+    id: `institution:${cert}`,
+    title: location ? `${title} (${location})` : title,
+    url: getInstitutionUrl(cert),
+  };
+}
+
+function failureSearchResult(record: Record<string, unknown>): SearchResult | undefined {
+  const cert = asNumber(record.CERT);
+  if (cert === undefined) {
+    return undefined;
+  }
+  const title = getRecordTitle(record, `Failed bank ${cert}`);
+  const failDate = asString(record.FAILDATE);
+  return {
+    id: `failure:${cert}`,
+    title: failDate ? `${title} failed ${failDate}` : `${title} failure record`,
+    url: getFailedBankListUrl(),
+  };
+}
+
+function branchSearchResult(record: Record<string, unknown>): SearchResult | undefined {
+  const id = buildBranchId(record);
+  if (!id) {
+    return undefined;
+  }
+  const name = getRecordTitle(record, "FDIC branch location");
+  const address = [record.ADDRESS, record.CITY, record.STALP, record.ZIP]
+    .map(asString)
+    .filter(Boolean)
+    .join(", ");
+  return {
+    id,
+    title: address ? `${name} - ${address}` : name,
+    url: getBranchCitationUrl(),
+  };
+}
+
+function schemaSearchResults(query: string): SearchResult[] {
+  const normalized = normalizeQuery(query).toLowerCase();
+  const metadata = listEndpointMetadata();
+  return metadata
+    .filter((endpoint) => {
+      if (normalized.includes(endpoint.endpoint.toLowerCase())) {
+        return true;
+      }
+      if (endpoint.title.toLowerCase().includes(normalized)) {
+        return true;
+      }
+      return Object.keys(endpoint.fields).some((field) =>
+        normalized.includes(field.toLowerCase()),
+      );
+    })
+    .slice(0, 2)
+    .map((endpoint) => ({
+      id: `schema:${endpoint.endpoint}`,
+      title: `${endpoint.title} schema`,
+      url: getSchemaDocsUrl(endpoint.endpoint),
+    }));
+}
+
+async function searchInstitutions(query: string): Promise<SearchResult[]> {
+  const cert = extractCertLikeNumber(query);
+  const filters =
+    cert !== undefined
+      ? `CERT:${cert}`
+      : `NAME:"${escapeFilterValue(query)}"`;
+  const response = await queryEndpoint(ENDPOINTS.INSTITUTIONS, {
+    filters,
+    fields: "CERT,NAME,CITY,STALP,ACTIVE",
+    limit: 3,
+    sort_by: "ACTIVE",
+    sort_order: "DESC",
+  });
+  return extractRecords(response)
+    .map(institutionSearchResult)
+    .filter((result): result is SearchResult => result !== undefined);
+}
+
+async function searchFailures(query: string): Promise<SearchResult[]> {
+  const cert = extractCertLikeNumber(query);
+  const filters =
+    cert !== undefined
+      ? `CERT:${cert}`
+      : `NAME:"${escapeFilterValue(query)}"`;
+  const response = await queryEndpoint(ENDPOINTS.FAILURES, {
+    filters,
+    fields: "CERT,NAME,CITY,STALP,FAILDATE,RESTYPE",
+    limit: 2,
+    sort_by: "FAILDATE",
+    sort_order: "DESC",
+  });
+  return extractRecords(response)
+    .map(failureSearchResult)
+    .filter((result): result is SearchResult => result !== undefined);
+}
+
+async function searchBranches(query: string): Promise<SearchResult[]> {
+  const cert = extractCertLikeNumber(query);
+  const normalized = normalizeQuery(query);
+  const zip = normalized.match(/\b\d{5}\b/)?.[0];
+  const filters =
+    cert !== undefined
+      ? `CERT:${cert}`
+      : zip !== undefined
+        ? `ZIP:${zip}`
+        : `CITY:"${escapeFilterValue(normalized)}"`;
+
+  const response = await queryEndpoint(ENDPOINTS.LOCATIONS, {
+    filters,
+    fields: "UNINUM,CERT,NAME,OFFNAME,ADDRESS,CITY,STALP,ZIP",
+    limit: 3,
+    sort_by: "UNINUM",
+    sort_order: "ASC",
+  });
+  return extractRecords(response)
+    .map(branchSearchResult)
+    .filter((result): result is SearchResult => result !== undefined);
+}
+
+async function safeSearch(
+  searcher: () => Promise<SearchResult[]>,
+): Promise<SearchResult[]> {
+  try {
+    return await searcher();
+  } catch {
+    return [];
+  }
+}
+
+function dedupeResults(results: SearchResult[]): SearchResult[] {
+  const seen = new Set<string>();
+  const deduped: SearchResult[] = [];
+  for (const result of results) {
+    if (seen.has(result.id)) {
+      continue;
+    }
+    seen.add(result.id);
+    deduped.push(result);
+  }
+  return deduped.slice(0, MAX_SEARCH_RESULTS);
+}
+
+function recordText(record: Record<string, unknown>, fields: string[]): string {
+  return fields
+    .map((field) => [field, asString(record[field])] as const)
+    .filter(([, value]) => value !== "")
+    .map(([field, value]) => `${field}: ${value}`)
+    .join("\n");
+}
+
+async function fetchInstitution(cert: number): Promise<FetchResult> {
+  const response = await queryEndpoint(ENDPOINTS.INSTITUTIONS, {
+    filters: `CERT:${cert}`,
+    limit: 1,
+  });
+  const record = extractRecords(response)[0];
+  if (!record) {
+    throw new Error(`No institution found for CERT ${cert}.`);
+  }
+  const title = getRecordTitle(record, `FDIC institution ${cert}`);
+  return {
+    id: `institution:${cert}`,
+    title,
+    text: recordText(record, [
+      "CERT",
+      "NAME",
+      "CITY",
+      "STALP",
+      "STNAME",
+      "ACTIVE",
+      "ASSET",
+      "DEP",
+      "OFFICES",
+      "BKCLASS",
+      "REGAGNT",
+      "ESTYMD",
+    ]),
+    url: getInstitutionUrl(cert),
+    metadata: { type: "institution", cert, source: "FDIC BankFind Suite" },
+  };
+}
+
+async function fetchFailure(cert: number): Promise<FetchResult> {
+  const response = await queryEndpoint(ENDPOINTS.FAILURES, {
+    filters: `CERT:${cert}`,
+    limit: 1,
+  });
+  const record = extractRecords(response)[0];
+  if (!record) {
+    throw new Error(`No failure record found for CERT ${cert}.`);
+  }
+  const title = getRecordTitle(record, `Failed bank ${cert}`);
+  return {
+    id: `failure:${cert}`,
+    title,
+    text: recordText(record, [
+      "CERT",
+      "NAME",
+      "CITY",
+      "STALP",
+      "FAILDATE",
+      "RESTYPE",
+      "QBFASSET",
+      "COST",
+    ]),
+    url: getFailedBankListUrl(),
+    metadata: { type: "failure", cert, source: "FDIC Failed Bank List" },
+  };
+}
+
+async function fetchBranch(rawId: string): Promise<FetchResult> {
+  const decoded = decodeURIComponent(rawId);
+  const [cert, brnum, zip] = decoded.split("~");
+  const filters =
+    cert && brnum
+      ? [`CERT:${cert}`, `BRNUM:${brnum}`, zip ? `ZIP:${zip}` : undefined]
+          .filter(Boolean)
+          .join(" AND ")
+      : `UNINUM:${decoded}`;
+  const response = await queryEndpoint(ENDPOINTS.LOCATIONS, {
+    filters,
+    limit: 1,
+  });
+  const record = extractRecords(response)[0];
+  if (!record) {
+    throw new Error(`No branch/location found for id ${rawId}.`);
+  }
+  const title = getRecordTitle(record, `FDIC branch ${rawId}`);
+  const id = buildBranchId(record) ?? `branch:${rawId}`;
+  return {
+    id,
+    title,
+    text: recordText(record, [
+      "UNINUM",
+      "CERT",
+      "UNINAME",
+      "NAMEFULL",
+      "ADDRESS",
+      "CITY",
+      "STALP",
+      "ZIP",
+      "COUNTY",
+      "BRNUM",
+      "BRSERTYP",
+      "ESTYMD",
+      "ENDEFYMD",
+    ]),
+    url: getBranchCitationUrl(),
+    metadata: {
+      type: "branch",
+      cert: record.CERT,
+      uninum: record.UNINUM,
+      source: "FDIC BankFind Suite locations",
+    },
+  };
+}
+
+function fetchSchema(endpoint: string): FetchResult {
+  const metadata = getEndpointMetadata(endpoint);
+  if (!metadata) {
+    throw new Error(`No schema metadata found for endpoint ${endpoint}.`);
+  }
+  const fields = Object.values(metadata.fields)
+    .slice(0, 200)
+    .map((field) => {
+      const title = field.title ? ` - ${field.title}` : "";
+      return `${field.name}${title}`;
+    })
+    .join("\n");
+  return {
+    id: `schema:${endpoint}`,
+    title: `${metadata.title} schema`,
+    text: [
+      metadata.description ?? metadata.title,
+      "",
+      `Endpoint: ${metadata.endpoint}`,
+      `Source: ${metadata.source.docsBaseUrl}`,
+      "",
+      "Fields:",
+      fields,
+    ].join("\n"),
+    url: getSchemaDocsUrl(endpoint),
+    metadata: {
+      type: "schema",
+      endpoint,
+      field_count: Object.keys(metadata.fields).length,
+      source: metadata.source.docsBaseUrl,
+    },
+  };
+}
+
+async function fetchById(id: string): Promise<FetchResult> {
+  const [kind, rawValue] = id.split(":", 2);
+  if (!kind || !rawValue) {
+    throw new Error(
+      "Invalid fetch id. Expected institution:<CERT>, failure:<CERT>, branch:<id>, or schema:<endpoint>.",
+    );
+  }
+
+  if (kind === "institution") {
+    const cert = Number.parseInt(rawValue, 10);
+    if (!Number.isInteger(cert) || cert <= 0) {
+      throw new Error(`Invalid institution CERT in id ${id}.`);
+    }
+    return fetchInstitution(cert);
+  }
+
+  if (kind === "failure") {
+    const cert = Number.parseInt(rawValue, 10);
+    if (!Number.isInteger(cert) || cert <= 0) {
+      throw new Error(`Invalid failure CERT in id ${id}.`);
+    }
+    return fetchFailure(cert);
+  }
+
+  if (kind === "branch") {
+    return fetchBranch(rawValue);
+  }
+
+  if (kind === "schema") {
+    return fetchSchema(rawValue);
+  }
+
+  throw new Error(`Unsupported fetch id kind: ${kind}.`);
+}
+
+export function registerChatGptRetrievalTools(server: McpServer): void {
+  server.registerTool(
+    "search",
+    {
+      title: "Search FDIC BankFind",
+      description:
+        "Use this when ChatGPT needs citation-friendly FDIC BankFind search results for institutions, failed banks, branches, or schema documentation.",
+      inputSchema: SearchInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ query }) => {
+      const normalized = normalizeQuery(query);
+      const shouldIncludeFailures = shouldSearchFailures(normalized);
+      const shouldIncludeBranches = shouldSearchBranches(normalized);
+      const shouldIncludeSchemas = shouldSearchSchemas(normalized);
+
+      const [institutions, failures, branches] = await Promise.all([
+        safeSearch(() => searchInstitutions(normalized)),
+        shouldIncludeFailures
+          ? safeSearch(() => searchFailures(normalized))
+          : Promise.resolve([]),
+        shouldIncludeBranches
+          ? safeSearch(() => searchBranches(normalized))
+          : Promise.resolve([]),
+      ]);
+
+      const fallbackFailures =
+        failures.length === 0 && institutions.length === 0
+          ? await safeSearch(() => searchFailures(normalized))
+          : [];
+      const fallbackBranches =
+        branches.length === 0 && institutions.length === 0
+          ? await safeSearch(() => searchBranches(normalized))
+          : [];
+      const schemas = shouldIncludeSchemas ? schemaSearchResults(normalized) : [];
+
+      const results = dedupeResults([
+        ...institutions,
+        ...failures,
+        ...branches,
+        ...fallbackFailures,
+        ...fallbackBranches,
+        ...schemas,
+      ]);
+
+      return {
+        content: [{ type: "text", text: jsonText({ results }) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "fetch",
+    {
+      title: "Fetch FDIC BankFind Result",
+      description:
+        "Use this when ChatGPT needs the full citation text for a result returned by search.",
+      inputSchema: FetchInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ id }) => {
+      try {
+        const result = await fetchById(id);
+        return {
+          content: [{ type: "text", text: jsonText(result) }],
+        };
+      } catch (err) {
+        return formatToolError(err);
+      }
+    },
+  );
+}

--- a/src/tools/institutions.ts
+++ b/src/tools/institutions.ts
@@ -16,50 +16,8 @@ export function registerInstitutionTools(server: McpServer): void {
     "fdic_search_institutions",
     {
       title: "Search FDIC Institutions",
-      description: `Search for FDIC-insured financial institutions (banks and savings institutions) using flexible filters.
-
-Returns institution profile data including name, location, charter class, asset size, deposit totals, profitability metrics, and regulatory status.
-
-Common filter examples:
-  - By state: STNAME:"California"
-  - Active banks only: ACTIVE:1
-  - Large banks: ASSET:[10000000 TO *]  (assets in $thousands)
-  - By bank class: BKCLASS:N (national bank), BKCLASS:SM (state member bank), BKCLASS:NM (state non-member)
-  - By name: NAME:"Wells Fargo"
-  - Commercial banks: CB:1
-  - Savings institutions: MUTUAL:1
-  - Recently established: ESTYMD:[2010-01-01 TO *]
-
-Charter class codes (BKCLASS):
-  N = National commercial bank (OCC-supervised)
-  SM = State-chartered, Federal Reserve member
-  NM = State-chartered, non-member (FDIC-supervised)
-  SB = Federal savings bank (OCC-supervised)
-  SA = State savings association
-  OI = Insured branch of foreign bank
-
-Key returned fields:
-  - CERT: FDIC Certificate Number (unique ID)
-  - NAME: Institution name
-  - CITY, STALP (two-letter state code), STNAME (full state name): Location
-  - ASSET: Total assets ($thousands)
-  - DEP: Total deposits ($thousands)
-  - BKCLASS: Charter class code (see above)
-  - ACTIVE: 1 if currently active, 0 if inactive
-  - ROA, ROE: Profitability ratios
-  - OFFICES: Number of branch offices
-  - ESTYMD: Establishment date (YYYY-MM-DD)
-  - REGAGNT: Primary federal regulator (OCC, FRS, FDIC)
-
-Args:
-  - filters (string, optional): ElasticSearch query filter
-  - fields (string, optional): Comma-separated field names
-  - limit (number): Records to return, 1-10000 (default: 20)
-  - offset (number): Pagination offset (default: 0)
-  - sort_by (string, optional): Field to sort by
-  - sort_order ('ASC'|'DESC'): Sort direction (default: 'ASC')
-
-Prefer concise human-readable summaries or tables when answering users. Structured fields are available for totals, pagination, and institution records.`,
+      description:
+        'Use this when the user needs FDIC-insured institution search results by name, state, CERT, asset size, charter class, or regulatory status. Returns institution profile rows with pagination; use fdic://schemas/institutions for the full field catalog.',
       inputSchema: CommonQuerySchema,
       annotations: {
         readOnlyHint: true,
@@ -104,15 +62,8 @@ Prefer concise human-readable summaries or tables when answering users. Structur
     "fdic_get_institution",
     {
       title: "Get Institution by Certificate Number",
-      description: `Retrieve detailed information for a specific FDIC-insured institution using its FDIC Certificate Number (CERT).
-
-Use this when you know the exact CERT number for an institution. To find a CERT number, use fdic_search_institutions first.
-
-Args:
-  - cert (number): FDIC Certificate Number (e.g., 3511 for Bank of America)
-  - fields (string, optional): Comma-separated list of fields to return
-
-Returns a detailed institution profile suitable for concise summaries, with structured fields available for exact values when needed.`,
+      description:
+        "Use this when the user knows an exact FDIC Certificate Number and needs one institution profile. To discover a CERT first, call fdic_search_institutions or the ChatGPT-compatible search tool.",
       inputSchema: CertSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/shared/chatgptUrls.ts
+++ b/src/tools/shared/chatgptUrls.ts
@@ -1,0 +1,24 @@
+export const FDIC_BANKFIND_BASE_URL =
+  "https://banks.data.fdic.gov/bankfind-suite";
+
+export const FDIC_FAILED_BANK_LIST_URL =
+  "https://www.fdic.gov/bank-failures/failed-bank-list";
+
+export const PROJECT_TOOL_REFERENCE_URL =
+  "https://jflamb.github.io/fdic-mcp-server/tool-reference/";
+
+export function getInstitutionUrl(cert: number | string): string {
+  return `${FDIC_BANKFIND_BASE_URL}/bankfind/details/${cert}`;
+}
+
+export function getFailedBankListUrl(): string {
+  return FDIC_FAILED_BANK_LIST_URL;
+}
+
+export function getSchemaDocsUrl(endpoint: string): string {
+  return `${PROJECT_TOOL_REFERENCE_URL}#${encodeURIComponent(endpoint)}`;
+}
+
+export function getBranchCitationUrl(): string {
+  return `${PROJECT_TOOL_REFERENCE_URL}#fdic_search_locations`;
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# First-Class ChatGPT App
+
+Reference: 2026-04-26 design proposal to make the FDIC MCP server behave like a first-class ChatGPT app.
+
+## Goals
+
+- [x] Add always-on ChatGPT-compatible `search` and `fetch` tools covering institutions, failures, branches, and schema docs.
+- [x] Add an embedded Bank Deep Dive widget resource and a render tool that links to it.
+- [x] Improve representative tool metadata for ChatGPT discovery without changing existing tool contracts.
+- [x] Document the ChatGPT app local/tunneled validation loop and submission readiness checklist.
+- [x] Validate with repo-standard commands.
+
+## Acceptance Criteria
+
+- [x] `tools/list` includes `search`, `fetch`, and existing FDIC tools.
+- [x] `search` and `fetch` use the expected exact input shapes and JSON text response wrappers.
+- [x] Retrieval results include canonical HTTPS URLs where possible and fetchable branch/location IDs.
+- [x] A widget resource is registered with MCP Apps UI MIME type and app metadata.
+- [x] A render tool returns dashboard-ready `structuredContent` and points to the widget resource.
+- [x] Existing FDIC tool behavior remains backward compatible.
+
+## Validation
+
+- [x] `npm run typecheck`
+- [x] `npm test`
+- [x] `npm run build`
+
+## Review / Results
+
+- [x] Implemented ChatGPT-compatible retrieval tools, embedded widget resource, bank deep-dive render tool, docs, tests, and regenerated extension schema/adapters.
+- [x] Full validation passed after committing generated schema updates.
+
 # Public Legal Pages For App Directory
 
 Reference: 2026-03-30 request to add a Privacy Policy URL and Terms of Service URL for the public OpenAI app submission.

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -789,13 +789,18 @@ describe("HTTP MCP server", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.body.result.tools).toHaveLength(23);
+    expect(response.body.result.tools).toHaveLength(26);
     expect(
       response.body.result.tools.map((tool: { name: string }) => tool.name),
     ).toContain("fdic_search_demographics");
     expect(
       response.body.result.tools.map((tool: { name: string }) => tool.name),
     ).toContain("fdic_compare_bank_snapshots");
+    expect(
+      response.body.result.tools.map((tool: { name: string }) => tool.name),
+    ).toEqual(
+      expect.arrayContaining(["search", "fetch", "fdic_show_bank_deep_dive"]),
+    );
 
     const financialsTool = response.body.result.tools.find(
       (tool: { name: string }) => tool.name === "fdic_search_financials",
@@ -817,6 +822,28 @@ describe("HTTP MCP server", () => {
     expect(peerGroupTool.inputSchema.properties.repdte.type).toBe("string");
     expect(peerGroupTool.inputSchema.properties.cert.type).toBe("integer");
     expect(peerGroupTool.inputSchema.properties.asset_min.type).toBe("number");
+
+    const searchTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "search",
+    );
+    expect(searchTool.inputSchema.properties.query.type).toBe("string");
+    expect(searchTool.annotations.readOnlyHint).toBe(true);
+
+    const fetchTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "fetch",
+    );
+    expect(fetchTool.inputSchema.properties.id.type).toBe("string");
+    expect(fetchTool.annotations.readOnlyHint).toBe(true);
+
+    const deepDiveTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "fdic_show_bank_deep_dive",
+    );
+    expect(deepDiveTool._meta.ui.resourceUri).toBe(
+      "ui://widget/fdic-bank-deep-dive-v1.html",
+    );
+    expect(deepDiveTool._meta["openai/outputTemplate"]).toBe(
+      "ui://widget/fdic-bank-deep-dive-v1.html",
+    );
   });
 
   it("lists schema resources for each supported FDIC endpoint", async () => {
@@ -840,8 +867,31 @@ describe("HTTP MCP server", () => {
         "fdic://schemas/summary",
         "fdic://schemas/sod",
         "fdic://schemas/demographics",
+        "ui://widget/fdic-bank-deep-dive-v1.html",
       ]),
     );
+  });
+
+  it("reads the ChatGPT bank deep-dive widget resource", async () => {
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 103,
+      method: "resources/read",
+      params: {
+        uri: "ui://widget/fdic-bank-deep-dive-v1.html",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const resource = response.body.result.contents[0];
+    expect(resource.uri).toBe("ui://widget/fdic-bank-deep-dive-v1.html");
+    expect(resource.mimeType).toBe("text/html;profile=mcp-app");
+    expect(resource.text).toContain("FDIC BankFind");
+    expect(resource._meta.ui.prefersBorder).toBe(true);
+    expect(resource._meta.ui.csp).toEqual({
+      connectDomains: [],
+      resourceDomains: [],
+    });
   });
 
   it("reads an endpoint schema resource over HTTP", async () => {
@@ -863,6 +913,210 @@ describe("HTTP MCP server", () => {
     expect(parsed.fields.CERT).toBeDefined();
     expect(parsed.fields.NETNIM).toBeDefined();
     expect(parsed.sort_fields).toContain("CERT");
+  });
+
+  it("returns ChatGPT-compatible search results", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            data: {
+              CERT: 3511,
+              NAME: "Wells Fargo Bank, National Association",
+              CITY: "Sioux Falls",
+              STALP: "SD",
+              ACTIVE: 1,
+            },
+          },
+        ],
+        meta: { total: 1 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 104,
+      method: "tools/call",
+      params: {
+        name: "search",
+        arguments: { query: "Wells Fargo Bank" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.content).toHaveLength(1);
+    const payload = JSON.parse(response.body.result.content[0].text);
+    expect(payload.results).toEqual([
+      {
+        id: "institution:3511",
+        title: "Wells Fargo Bank, National Association (Sioux Falls, SD)",
+        url: "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511",
+      },
+    ]);
+  });
+
+  it("returns fetch text for an institution result", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            data: {
+              CERT: 3511,
+              NAME: "Wells Fargo Bank, National Association",
+              CITY: "Sioux Falls",
+              STALP: "SD",
+              ACTIVE: 1,
+              ASSET: 1000000,
+            },
+          },
+        ],
+        meta: { total: 1 },
+      },
+    });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 105,
+      method: "tools/call",
+      params: {
+        name: "fetch",
+        arguments: { id: "institution:3511" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.content).toHaveLength(1);
+    const payload = JSON.parse(response.body.result.content[0].text);
+    expect(payload).toMatchObject({
+      id: "institution:3511",
+      title: "Wells Fargo Bank, National Association",
+      url: "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511",
+      metadata: {
+        type: "institution",
+        cert: 3511,
+      },
+    });
+    expect(payload.text).toContain("CERT: 3511");
+  });
+
+  it("returns fetchable branch search results", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: { data: [], meta: { total: 0 } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                UNINUM: 123456,
+                CERT: 3511,
+                UNINAME: "Wells Fargo Bank",
+                NAMEFULL: "Austin Branch",
+                ADDRESS: "100 Congress Ave",
+                CITY: "Austin",
+                STALP: "TX",
+                ZIP: "78701",
+                BRNUM: 12,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 106,
+      method: "tools/call",
+      params: {
+        name: "search",
+        arguments: { query: "branches in Austin" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = JSON.parse(response.body.result.content[0].text);
+    expect(payload.results).toEqual([
+      {
+        id: "branch:123456",
+        title: "Wells Fargo Bank - 100 Congress Ave, Austin, TX, 78701",
+        url: "https://jflamb.github.io/fdic-mcp-server/tool-reference/#fdic_search_locations",
+      },
+    ]);
+  });
+
+  it("returns dashboard structuredContent for the ChatGPT bank deep-dive tool", async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                NAME: "Wells Fargo Bank, National Association",
+                CITY: "Sioux Falls",
+                STALP: "SD",
+                ACTIVE: 1,
+                ASSET: 1000000,
+                DEP: 900000,
+                OFFICES: 10,
+                BKCLASS: "N",
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              data: {
+                CERT: 3511,
+                REPDTE: "20241231",
+                ASSET: 1000000,
+                DEP: 900000,
+                ROA: 1.25,
+                IDT1CER: 8.5,
+              },
+            },
+          ],
+          meta: { total: 1 },
+        },
+      });
+
+    const response = await mcpPost({
+      jsonrpc: "2.0",
+      id: 107,
+      method: "tools/call",
+      params: {
+        name: "fdic_show_bank_deep_dive",
+        arguments: { cert: 3511, repdte: "20241231" },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result.structuredContent).toMatchObject({
+      institution: {
+        cert: 3511,
+        name: "Wells Fargo Bank, National Association",
+        report_date: "20241231",
+        asset_thousands: 1000000,
+      },
+      metrics: {
+        roa: "1.25%",
+        tier1_leverage: "8.50%",
+      },
+      sources: [
+        {
+          url: "https://banks.data.fdic.gov/bankfind-suite/bankfind/details/3511",
+        },
+      ],
+    });
+    expect(response.body.result._meta.widget.resourceUri).toBe(
+      "ui://widget/fdic-bank-deep-dive-v1.html",
+    );
   });
 
   it("reuses cached FDIC responses across sequential HTTP requests", async () => {


### PR DESCRIPTION
## Summary
- add always-on ChatGPT-compatible search/fetch tools for citation-friendly institution, failure, branch, and schema retrieval
- add an embedded Bank Deep Dive MCP Apps widget resource plus fdic_show_bank_deep_dive render tool
- update ChatGPT setup docs, tool reference, generated tool schemas/adapters, and implementation plan tracking

## Validation
- npm run typecheck
- npm test
- npm run build
- npm run extensions:validate

## Release impact
- feat: adds new read-only MCP tools and app resource metadata while preserving existing FDIC tool contracts

## Residual risk
- branch result citations fall back to the project tool reference unless a stable FDIC branch deep link is identified