### PR TITLE
fix: throttle MCP streams by IP

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -136,6 +136,9 @@ jobs:
           env_vars: |-
             HOST=0.0.0.0
             CHAT_ALLOWED_ORIGINS=${{ env.CHAT_ALLOWED_ORIGIN }}
+            MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE=120
+            MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR=2
+            MCP_MAX_CONCURRENT_STREAMS_PER_IP=1
           secrets: |-
             GEMINI_API_KEY=gemini-api-key:latest
           flags: >-

--- a/reference/cloud-run-deployment.md
+++ b/reference/cloud-run-deployment.md
@@ -39,6 +39,18 @@ Operationally, this means the public MCP endpoint is a stateless Cloud Run revis
 - `HOST=0.0.0.0`
 - a non-root container user for the production runtime
 
+## Cost Controls
+
+The public `/mcp` endpoint applies in-process per-IP throttles before requests reach the MCP transport. This is primarily to prevent long-lived streamable HTTP `GET /mcp` connections from keeping Cloud Run continuously billable.
+
+Production defaults:
+
+- `MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE=120`
+- `MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR=2`
+- `MCP_MAX_CONCURRENT_STREAMS_PER_IP=1`
+
+The stream controls are intentionally stricter than the general request limit. Normal MCP JSON POST calls are short and inexpensive, while open stream requests can hold a Cloud Run request active until the service timeout.
+
 ## Expected Google Cloud Resources
 
 This repo is configured around the following resource pattern:

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -4,6 +4,7 @@ import type { Request, Response, Router } from "express";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { RateLimiter } from "./chatRateLimit.js";
+import { getRequestIp } from "./requestIdentity.js";
 
 export const CHAT_SYSTEM_PROMPT = `You are a demo assistant for the FDIC BankFind MCP Server. You help users
 explore FDIC banking data using the tools available to you.
@@ -217,15 +218,6 @@ function mapMessagesToContents(messages: ChatMessage[]): ChatContent[] {
     role: message.role === "assistant" ? "model" : "user",
     parts: [{ text: message.content }],
   }));
-}
-
-function getRequestIp(req: Request): string {
-  const forwarded = req.get("x-forwarded-for");
-  if (forwarded) {
-    return forwarded.split(",")[0]?.trim() || req.ip || "unknown";
-  }
-
-  return req.ip || "unknown";
 }
 
 function getResponseParts(

--- a/src/chatRateLimit.ts
+++ b/src/chatRateLimit.ts
@@ -28,3 +28,37 @@ export class RateLimiter {
     return true;
   }
 }
+
+export class ConcurrentLimiter {
+  private readonly maxConcurrent: number;
+  private readonly active = new Map<string, number>();
+
+  constructor(maxConcurrent: number) {
+    this.maxConcurrent = maxConcurrent;
+  }
+
+  acquire(key: string): (() => void) | undefined {
+    const current = this.active.get(key) ?? 0;
+    if (current >= this.maxConcurrent) {
+      return undefined;
+    }
+
+    this.active.set(key, current + 1);
+
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+
+      const latest = this.active.get(key) ?? 0;
+      if (latest <= 1) {
+        this.active.delete(key);
+        return;
+      }
+
+      this.active.set(key, latest - 1);
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import {
   parseChatAllowedOrigins,
   sweepIdleChatSessions,
 } from "./chat.js";
+import { ConcurrentLimiter, RateLimiter } from "./chatRateLimit.js";
+import { getRequestIp } from "./requestIdentity.js";
 import { registerInstitutionTools } from "./tools/institutions.js";
 import { registerFailureTools } from "./tools/failures.js";
 import { registerLocationTools } from "./tools/locations.js";
@@ -198,6 +200,9 @@ interface HttpAppOptions {
   sessionSweepIntervalMs?: number;
   chatAllowedOrigins?: string[];
   geminiApiKey?: string;
+  mcpRateLimiter?: RateLimiter;
+  mcpStreamRateLimiter?: RateLimiter;
+  mcpStreamConcurrentLimiter?: ConcurrentLimiter;
   serverFactory?: () => McpServer;
   /**
    * When true, run the streamable HTTP transport in stateless JSON mode (no
@@ -216,6 +221,28 @@ interface SessionContext {
 
 const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_MCP_RATE_LIMIT_MAX_REQUESTS = 120;
+const DEFAULT_MCP_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_MCP_STREAM_RATE_LIMIT_MAX_REQUESTS = 2;
+const DEFAULT_MCP_STREAM_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_MCP_MAX_CONCURRENT_STREAMS_PER_IP = 1;
+
+function parsePositiveInteger(
+  rawValue: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (rawValue === undefined || rawValue.trim().length === 0) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer. Received: ${rawValue}`);
+  }
+
+  return value;
+}
 
 async function closeSession(
   sessions: Map<string, SessionContext>,
@@ -264,6 +291,21 @@ function sendInvalidSessionResponse(res: express.Response): void {
   });
 }
 
+function sendMcpRateLimitResponse(
+  res: express.Response,
+  retryAfterSeconds: number,
+): void {
+  res.setHeader("Retry-After", String(retryAfterSeconds));
+  res.status(429).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Rate limit exceeded. Try again shortly.",
+    },
+    id: null,
+  });
+}
+
 export function createApp(options: HttpAppOptions = {}): Express {
   const app = express();
   const serverFactory = options.serverFactory ?? (() => createServer());
@@ -281,6 +323,35 @@ export function createApp(options: HttpAppOptions = {}): Express {
     options.sessionSweepIntervalMs ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
   const stateless =
     options.stateless ?? process.env.FDIC_MCP_STATELESS_HTTP === "true";
+  const mcpRateLimiter =
+    options.mcpRateLimiter ??
+    new RateLimiter({
+      maxRequests: parsePositiveInteger(
+        process.env.MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE,
+        DEFAULT_MCP_RATE_LIMIT_MAX_REQUESTS,
+        "MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE",
+      ),
+      windowMs: DEFAULT_MCP_RATE_LIMIT_WINDOW_MS,
+    });
+  const mcpStreamRateLimiter =
+    options.mcpStreamRateLimiter ??
+    new RateLimiter({
+      maxRequests: parsePositiveInteger(
+        process.env.MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR,
+        DEFAULT_MCP_STREAM_RATE_LIMIT_MAX_REQUESTS,
+        "MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR",
+      ),
+      windowMs: DEFAULT_MCP_STREAM_RATE_LIMIT_WINDOW_MS,
+    });
+  const mcpStreamConcurrentLimiter =
+    options.mcpStreamConcurrentLimiter ??
+    new ConcurrentLimiter(
+      parsePositiveInteger(
+        process.env.MCP_MAX_CONCURRENT_STREAMS_PER_IP,
+        DEFAULT_MCP_MAX_CONCURRENT_STREAMS_PER_IP,
+        "MCP_MAX_CONCURRENT_STREAMS_PER_IP",
+      ),
+    );
   app.use(express.json());
 
   if (!stateless) {
@@ -296,6 +367,35 @@ export function createApp(options: HttpAppOptions = {}): Express {
   });
 
   app.all("/mcp", async (req, res) => {
+    const requestIp = getRequestIp(req);
+    if (!mcpRateLimiter.check(requestIp)) {
+      sendMcpRateLimitResponse(
+        res,
+        Math.ceil(DEFAULT_MCP_RATE_LIMIT_WINDOW_MS / 1000),
+      );
+      return;
+    }
+
+    if (req.method === "GET") {
+      const releaseStream = mcpStreamConcurrentLimiter.acquire(requestIp);
+      if (!releaseStream) {
+        sendMcpRateLimitResponse(res, 60);
+        return;
+      }
+
+      if (!mcpStreamRateLimiter.check(requestIp)) {
+        releaseStream();
+        sendMcpRateLimitResponse(
+          res,
+          Math.ceil(DEFAULT_MCP_STREAM_RATE_LIMIT_WINDOW_MS / 1000),
+        );
+        return;
+      }
+
+      res.once("close", releaseStream);
+      res.once("finish", releaseStream);
+    }
+
     if (stateless) {
       let server: McpServer | undefined;
       let transport: StreamableHTTPServerTransport | undefined;

--- a/src/requestIdentity.ts
+++ b/src/requestIdentity.ts
@@ -1,0 +1,10 @@
+import type { Request } from "express";
+
+export function getRequestIp(req: Request): string {
+  const forwarded = req.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0]?.trim() || req.ip || "unknown";
+  }
+
+  return req.ip || "unknown";
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -510,6 +510,38 @@ Reference: 2026-03-29 investigation of failed GitHub Actions workflow `Deploy Cl
 
 ---
 
+# Cloud Run MCP IP Throttling
+
+Reference: 2026-06-20 cost investigation found repeated long-lived `GET /mcp` streams from a single client IP keeping Cloud Run billable.
+
+## Goals
+
+- [x] Add per-IP throttling for the public MCP endpoint.
+- [x] Cap expensive long-lived MCP stream requests separately from normal short MCP POST calls.
+- [x] Make production Cloud Run throttle settings explicit in deployment config.
+- [x] Validate the rate-limit behavior and TypeScript build.
+
+## Acceptance Criteria
+
+- [x] `/mcp` returns 429 with `Retry-After` when an IP exceeds the general MCP request rate.
+- [x] `/mcp` returns 429 when an IP opens too many stream requests in the stream window.
+- [x] `/mcp` returns 429 when an IP already has the maximum allowed concurrent stream requests.
+- [x] Default stream controls are cost-protective: 1 concurrent stream and 2 stream openings per hour per IP.
+- [x] Targeted tests and typecheck pass.
+
+## Validation
+
+- [x] `npx vitest run tests/chat-rate-limit.test.ts tests/mcp-http.test.ts` — 2 files, 76 tests passed
+- [x] `npm run typecheck` — clean
+- [x] `npm run build` — success
+
+## Review / Results
+
+- [x] Added shared IP extraction, general MCP request throttling, stream request throttling, and per-IP stream concurrency limiting.
+- [x] Added production Cloud Run env vars and reference documentation for throttle tuning.
+
+---
+
 # QBP Lite Data Tool
 
 Reference: 2026-04-29 request to make production of a 3-5 page QBP Lite report more efficient.

--- a/tests/chat-rate-limit.test.ts
+++ b/tests/chat-rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { RateLimiter } from "../src/chatRateLimit.js";
+import { ConcurrentLimiter, RateLimiter } from "../src/chatRateLimit.js";
 
 describe("RateLimiter", () => {
   it("allows requests under the threshold", () => {
@@ -39,5 +39,38 @@ describe("RateLimiter", () => {
     expect(limiter.check("1.2.3.4", 60_005)).toBe(true);
 
     vi.useRealTimers();
+  });
+});
+
+describe("ConcurrentLimiter", () => {
+  it("allows acquisitions under the threshold", () => {
+    const limiter = new ConcurrentLimiter(2);
+
+    const firstRelease = limiter.acquire("1.2.3.4");
+    const secondRelease = limiter.acquire("1.2.3.4");
+
+    expect(firstRelease).toBeTypeOf("function");
+    expect(secondRelease).toBeTypeOf("function");
+  });
+
+  it("rejects acquisitions at the threshold until one is released", () => {
+    const limiter = new ConcurrentLimiter(1);
+
+    const release = limiter.acquire("1.2.3.4");
+
+    expect(release).toBeTypeOf("function");
+    expect(limiter.acquire("1.2.3.4")).toBeUndefined();
+
+    release?.();
+
+    expect(limiter.acquire("1.2.3.4")).toBeTypeOf("function");
+  });
+
+  it("tracks keys independently", () => {
+    const limiter = new ConcurrentLimiter(1);
+
+    expect(limiter.acquire("1.2.3.4")).toBeTypeOf("function");
+    expect(limiter.acquire("1.2.3.4")).toBeUndefined();
+    expect(limiter.acquire("5.6.7.8")).toBeTypeOf("function");
   });
 });

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -35,6 +35,7 @@ import {
   parseHttpHost,
   parseHttpPort,
 } from "../src/index.js";
+import { ConcurrentLimiter, RateLimiter } from "../src/chatRateLimit.js";
 import { clearQueryCache } from "../src/services/fdicClient.js";
 import packageJson from "../package.json";
 
@@ -300,6 +301,117 @@ describe("HTTP MCP server", () => {
 
     expect(postDeleteResponse.status).toBe(404);
     expect(postDeleteResponse.body.error.message).toBe("Session not found");
+  });
+
+  it("rate limits MCP requests by client IP", async () => {
+    const mcpRateLimiter = new RateLimiter({
+      maxRequests: 1,
+      windowMs: 60_000,
+    });
+    mcpRateLimiter.check("203.0.113.10", Date.now());
+    const app = createApp({
+      mcpRateLimiter,
+    });
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("x-forwarded-for", "203.0.113.10")
+      .send({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: defaultProtocolVersion,
+          capabilities: {},
+          clientInfo: {
+            name: "vitest",
+            version: "1.0.0",
+          },
+        },
+      });
+
+    expect(response.status).toBe(429);
+    expect(response.headers["retry-after"]).toBe("60");
+    expect(response.body.error.message).toBe(
+      "Rate limit exceeded. Try again shortly.",
+    );
+  });
+
+  it("limits how often a client IP can open MCP stream requests", async () => {
+    const app = createApp({
+      mcpStreamRateLimiter: new RateLimiter({
+        maxRequests: 1,
+        windowMs: 60 * 60 * 1000,
+      }),
+    });
+    const { sessionId } = await initializeSession(app);
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP address for test server");
+    }
+
+    const headers = {
+      accept: "text/event-stream",
+      "mcp-session-id": sessionId,
+      "x-forwarded-for": "203.0.113.20",
+    };
+    const firstResponse = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+      headers,
+    });
+
+    expect(firstResponse.status).toBe(200);
+    await firstResponse.body?.cancel();
+
+    const secondResponse = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+      headers,
+    });
+
+    expect(secondResponse.status).toBe(429);
+    expect(secondResponse.headers.get("retry-after")).toBe("3600");
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it("limits concurrent MCP stream requests by client IP", async () => {
+    const app = createApp({
+      mcpStreamConcurrentLimiter: new ConcurrentLimiter(1),
+    });
+    const { sessionId } = await initializeSession(app);
+    const server = app.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected TCP address for test server");
+    }
+
+    const headers = {
+      accept: "text/event-stream",
+      "mcp-session-id": sessionId,
+      "x-forwarded-for": "203.0.113.30",
+    };
+    const firstResponse = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+      headers,
+    });
+
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+      headers,
+    });
+
+    expect(secondResponse.status).toBe(429);
+    expect(secondResponse.headers.get("retry-after")).toBe("60");
+
+    await firstResponse.body?.cancel();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
   });
 
   it("expires idle HTTP sessions even when the client never sends DELETE", async () => {


### PR DESCRIPTION
## Summary
- add per-IP throttling for `/mcp` before requests reach the MCP transport
- cap long-lived stream requests separately from normal MCP POST calls
- make Cloud Run throttle settings explicit in the production deploy workflow

## Why
The Cloud Run budget alert was driven by repeated long-lived `GET /mcp` streams that held requests open for about 300 seconds. The live service needs a cost-control guard that limits stream abuse by client IP.

## Validation
- `npx vitest run tests/chat-rate-limit.test.ts tests/mcp-http.test.ts` — 76 tests passed
- `npm run typecheck` — clean
- `npm run build` — success

## Release impact
Patch-level production behavior fix. Public clients that repeatedly open MCP streams from one IP will receive `429` with `Retry-After`.