### PR TITLE
fix: block abusive MCP client range

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -139,6 +139,7 @@ jobs:
             MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE=120
             MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR=2
             MCP_MAX_CONCURRENT_STREAMS_PER_IP=1
+            MCP_BLOCKED_IPS=2605:a601:8119:1800::/64
           secrets: |-
             GEMINI_API_KEY=gemini-api-key:latest
           flags: >-

--- a/reference/cloud-run-deployment.md
+++ b/reference/cloud-run-deployment.md
@@ -48,8 +48,11 @@ Production defaults:
 - `MCP_RATE_LIMIT_MAX_REQUESTS_PER_MINUTE=120`
 - `MCP_STREAM_RATE_LIMIT_MAX_REQUESTS_PER_HOUR=2`
 - `MCP_MAX_CONCURRENT_STREAMS_PER_IP=1`
+- `MCP_BLOCKED_IPS=2605:a601:8119:1800::/64`
 
 The stream controls are intentionally stricter than the general request limit. Normal MCP JSON POST calls are short and inexpensive, while open stream requests can hold a Cloud Run request active until the service timeout.
+
+`MCP_BLOCKED_IPS` accepts comma- or whitespace-separated exact IP addresses and CIDR ranges. The production blocklist includes the IPv6 `/64` observed repeatedly opening long-lived `GET /mcp` streams.
 
 ## Expected Google Cloud Resources
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,12 @@ import {
   sweepIdleChatSessions,
 } from "./chat.js";
 import { ConcurrentLimiter, RateLimiter } from "./chatRateLimit.js";
-import { getRequestIp } from "./requestIdentity.js";
+import {
+  getRequestIp,
+  isBlockedIp,
+  parseBlockedIpRules,
+  type IpBlockRule,
+} from "./requestIdentity.js";
 import { registerInstitutionTools } from "./tools/institutions.js";
 import { registerFailureTools } from "./tools/failures.js";
 import { registerLocationTools } from "./tools/locations.js";
@@ -203,6 +208,7 @@ interface HttpAppOptions {
   mcpRateLimiter?: RateLimiter;
   mcpStreamRateLimiter?: RateLimiter;
   mcpStreamConcurrentLimiter?: ConcurrentLimiter;
+  mcpBlockedIpRules?: IpBlockRule[];
   serverFactory?: () => McpServer;
   /**
    * When true, run the streamable HTTP transport in stateless JSON mode (no
@@ -306,6 +312,17 @@ function sendMcpRateLimitResponse(
   });
 }
 
+function sendMcpBlockedIpResponse(res: express.Response): void {
+  res.status(403).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Forbidden client IP.",
+    },
+    id: null,
+  });
+}
+
 export function createApp(options: HttpAppOptions = {}): Express {
   const app = express();
   const serverFactory = options.serverFactory ?? (() => createServer());
@@ -352,6 +369,8 @@ export function createApp(options: HttpAppOptions = {}): Express {
         "MCP_MAX_CONCURRENT_STREAMS_PER_IP",
       ),
     );
+  const mcpBlockedIpRules =
+    options.mcpBlockedIpRules ?? parseBlockedIpRules(process.env.MCP_BLOCKED_IPS);
   app.use(express.json());
 
   if (!stateless) {
@@ -368,6 +387,11 @@ export function createApp(options: HttpAppOptions = {}): Express {
 
   app.all("/mcp", async (req, res) => {
     const requestIp = getRequestIp(req);
+    if (isBlockedIp(requestIp, mcpBlockedIpRules)) {
+      sendMcpBlockedIpResponse(res);
+      return;
+    }
+
     if (!mcpRateLimiter.check(requestIp)) {
       sendMcpRateLimitResponse(
         res,

--- a/src/requestIdentity.ts
+++ b/src/requestIdentity.ts
@@ -1,4 +1,12 @@
 import type { Request } from "express";
+import { isIP } from "node:net";
+
+export interface IpBlockRule {
+  raw: string;
+  version: 4 | 6;
+  address: bigint;
+  prefixLength: number;
+}
 
 export function getRequestIp(req: Request): string {
   const forwarded = req.get("x-forwarded-for");
@@ -7,4 +15,108 @@ export function getRequestIp(req: Request): string {
   }
 
   return req.ip || "unknown";
+}
+
+export function parseBlockedIpRules(rawRules: string | undefined): IpBlockRule[] {
+  if (!rawRules) {
+    return [];
+  }
+
+  return rawRules
+    .split(/[\s,]+/)
+    .map((rule) => rule.trim())
+    .filter((rule) => rule.length > 0)
+    .map(parseBlockedIpRule);
+}
+
+export function isBlockedIp(ip: string, rules: IpBlockRule[]): boolean {
+  const parsedIp = parseIpAddress(ip);
+  if (!parsedIp) {
+    return false;
+  }
+
+  return rules.some((rule) => {
+    if (rule.version !== parsedIp.version) {
+      return false;
+    }
+
+    const totalBits = rule.version === 4 ? 32n : 128n;
+    const hostBits = totalBits - BigInt(rule.prefixLength);
+    const mask = ((1n << totalBits) - 1n) ^ ((1n << hostBits) - 1n);
+    return (parsedIp.address & mask) === (rule.address & mask);
+  });
+}
+
+function parseBlockedIpRule(rawRule: string): IpBlockRule {
+  const [rawIp, rawPrefix] = rawRule.split("/", 2);
+  const parsedIp = parseIpAddress(rawIp);
+  if (!parsedIp) {
+    throw new Error(`Invalid MCP_BLOCKED_IPS entry: ${rawRule}`);
+  }
+
+  const maxPrefix = parsedIp.version === 4 ? 32 : 128;
+  const prefixLength =
+    rawPrefix === undefined ? maxPrefix : Number.parseInt(rawPrefix, 10);
+  if (
+    !Number.isInteger(prefixLength) ||
+    prefixLength < 0 ||
+    prefixLength > maxPrefix
+  ) {
+    throw new Error(`Invalid MCP_BLOCKED_IPS prefix: ${rawRule}`);
+  }
+
+  return {
+    raw: rawRule,
+    version: parsedIp.version,
+    address: parsedIp.address,
+    prefixLength,
+  };
+}
+
+function parseIpAddress(ip: string | undefined): { version: 4 | 6; address: bigint } | undefined {
+  if (!ip) {
+    return undefined;
+  }
+
+  const normalizedIp = ip.trim().replace(/^\[/, "").replace(/\]$/, "");
+  const version = isIP(normalizedIp);
+  if (version === 4) {
+    return { version, address: parseIpv4(normalizedIp) };
+  }
+  if (version === 6) {
+    return { version, address: parseIpv6(normalizedIp) };
+  }
+
+  return undefined;
+}
+
+function parseIpv4(ip: string): bigint {
+  return ip
+    .split(".")
+    .map((part) => Number.parseInt(part, 10))
+    .reduce((value, octet) => (value << 8n) + BigInt(octet), 0n);
+}
+
+function parseIpv6(ip: string): bigint {
+  const [headRaw, tailRaw] = ip.toLowerCase().split("::", 2);
+  const head = parseIpv6Hextets(headRaw);
+  const tail = tailRaw === undefined ? [] : parseIpv6Hextets(tailRaw);
+  const missing = 8 - head.length - tail.length;
+  const hextets =
+    tailRaw === undefined
+      ? head
+      : [...head, ...Array.from({ length: missing }, () => 0), ...tail];
+
+  return hextets.reduce(
+    (value, hextet) => (value << 16n) + BigInt(hextet),
+    0n,
+  );
+}
+
+function parseIpv6Hextets(raw: string | undefined): number[] {
+  if (!raw) {
+    return [];
+  }
+
+  return raw.split(":").map((part) => Number.parseInt(part, 16));
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Cloud Run MCP IP Blocklist
+
+Reference: 2026-06-20/21 cost incident where repeated long-lived `GET /mcp` streams came from rotating IPv6 addresses in `2605:a601:8119:1800::/64`.
+
+## Goals
+
+- [x] Add an app-level exact IP/CIDR blocklist for `/mcp`.
+- [x] Block the observed abusive IPv6 `/64` in production deploy configuration.
+- [x] Keep the block ahead of MCP transport setup and rate-limit counters.
+- [x] Validate locally and deploy through `main`.
+
+## Acceptance Criteria
+
+- [x] `MCP_BLOCKED_IPS` accepts exact IPs and CIDR ranges.
+- [x] Blocked `/mcp` requests return 403 immediately.
+- [x] Production deploy config includes `MCP_BLOCKED_IPS=2605:a601:8119:1800::/64`.
+- [x] Tests, typecheck, and build pass.
+- [ ] Production returns 403 for the blocked client range after deploy.
+
+## Validation
+
+- [x] `npx vitest run tests/requestIdentity.test.ts tests/mcp-http.test.ts` — 2 files, 73 tests passed
+- [x] `npm run typecheck` — clean
+- [x] `npm run build` — success
+
+## Review / Results
+
+- [ ] Document PR, deploy, and live verification.
+
+---
+
 # Issue #222: Peer Percentile Deprecation Plan
 
 Reference: https://github.com/jflamb/fdic-mcp-server/issues/222

--- a/tests/mcp-http.test.ts
+++ b/tests/mcp-http.test.ts
@@ -339,6 +339,41 @@ describe("HTTP MCP server", () => {
     );
   });
 
+  it("blocks MCP requests from configured client IP ranges", async () => {
+    const app = createApp({
+      mcpBlockedIpRules: [
+        {
+          raw: "2605:a601:8119:1800::/64",
+          version: 6,
+          address: 0x2605a601811918000000000000000000n,
+          prefixLength: 64,
+        },
+      ],
+    });
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("content-type", "application/json")
+      .set("accept", mcpAcceptHeader)
+      .set("x-forwarded-for", "2605:a601:8119:1800:b10e:b915:d83c:13e1")
+      .send({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: defaultProtocolVersion,
+          capabilities: {},
+          clientInfo: {
+            name: "vitest",
+            version: "1.0.0",
+          },
+        },
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.message).toBe("Forbidden client IP.");
+  });
+
   it("limits how often a client IP can open MCP stream requests", async () => {
     const app = createApp({
       mcpStreamRateLimiter: new RateLimiter({

--- a/tests/requestIdentity.test.ts
+++ b/tests/requestIdentity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { isBlockedIp, parseBlockedIpRules } from "../src/requestIdentity.js";
+
+describe("IP block rules", () => {
+  it("matches exact IPv4 and IPv6 addresses", () => {
+    const rules = parseBlockedIpRules("203.0.113.10 2605:a601:8119:1800::1");
+
+    expect(isBlockedIp("203.0.113.10", rules)).toBe(true);
+    expect(isBlockedIp("203.0.113.11", rules)).toBe(false);
+    expect(isBlockedIp("2605:a601:8119:1800::1", rules)).toBe(true);
+    expect(isBlockedIp("2605:a601:8119:1800::2", rules)).toBe(false);
+  });
+
+  it("matches IPv4 and IPv6 CIDR ranges", () => {
+    const rules = parseBlockedIpRules(
+      "203.0.113.0/24,2605:a601:8119:1800::/64",
+    );
+
+    expect(isBlockedIp("203.0.113.10", rules)).toBe(true);
+    expect(isBlockedIp("203.0.114.10", rules)).toBe(false);
+    expect(
+      isBlockedIp("2605:a601:8119:1800:b10e:b915:d83c:13e1", rules),
+    ).toBe(true);
+    expect(
+      isBlockedIp("2605:a601:8119:1801:b10e:b915:d83c:13e1", rules),
+    ).toBe(false);
+  });
+
+  it("rejects invalid blocklist entries", () => {
+    expect(() => parseBlockedIpRules("not-an-ip")).toThrow(
+      "Invalid MCP_BLOCKED_IPS entry: not-an-ip",
+    );
+    expect(() => parseBlockedIpRules("203.0.113.0/33")).toThrow(
+      "Invalid MCP_BLOCKED_IPS prefix: 203.0.113.0/33",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `MCP_BLOCKED_IPS` support for exact IPs and CIDR ranges on `/mcp`
- block the observed abusive IPv6 `/64` in Cloud Run deploy configuration
- reject blocked clients with immediate 403 before MCP transport setup or rate-limit counters

## Why
Recent production logs showed repeated long-lived `GET /mcp` streams rotating through addresses in `2605:a601:8119:1800::/64`. The existing per-IP throttle reduced per-address abuse but does not stop privacy-address rotation inside the same IPv6 subnet.

## Validation
- `npx vitest run tests/requestIdentity.test.ts tests/mcp-http.test.ts` — 73 tests passed
- `npm run typecheck` — clean
- `npm run build` — success

## Release impact
Patch-level production behavior fix. Requests from `2605:a601:8119:1800::/64` to `/mcp` will receive `403`.